### PR TITLE
Refactor codegen scripts for eventual removal

### DIFF
--- a/.dotnet/scripts/Add-Customizations.ps1
+++ b/.dotnet/scripts/Add-Customizations.ps1
@@ -34,6 +34,25 @@ function Set-LangVersionToLatest {
     $xml.Save($filePath)
 }
 
+function Edit-RunObjectSerialization {
+    $root = Split-Path $PSScriptRoot -Parent
+    $directory = Join-Path -Path $root -ChildPath "src\Generated\Models"
+
+    $file = Get-ChildItem -Path $directory -Filter "RunObject.Serialization.cs"
+    $content = Get-Content -Path $file -Raw
+
+    Write-Output "Editing $($file.FullName)"
+
+    $content = $content -creplace "expiresAt = property\.Value\.GetDateTimeOffset\(`"O`"\);", "// BUG: https://github.com/Azure/autorest.csharp/issues/4296`r`n                    // expiresAt = property.Value.GetDateTimeOffset(`"O`");`r`n                    expiresAt = DateTimeOffset.FromUnixTimeSeconds(property.Value.GetInt64());"
+    $content = $content -creplace "startedAt = property\.Value\.GetDateTimeOffset\(`"O`"\);", "// BUG: https://github.com/Azure/autorest.csharp/issues/4296`r`n                    // startedAt = property.Value.GetDateTimeOffset(`"O`");`r`n                    startedAt = DateTimeOffset.FromUnixTimeSeconds(property.Value.GetInt64());"
+    $content = $content -creplace "cancelledAt = property\.Value\.GetDateTimeOffset\(`"O`"\);", "// BUG: https://github.com/Azure/autorest.csharp/issues/4296`r`n                    // cancelledAt = property.Value.GetDateTimeOffset(`"O`");`r`n                    cancelledAt = DateTimeOffset.FromUnixTimeSeconds(property.Value.GetInt64());"
+    $content = $content -creplace "failedAt = property\.Value\.GetDateTimeOffset\(`"O`"\);", "// BUG: https://github.com/Azure/autorest.csharp/issues/4296`r`n                    // failedAt = property.Value.GetDateTimeOffset(`"O`");`r`n                    failedAt = DateTimeOffset.FromUnixTimeSeconds(property.Value.GetInt64());"
+    $content = $content -creplace "completedAt = property\.Value\.GetDateTimeOffset\(`"O`"\);", "// BUG: https://github.com/Azure/autorest.csharp/issues/4296`r`n                    // completedAt = property.Value.GetDateTimeOffset(`"O`");`r`n                    completedAt = DateTimeOffset.FromUnixTimeSeconds(property.Value.GetInt64());"
+
+    $content | Set-Content -Path $file.FullName -NoNewline
+}
+
 Update-SystemTextJsonPackage
 Update-MicrosoftBclAsyncInterfacesPackage
 Set-LangVersionToLatest
+Edit-RunObjectSerialization

--- a/.dotnet/scripts/ConvertTo-Internal.ps1
+++ b/.dotnet/scripts/ConvertTo-Internal.ps1
@@ -1,8 +1,30 @@
-function Edit-GeneratedSources {
+function Edit-GeneratedOpenAIClient {
     $root = Split-Path $PSScriptRoot -Parent
 
     $directory = Join-Path -Path $root -ChildPath "src\Generated"
-    $files = Get-ChildItem -Path $($directory + "\*") -Include "*.cs" -Recurse
+    $file = Get-ChildItem -Path $directory -Filter "OpenAIClient.cs"
+
+    $content = Get-Content -Path $file -Raw
+
+    Write-Output "Editing $($file.FullName)"
+
+    $content = $content -creplace "public partial class", "internal partial class"
+    $content = $content -creplace "public readonly partial struct", "internal readonly partial struct"
+    $content = $content -creplace "public static partial class", "internal static partial class"
+    $content = $content -creplace "namespace OpenAI", "namespace OpenAI.Internal"
+    $content = $content -creplace "using OpenAI.Models;", "using OpenAI.Internal.Models;"
+    $content = $content -creplace "private (OpenAI.)?(?<var>\w+) _cached(\w+);", "private OpenAI.Internal.`${var} _cached`${var};"
+    $content = $content -creplace "public virtual (OpenAI.)?(?<var>\w+) Get(\w+)Client", "public virtual OpenAI.Internal.`${var} Get`${var}Client"
+    $content = $content -creplace "ref _cached(\w+), new (OpenAI.)?(?<var>\w+)", "ref _cached`${var}, new OpenAI.Internal.`${var}"
+
+    $content | Set-Content -Path $file.FullName -NoNewline
+}
+
+function Edit-GeneratedSubclients {
+    $root = Split-Path $PSScriptRoot -Parent
+
+    $directory = Join-Path -Path $root -ChildPath "src\Generated"
+    $files = Get-ChildItem -Path $($directory + "\*") -Include "*.cs" -Exclude "OpenAIClient.cs"
 
     foreach ($file in $files) {
         $content = Get-Content -Path $file -Raw
@@ -17,17 +39,27 @@ function Edit-GeneratedSources {
 
         $content | Set-Content -Path $file.FullName -NoNewline
     }
+}
 
-    $file = Get-ChildItem -Path $directory -Filter "OpenAIClient.cs"
-    $content = Get-Content -Path $file -Raw
+function Edit-GeneratedModels {
+    $root = Split-Path $PSScriptRoot -Parent
 
-    Write-Output "Editing $($file.FullName)"
+    $directory = Join-Path -Path $root -ChildPath "src\Generated\Models"
+    $files = Get-ChildItem -Path $($directory + "\*") -Include "*.cs"
 
-    $content = $content -creplace "private (OpenAI.)?(?<var>\w+) _cached(\w+);", "private OpenAI.Internal.`${var} _cached`${var};"
-    $content = $content -creplace "public virtual (OpenAI.)?(?<var>\w+) Get(\w+)Client", "public virtual OpenAI.Internal.`${var} Get`${var}Client"
-    $content = $content -creplace "ref _cached(\w+), new (OpenAI.)?(?<var>\w+)", "ref _cached`${var}, new OpenAI.Internal.`${var}"
+    foreach ($file in $files) {
+        $content = Get-Content -Path $file -Raw
 
-    $content | Set-Content -Path $file.FullName -NoNewline
+        Write-Output "Editing $($file.FullName)"
+
+        $content = $content -creplace "public partial class", "internal partial class"
+        $content = $content -creplace "public readonly partial struct", "internal readonly partial struct"
+        $content = $content -creplace "public static partial class", "internal static partial class"
+        $content = $content -creplace "namespace OpenAI", "namespace OpenAI.Internal"
+        $content = $content -creplace "using OpenAI.Models;", "using OpenAI.Internal.Models;"
+
+        $content | Set-Content -Path $file.FullName -NoNewline
+    }
 }
 
 function Remove-GeneratedTests {
@@ -37,5 +69,7 @@ function Remove-GeneratedTests {
     Remove-Item -LiteralPath $directory -Recurse -Force
 }
 
-Edit-GeneratedSources
+Edit-GeneratedOpenAIClient
+Edit-GeneratedSubclients
+Edit-GeneratedModels
 Remove-GeneratedTests


### PR DESCRIPTION
The objective is to eventually stop depending on these scripts and remove them entirely. With this in mind, I refactored the scripts to split them into smaller parts so that it's easier to remove them incrementally.