### PR TITLE
Expose protocol methods publicly

### DIFF
--- a/.dotnet/src/Custom/Assistants/AssistantClient.Protocol.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantClient.Protocol.cs
@@ -1,5 +1,4 @@
 using System.ClientModel;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.ComponentModel;
 using System.Threading.Tasks;
@@ -8,219 +7,246 @@ namespace OpenAI.Assistants;
 
 public partial class AssistantClient
 {
-
+    /// <inheritdoc cref="Internal.Assistants.CreateAssistant(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult CreateAssistant(BinaryContent content, RequestOptions context = null)
-    {
-        return Shim.CreateAssistant(content, context);
-    }
+    public virtual ClientResult CreateAssistant(
+        BinaryContent content,
+        RequestOptions options = null)
+        => Shim.CreateAssistant(content, options);
 
+    /// <inheritdoc cref="Internal.Assistants.CreateAssistantAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> CreateAssistantAsync(BinaryContent content, RequestOptions context = null)
-    {
-        return Shim.CreateAssistantAsync(content, context);
-    }
+    public virtual async Task<ClientResult> CreateAssistantAsync(
+        BinaryContent content,
+        RequestOptions options = null)
+        => await Shim.CreateAssistantAsync(content, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Assistants.GetAssistant(string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetAssistant(string assistantId, RequestOptions context)
-    {
-        return Shim.GetAssistant(assistantId, context);
-    }
+    public virtual ClientResult GetAssistant(
+        string assistantId,
+        RequestOptions options)
+        => Shim.GetAssistant(assistantId, options);
 
+    /// <inheritdoc cref="Internal.Assistants.GetAssistantAsync(string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetAssistantAsync(string assistantId, RequestOptions context)
-    {
-        return Shim.GetAssistantAsync(assistantId, context);
-    }
+    public virtual async Task<ClientResult> GetAssistantAsync(
+        string assistantId,
+        RequestOptions options)
+        => await Shim.GetAssistantAsync(assistantId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Assistants.GetAssistants(int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ClientResult GetAssistants(
         int? maxResults,
         string createdSortOrder,
         string previousAssistantId,
         string subsequentAssistantId,
-        RequestOptions context)
-    {
-        return Shim.GetAssistants(maxResults, createdSortOrder, previousAssistantId, subsequentAssistantId, context);
-    }
+        RequestOptions options)
+        => Shim.GetAssistants(maxResults, createdSortOrder, previousAssistantId, subsequentAssistantId, options);
 
+    /// <inheritdoc cref="Internal.Assistants.GetAssistantsAsync(int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetAssistantsAsync(
+    public virtual async Task<ClientResult> GetAssistantsAsync(
         int? maxResults,
         string createdSortOrder,
         string previousAssistantId,
         string subsequentAssistantId,
-        RequestOptions context)
-    {
-        return Shim.GetAssistantsAsync(maxResults, createdSortOrder, previousAssistantId, subsequentAssistantId, context);
-    }
+        RequestOptions options)
+        => await Shim.GetAssistantsAsync(maxResults, createdSortOrder, previousAssistantId, subsequentAssistantId, options).ConfigureAwait(false);
 
 
+    /// <inheritdoc cref="Internal.Assistants.ModifyAssistant(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult ModifyAssistant(string assistantId, BinaryContent content, RequestOptions context = null)
-    {
-        return Shim.ModifyAssistant(assistantId, content, context);
-    }
+    public virtual ClientResult ModifyAssistant(
+        string assistantId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => Shim.ModifyAssistant(assistantId, content, options);
 
+    /// <inheritdoc cref="Internal.Assistants.ModifyAssistantAsync(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> ModifyAssistantAsync(string assistantId, BinaryContent content, RequestOptions context = null)
-    {
-        return Shim.ModifyAssistantAsync(assistantId, content, context);
-    }
+    public virtual async Task<ClientResult> ModifyAssistantAsync(
+        string assistantId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => await Shim.ModifyAssistantAsync(assistantId, content, options).ConfigureAwait(false);
 
-
+    /// <inheritdoc cref="Internal.Assistants.DeleteAssistant(string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult DeleteAssistant(string assistantId, RequestOptions context)
-    {
-        return Shim.DeleteAssistant(assistantId, context);
-    }
+    public virtual ClientResult DeleteAssistant(
+        string assistantId,
+        RequestOptions options)
+        => Shim.DeleteAssistant(assistantId, options);
 
+    /// <inheritdoc cref="Internal.Assistants.DeleteAssistantAsync(string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> DeleteAssistantAsync(string assistantId, RequestOptions context)
-    {
-        return Shim.DeleteAssistantAsync(assistantId, context);
-    }
+    public virtual async Task<ClientResult> DeleteAssistantAsync(
+        string assistantId,
+        RequestOptions options)
+        => await Shim.DeleteAssistantAsync(assistantId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Assistants.CreateAssistantFile(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ClientResult CreateAssistantFileAssociation(
         string assistantId,
         BinaryContent content,
-        RequestOptions context = null)
-    {
-        return Shim.CreateAssistantFile(assistantId, content, context);
-    }
+        RequestOptions options = null)
+        => Shim.CreateAssistantFile(assistantId, content, options);
 
+    /// <inheritdoc cref="Internal.Assistants.CreateAssistantFileAsync(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> CreateAssistantFileAssociationAsync(
+    public virtual async Task<ClientResult> CreateAssistantFileAssociationAsync(
         string assistantId,
         BinaryContent content,
-        RequestOptions context = null)
-    {
-        return Shim.CreateAssistantFileAsync(assistantId, content, context);
-    }
+        RequestOptions options = null)
+        => await Shim.CreateAssistantFileAsync(assistantId, content, options).ConfigureAwait(false);
 
-
+    /// <inheritdoc cref="Internal.Assistants.GetAssistantFile(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetAssistantFileAssociation(string assistantId, string fileId, RequestOptions context)
-    {
-        return Shim.GetAssistantFile(assistantId, fileId, context);
-    }
+    public virtual ClientResult GetAssistantFileAssociation(
+        string assistantId,
+        string fileId,
+        RequestOptions options)
+        => Shim.GetAssistantFile(assistantId, fileId, options);
 
+    /// <inheritdoc cref="Internal.Assistants.GetAssistantFileAsync(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetAssistantFileAssociationAsync(string assistantId, string fileId, RequestOptions context)
-    {
-        return Shim.GetAssistantFileAsync(assistantId, fileId, context);
-    }
+    public virtual async Task<ClientResult> GetAssistantFileAssociationAsync(
+        string assistantId,
+        string fileId,
+        RequestOptions options)
+        => await Shim.GetAssistantFileAsync(assistantId, fileId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Assistants.GetAssistantFiles(string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetAssistantFileAssociations(
+    public virtual ClientResult GetAssistantFileAssociation(
         string assistantId,
         int? maxResults,
         string createdSortOrder,
         string previousId,
         string subsequentId,
-        RequestOptions context)
-    {
-        return Shim.GetAssistantFiles(assistantId, maxResults, createdSortOrder, previousId, subsequentId, context);
-    }
+        RequestOptions options)
+        => Shim.GetAssistantFiles(assistantId, maxResults, createdSortOrder, previousId, subsequentId, options);
 
+    /// <inheritdoc cref="Internal.Assistants.GetAssistantFilesAsync(string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetAssistantFileAssociationsAsync(
+    public virtual async Task<ClientResult> GetAssistantFileAssociationAsync(
         string assistantId,
         int? maxResults,
         string createdSortOrder,
         string previousId,
         string subsequentId,
-        RequestOptions context)
-    {
-        return Shim
-            .GetAssistantFilesAsync(assistantId, maxResults, createdSortOrder, previousId, subsequentId, context);
-    }
+        RequestOptions options)
+        => await Shim.GetAssistantFilesAsync(assistantId, maxResults, createdSortOrder, previousId, subsequentId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Assistants.DeleteAssistantFile(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult RemoveAssistantFileAssociation(string assistantId, string fileId, RequestOptions context)
-    {
-        return Shim.DeleteAssistantFile(assistantId, fileId, context);
-    }
+    public virtual ClientResult RemoveAssistantFileAssociation(
+        string assistantId,
+        string fileId,
+        RequestOptions options)
+        => Shim.DeleteAssistantFile(assistantId, fileId, options);
 
+    /// <inheritdoc cref="Internal.Assistants.DeleteAssistantFileAsync(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> RemoveAssistantFileAssociationAsync(string assistantId, string fileId, RequestOptions context)
-    {
-        return Shim.DeleteAssistantFileAsync(assistantId, fileId, context);
-    }
+    public virtual async Task<ClientResult> RemoveAssistantFileAssociationAsync(
+        string assistantId,
+        string fileId,
+        RequestOptions options)
+        => await Shim.DeleteAssistantFileAsync(assistantId, fileId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Threads.CreateThread(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult CreateThread(BinaryContent content, RequestOptions context = null)
-    {
-        return ThreadShim.CreateThread(content, context);
-    }
+    public virtual ClientResult CreateThread(
+        BinaryContent content,
+        RequestOptions options = null)
+        => ThreadShim.CreateThread(content, options);
 
+    /// <inheritdoc cref="Internal.Threads.CreateThreadAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> CreateThreadAsync(BinaryContent content, RequestOptions context = null)
-    {
-        return ThreadShim.CreateThreadAsync(content, context);
-    }
+    public virtual async Task<ClientResult> CreateThreadAsync(
+        BinaryContent content,
+        RequestOptions options = null)
+        => await ThreadShim.CreateThreadAsync(content, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Threads.GetThread(string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetThread(string threadId, RequestOptions context)
-    {
-        return ThreadShim.GetThread(threadId, context);
-    }
+    public virtual ClientResult GetThread(
+        string threadId,
+        RequestOptions options)
+        => ThreadShim.GetThread(threadId, options);
 
+    /// <inheritdoc cref="Internal.Threads.GetThreadAsync(string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetThreadAsync(string threadId, RequestOptions context)
-    {
-        return ThreadShim.GetThreadAsync(threadId, context);
-    }
+    public virtual async Task<ClientResult> GetThreadAsync(
+        string threadId,
+        RequestOptions options)
+        => await ThreadShim.GetThreadAsync(threadId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Threads.ModifyThread(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult ModifyThread(string threadId, BinaryContent content, RequestOptions context = null)
-    {
-        return ThreadShim.ModifyThread(threadId, content, context);
-    }
+    public virtual ClientResult ModifyThread(
+        string threadId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => ThreadShim.ModifyThread(threadId, content, options);
 
+    /// <inheritdoc cref="Internal.Threads.ModifyThreadAsync(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> ModifyThreadAsync(string threadId, BinaryContent content, RequestOptions context = null)
-    {
-        return ThreadShim.ModifyThreadAsync(threadId, content, context);
-    }
+    public virtual async Task<ClientResult> ModifyThreadAsync(
+        string threadId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => await ThreadShim.ModifyThreadAsync(threadId, content, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Threads.DeleteThread(string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult DeleteThread(string threadId, RequestOptions context)
-    {
-        return ThreadShim.DeleteThread(threadId, context);
-    }
+    public virtual ClientResult DeleteThread(
+        string threadId,
+        RequestOptions options)
+        => ThreadShim.DeleteThread(threadId, options);
 
+    /// <inheritdoc cref="Internal.Threads.DeleteThreadAsync(string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> DeleteThreadAsync(string threadId, RequestOptions context)
-    {
-        return ThreadShim.DeleteThreadAsync(threadId, context);
-    }
+    public virtual async Task<ClientResult> DeleteThreadAsync(
+        string threadId,
+        RequestOptions options)
+        => await ThreadShim.DeleteThreadAsync(threadId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Messages.CreateMessage(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult CreateMessage(string threadId, BinaryContent content, RequestOptions context = null)
-    {
-        return MessageShim.CreateMessage(threadId, content, context);
-    }
+    public virtual ClientResult CreateMessage(
+        string threadId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => MessageShim.CreateMessage(threadId, content, options);
 
+    /// <inheritdoc cref="Internal.Messages.CreateMessageAsync(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> CreateMessageAsync(string threadId, BinaryContent content, RequestOptions context = null)
-    {
-        return MessageShim.CreateMessageAsync(threadId, content, context);
-    }
+    public virtual async Task<ClientResult> CreateMessageAsync(
+        string threadId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => await MessageShim.CreateMessageAsync(threadId, content, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Messages.GetMessage(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetMessage(string threadId, string messageId, RequestOptions context)
-    {
-        return MessageShim.GetMessage(threadId, messageId, context);
-    }
+    public virtual ClientResult GetMessage(
+        string threadId,
+        string messageId,
+        RequestOptions options)
+        => MessageShim.GetMessage(threadId, messageId, options);
 
+    /// <inheritdoc cref="Internal.Messages.GetMessageAsync(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetMessageAsync(string threadId, string messageId, RequestOptions context)
-    {
-        return MessageShim.GetMessageAsync(threadId, messageId, context);
-    }
+    public virtual async Task<ClientResult> GetMessageAsync(
+        string threadId,
+        string messageId,
+        RequestOptions options)
+        => await MessageShim.GetMessageAsync(threadId, messageId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Messages.GetMessages(string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ClientResult GetMessages(
         string threadId,
@@ -228,41 +254,39 @@ public partial class AssistantClient
         string createdSortOrder,
         string previousMessageId,
         string subsequentMessageId,
-        RequestOptions context)
-    {
-        return MessageShim
-            .GetMessages(threadId, maxResults, createdSortOrder, previousMessageId, subsequentMessageId, context);
-    }
+        RequestOptions options)
+        => MessageShim.GetMessages(threadId, maxResults, createdSortOrder, previousMessageId, subsequentMessageId, options);
 
+    /// <inheritdoc cref="Internal.Messages.GetMessagesAsync(string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetMessagesAsync(
+    public virtual async Task<ClientResult> GetMessagesAsync(
         string threadId,
         int? maxResults,
         string createdSortOrder,
         string previousMessageId,
         string subsequentMessageId,
-        RequestOptions context)
-    {
-        return MessageShim
-            .GetMessagesAsync(threadId, maxResults, createdSortOrder, previousMessageId, subsequentMessageId, context);
-    }
+        RequestOptions options)
+        => await MessageShim.GetMessagesAsync(threadId, maxResults, createdSortOrder, previousMessageId, subsequentMessageId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Messages.GetMessageFile(string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetMessageFileAssociation(string threadId, string messageId, string fileId, RequestOptions context)
-    {
-        return MessageShim.GetMessageFile(threadId, messageId, fileId, context);
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetMessageFileAssociationAsync(
+    public virtual ClientResult GetMessageFileAssociation(
         string threadId,
         string messageId,
         string fileId,
-        RequestOptions context)
-    {
-        return MessageShim.GetMessageFileAsync(threadId, messageId, fileId, context);
-    }
+        RequestOptions options)
+        => MessageShim.GetMessageFile(threadId, messageId, fileId, options);
 
+    /// <inheritdoc cref="Internal.Messages.GetMessageFileAsync(string, string, string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> GetMessageFileAssociationAsync(
+        string threadId,
+        string messageId,
+        string fileId,
+        RequestOptions options)
+        => await MessageShim.GetMessageFileAsync(threadId, messageId, fileId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.Messages.GetMessageFiles(string, string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ClientResult GetMessageFileAssociations(
         string threadId,
@@ -271,62 +295,68 @@ public partial class AssistantClient
         string createdSortOrder,
         string previousId ,
         string subsequentId,
-        RequestOptions context)
-    {
-        return MessageShim
-            .GetMessageFiles(threadId, messageId, maxResults, createdSortOrder, previousId, subsequentId, context);
-    }
+        RequestOptions options)
+        => MessageShim.GetMessageFiles(threadId, messageId, maxResults, createdSortOrder, previousId, subsequentId, options);
 
+    /// <inheritdoc cref="Internal.Messages.GetMessageFilesAsync(string, string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetMessageFileAssociationsAsync(
+    public virtual async Task<ClientResult> GetMessageFileAssociationsAsync(
         string threadId,
         string messageId,
         int? maxResults,
         string createdSortOrder,
         string previousId,
         string subsequentId,
-        RequestOptions context)
-    {
-        return MessageShim
-            .GetMessageFilesAsync(threadId, messageId, maxResults, createdSortOrder, previousId, subsequentId, context);
-    }
+        RequestOptions options)
+        => await MessageShim.GetMessageFilesAsync(threadId, messageId, maxResults, createdSortOrder, previousId, subsequentId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Runs.CreateRun(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult CreateRun(string threadId, BinaryContent content, RequestOptions context = null)
-    {
-        return RunShim.CreateRun(threadId, content, context);
-    }
+    public virtual ClientResult CreateRun(
+        string threadId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => RunShim.CreateRun(threadId, content, options);
 
+    /// <inheritdoc cref="Internal.Runs.CreateRunAsync(string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> CreateRunAsync(string threadId, BinaryContent content, RequestOptions context = null)
-    {
-        return RunShim.CreateRunAsync(threadId, content, context);
-    }
+    public virtual async Task<ClientResult> CreateRunAsync(
+        string threadId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => await RunShim.CreateRunAsync(threadId, content, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Runs.CreateThreadAndRun(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult CreateThreadAndRun(BinaryContent content, RequestOptions context = null)
-    {
-        return RunShim.CreateThreadAndRun(content, context);
-    }
+    public virtual ClientResult CreateThreadAndRun(
+        BinaryContent content,
+        RequestOptions options = null)
+        => RunShim.CreateThreadAndRun(content, options);
 
+    /// <inheritdoc cref="Internal.Runs.CreateThreadAndRunAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> CreateThreadAndRunAsync(BinaryContent content, RequestOptions context = null)
-    {
-        return RunShim.CreateThreadAndRunAsync(content, context);
-    }
+    public virtual async Task<ClientResult> CreateThreadAndRunAsync(
+        BinaryContent content,
+        RequestOptions options = null)
+        => await RunShim.CreateThreadAndRunAsync(content, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Runs.GetRun(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetRun(string threadId, string runId, RequestOptions context)
-    {
-        return RunShim.GetRun(threadId, runId, context);
-    }
+    public virtual ClientResult GetRun(
+        string threadId,
+        string runId,
+        RequestOptions options)
+        => RunShim.GetRun(threadId, runId, options);
 
+    /// <inheritdoc cref="Internal.Runs.GetRunAsync(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetRunAsync(string threadId, string runId, RequestOptions context)
-    {
-        return RunShim.GetRunAsync(threadId, runId, context);
-    }
+    public virtual async Task<ClientResult> GetRunAsync(
+        string threadId,
+        string runId,
+        RequestOptions options)
+        => await RunShim.GetRunAsync(threadId, runId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Runs.GetRuns(string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ClientResult GetRuns(
         string threadId,
@@ -334,73 +364,89 @@ public partial class AssistantClient
         string createdSortOrder,
         string previousRunId,
         string subsequentRunId,
-        RequestOptions context)
-    {
-        return RunShim.GetRuns(threadId, maxResults, createdSortOrder, previousRunId, subsequentRunId, context);
-    }
+        RequestOptions options)
+        => RunShim.GetRuns(threadId, maxResults, createdSortOrder, previousRunId, subsequentRunId, options);
 
+    /// <inheritdoc cref="Internal.Runs.GetRunsAsync(string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetRunsAsync(
+    public virtual async Task<ClientResult> GetRunsAsync(
         string threadId,
         int? maxResults,
         string createdSortOrder,
         string previousRunId,
         string subsequentRunId,
-        RequestOptions context)
-    {
-        return RunShim.GetRunsAsync(threadId, maxResults, createdSortOrder, previousRunId, subsequentRunId, context);
-    }
+        RequestOptions options)
+        => await RunShim.GetRunsAsync(threadId, maxResults, createdSortOrder, previousRunId, subsequentRunId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Runs.ModifyRun(string, string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult ModifyRun(string threadId, string runId, BinaryContent content, RequestOptions context = null)
-    {
-        return RunShim.ModifyRun(threadId, runId, content, context);
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> ModifyRunAsync(
+    public virtual ClientResult ModifyRun(
         string threadId,
         string runId,
         BinaryContent content,
-        RequestOptions context = null)
-    {
-        return RunShim.ModifyRunAsync(threadId, runId, content, context);
-    }
+        RequestOptions options = null)
+        => RunShim.ModifyRun(threadId, runId, content, options);
 
+    /// <inheritdoc cref="Internal.Runs.ModifyRunAsync(string, string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult CancelRun(string threadId, string runId, RequestOptions context)
-    {
-        return RunShim.CancelRun(threadId, runId, context);
-    }
+    public virtual async Task<ClientResult> ModifyRunAsync(
+        string threadId,
+        string runId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => await RunShim.ModifyRunAsync(threadId, runId, content, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Runs.CancelRun(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> CancelRunAsync(string threadId, string runId, RequestOptions context)
-    {
-        return RunShim.CancelRunAsync(threadId, runId, context);
-    }
+    public virtual ClientResult CancelRun(
+        string threadId,
+        string runId,
+        RequestOptions options)
+        => RunShim.CancelRun(threadId, runId, options);
 
+    /// <inheritdoc cref="Internal.Runs.CancelRunAsync(string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult SubmitToolOutputs(string threadId, string runId, BinaryContent content, RequestOptions context = null)
-    {
-        return RunShim.SubmitToolOuputsToRun(threadId, runId, content, context);
-    }
+    public virtual async Task<ClientResult> CancelRunAsync(
+        string threadId,
+        string runId,
+        RequestOptions options)
+        => await RunShim.CancelRunAsync(threadId, runId, options).ConfigureAwait(false);
 
+    /// <inheritdoc cref="Internal.Runs.SubmitToolOuputsToRun(string, string, BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> SubmitToolOutputsAsync(string threadId, string runId, BinaryContent content, RequestOptions context = null)
-    {
-        return RunShim.SubmitToolOuputsToRunAsync(threadId, runId, content, context);
-    }
+    public virtual ClientResult SubmitToolOutputs(
+        string threadId,
+        string runId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => RunShim.SubmitToolOuputsToRun(threadId, runId, content, options);
 
-    public virtual ClientResult GetRunStep(string threadId, string runId, string stepId, RequestOptions context)
-    {
-        return RunShim.GetRunStep(threadId, runId, stepId, context);
-    }
+    /// <inheritdoc cref="Internal.Runs.SubmitToolOuputsToRunAsync(string, string, BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> SubmitToolOutputsAsync(
+        string threadId,
+        string runId,
+        BinaryContent content,
+        RequestOptions options = null)
+        => await RunShim.SubmitToolOuputsToRunAsync(threadId, runId, content, options).ConfigureAwait(false);
 
-    public virtual Task<ClientResult> GetRunStepAsync(string threadId, string runId, string stepId, RequestOptions context)
-    {
-        return RunShim.GetRunStepAsync(threadId, runId, stepId, context);
-    }
+    /// <inheritdoc cref="Internal.Runs.GetRunStep(string, string, string, RequestOptions)"/>
+    public virtual ClientResult GetRunStep(
+        string threadId,
+        string runId,
+        string stepId,
+        RequestOptions options)
+        => RunShim.GetRunStep(threadId, runId, stepId, options);
 
+    /// <inheritdoc cref="Internal.Runs.GetRunStepAsync(string, string, string, RequestOptions)"/>
+    public virtual async Task<ClientResult> GetRunStepAsync(
+        string threadId,
+        string runId,
+        string stepId, 
+        RequestOptions options)
+        => await RunShim.GetRunStepAsync(threadId, runId, stepId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.Runs.GetRunSteps(string, string, int?, string, string, string, RequestOptions)"/>
     public virtual ClientResult GetRunSteps(
         string threadId,
         string runId,
@@ -408,22 +454,17 @@ public partial class AssistantClient
         string createdSortOrder,
         string previousStepId,
         string subsequentStepId,
-        RequestOptions context)
-    {
-        return RunShim
-            .GetRunSteps(threadId, runId, maxResults, createdSortOrder, previousStepId, subsequentStepId, context);
-    }
+        RequestOptions options)
+        => RunShim.GetRunSteps(threadId, runId, maxResults, createdSortOrder, previousStepId, subsequentStepId, options);
 
-    public virtual Task<ClientResult> GetRunStepsAsync(
+    /// <inheritdoc cref="Internal.Runs.GetRunStepsAsync(string, string, int?, string, string, string, RequestOptions)"/>
+    public virtual async Task<ClientResult> GetRunStepsAsync(
         string threadId,
         string runId,
         int? maxResults,
         string createdSortOrder,
         string previousStepId,
         string subsequentStepId,
-        RequestOptions context)
-    {
-        return RunShim
-            .GetRunStepsAsync(threadId, runId, maxResults, createdSortOrder, previousStepId, subsequentStepId, context);
-    }
+        RequestOptions options)
+        => await RunShim.GetRunStepsAsync(threadId, runId, maxResults, createdSortOrder, previousStepId, subsequentStepId, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/Assistants/AssistantClient.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantClient.cs
@@ -99,14 +99,18 @@ public partial class AssistantClient
         : this(endpoint: null, credential: null, options)
     { }
 
-    public virtual ClientResult<Assistant> CreateAssistant(string modelName, AssistantCreationOptions options = null)
+    public virtual ClientResult<Assistant> CreateAssistant(
+        string modelName,
+        AssistantCreationOptions options = null)
     {
         Internal.Models.CreateAssistantRequest request = CreateInternalCreateAssistantRequest(modelName, options);
         ClientResult<Internal.Models.AssistantObject> internalResult = Shim.CreateAssistant(request);
         return ClientResult.FromValue(new Assistant(internalResult.Value), internalResult.GetRawResponse());
     }
 
-     public virtual async Task<ClientResult<Assistant>> CreateAssistantAsync(string modelName, AssistantCreationOptions options = null)
+    public virtual async Task<ClientResult<Assistant>> CreateAssistantAsync(
+        string modelName,
+        AssistantCreationOptions options = null)
     {
         Internal.Models.CreateAssistantRequest request = CreateInternalCreateAssistantRequest(modelName, options);
         ClientResult<Internal.Models.AssistantObject> internalResult
@@ -114,7 +118,7 @@ public partial class AssistantClient
         return ClientResult.FromValue(new Assistant(internalResult.Value), internalResult.GetRawResponse());
     }
 
-     public virtual ClientResult<Assistant> GetAssistant(string assistantId)
+    public virtual ClientResult<Assistant> GetAssistant(string assistantId)
     {
         ClientResult<Internal.Models.AssistantObject> internalResult = Shim.GetAssistant(assistantId);
         return ClientResult.FromValue(new Assistant(internalResult.Value), internalResult.GetRawResponse());
@@ -175,7 +179,8 @@ public partial class AssistantClient
         return ClientResult.FromValue(new Assistant(internalResult.Value), internalResult.GetRawResponse());
     }
 
-     public virtual ClientResult<bool> DeleteAssistant(string assistantId)
+    public virtual ClientResult<bool> DeleteAssistant(
+        string assistantId)
     {
         ClientResult<Internal.Models.DeleteAssistantResponse> internalResponse = Shim.DeleteAssistant(assistantId);
         return ClientResult.FromValue(internalResponse.Value.Deleted, internalResponse.GetRawResponse());

--- a/.dotnet/src/Custom/Audio/AudioClient.Protocol.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.Protocol.cs
@@ -1,0 +1,19 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace OpenAI.Audio;
+
+public partial class AudioClient
+{
+    /// <inheritdoc cref="Internal.Audio.CreateSpeech(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateSpeech(content, options);
+
+    /// <inheritdoc cref="Internal.Audio.CreateSpeechAsync(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateSpeechAsync(content, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -3,7 +3,6 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -144,14 +143,6 @@ public partial class AudioClient
         Internal.Models.CreateSpeechRequest request = CreateInternalTtsRequest(text, voice, options);
         return Shim.CreateSpeechAsync(request);
     }
-
-    /// <inheritdoc cref="Internal.Audio.CreateSpeech(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateSpeech(content, options);
-
-    /// <inheritdoc cref="Internal.Audio.CreateSpeechAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateSpeechAsync(content, options).ConfigureAwait(false);
 
     public virtual ClientResult<AudioTranscription> TranscribeAudio(BinaryData audioBytes, string filename, AudioTranscriptionOptions options = null)
     {

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -1,13 +1,11 @@
 using OpenAI.ClientShared.Internal;
 using System;
 using System.ClientModel;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenAI.Audio;
@@ -15,7 +13,7 @@ namespace OpenAI.Audio;
 /// <summary> The service client for OpenAI audio operations. </summary>
 public partial class AudioClient
 {
-    private OpenAIClientConnector _clientConnector;
+    private readonly OpenAIClientConnector _clientConnector;
     private Internal.Audio Shim => _clientConnector.InternalClient.GetAudioClient();
 
     /// <summary>
@@ -148,14 +146,12 @@ public partial class AudioClient
     }
 
     /// <inheritdoc cref="Internal.Audio.CreateSpeech(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateSpeech(content, context);
+    public virtual ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateSpeech(content, options);
 
-    /// <inheritdoc cref="Internal.Audio.CreateSpeech(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateSpeechAsync(content, context);
+    /// <inheritdoc cref="Internal.Audio.CreateSpeechAsync(BinaryContent, RequestOptions)"/>
+    public virtual async Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateSpeechAsync(content, options).ConfigureAwait(false);
 
     public virtual ClientResult<AudioTranscription> TranscribeAudio(BinaryData audioBytes, string filename, AudioTranscriptionOptions options = null)
     {
@@ -172,14 +168,12 @@ public partial class AudioClient
     }
 
     /// <inheritdoc cref="Internal.Audio.CreateTranscription(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult TranscribeAudio(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateTranscription(content, context);
+    public virtual ClientResult TranscribeAudio(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateTranscription(content, options);
 
     /// <inheritdoc cref="Internal.Audio.CreateTranscriptionAsync(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> TranscribeAudioAsync(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateTranscriptionAsync(content, context);
+    public virtual async Task<ClientResult> TranscribeAudioAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateTranscriptionAsync(content, options).ConfigureAwait(false);
 
     public virtual ClientResult<AudioTranslation> TranslateAudio(BinaryData audioBytes, string filename, AudioTranslationOptions options = null)
     {
@@ -196,14 +190,12 @@ public partial class AudioClient
     }
 
     /// <inheritdoc cref="Internal.Audio.CreateTranslation(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult TranslateAudio(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateTranslation(content, context);
+    public virtual ClientResult TranslateAudio(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateTranslation(content, options);
 
     /// <inheritdoc cref="Internal.Audio.CreateTranslationAsync(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> TranslateAudioAsync(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateTranslationAsync(content, context);
+    public virtual async Task<ClientResult> TranslateAudioAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateTranslationAsync(content, options).ConfigureAwait(false);
 
     private PipelineMessage CreateInternalTranscriptionRequestMessage(BinaryData audioBytes, string filename, AudioTranscriptionOptions options)
     {

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -167,14 +167,6 @@ public partial class AudioClient
         return GetTranscriptionResultFromResponse(message.Response);
     }
 
-    /// <inheritdoc cref="Internal.Audio.CreateTranscription(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult TranscribeAudio(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateTranscription(content, options);
-
-    /// <inheritdoc cref="Internal.Audio.CreateTranscriptionAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> TranscribeAudioAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateTranscriptionAsync(content, options).ConfigureAwait(false);
-
     public virtual ClientResult<AudioTranslation> TranslateAudio(BinaryData audioBytes, string filename, AudioTranslationOptions options = null)
     {
         PipelineMessage message = CreateInternalTranslationRequestMessage(audioBytes, filename, options);
@@ -188,14 +180,6 @@ public partial class AudioClient
         await Shim.Pipeline.SendAsync(message);
         return GetTranslationResultFromResponse(message.Response);
     }
-
-    /// <inheritdoc cref="Internal.Audio.CreateTranslation(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult TranslateAudio(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateTranslation(content, options);
-
-    /// <inheritdoc cref="Internal.Audio.CreateTranslationAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> TranslateAudioAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateTranslationAsync(content, options).ConfigureAwait(false);
 
     private PipelineMessage CreateInternalTranscriptionRequestMessage(BinaryData audioBytes, string filename, AudioTranscriptionOptions options)
     {

--- a/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
@@ -1,0 +1,20 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace OpenAI.Chat;
+
+/// <summary> The service client for the OpenAI Chat Completions endpoint. </summary>
+public partial class ChatClient
+{
+    /// <inheritdoc cref="Internal.Chat.CreateChatCompletion(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult CompleteChat(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateChatCompletion(content, options);
+
+    /// <inheritdoc cref="Internal.Chat.CreateChatCompletionAsync(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> CompleteChatAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateChatCompletionAsync(content, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/Chat/ChatClient.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.cs
@@ -11,7 +11,7 @@ namespace OpenAI.Chat;
 /// <summary> The service client for the OpenAI Chat Completions endpoint. </summary>
 public partial class ChatClient
 {
-    private OpenAIClientConnector _clientConnector;
+    private readonly OpenAIClientConnector _clientConnector;
     private Internal.Chat Shim => _clientConnector.InternalClient.GetChatClient();
 
     /// <summary>
@@ -316,14 +316,12 @@ public partial class ChatClient
     }
 
     /// <inheritdoc cref="Internal.Chat.CreateChatCompletion(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult CompleteChat(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateChatCompletion(content, context);
+    public virtual ClientResult CompleteChat(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateChatCompletion(content, options);
 
     /// <inheritdoc cref="Internal.Chat.CreateChatCompletionAsync(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> CompleteChatAsync(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateChatCompletionAsync(content, context);
+    public virtual async Task<ClientResult> CompleteChatAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateChatCompletionAsync(content, options).ConfigureAwait(false);
 
     private Internal.Models.CreateChatCompletionRequest CreateInternalRequest(
         IEnumerable<ChatRequestMessage> messages,

--- a/.dotnet/src/Custom/Chat/ChatClient.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -314,14 +313,6 @@ public partial class ChatClient
                 responseForEnumeration.GetRawResponse().ContentStream,
                 e => StreamingChatUpdate.DeserializeStreamingChatUpdates(e)));   
     }
-
-    /// <inheritdoc cref="Internal.Chat.CreateChatCompletion(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult CompleteChat(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateChatCompletion(content, options);
-
-    /// <inheritdoc cref="Internal.Chat.CreateChatCompletionAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> CompleteChatAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateChatCompletionAsync(content, options).ConfigureAwait(false);
 
     private Internal.Models.CreateChatCompletionRequest CreateInternalRequest(
         IEnumerable<ChatRequestMessage> messages,

--- a/.dotnet/src/Custom/Embeddings/EmbeddingClient.Protocol.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingClient.Protocol.cs
@@ -1,0 +1,19 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace OpenAI.Embeddings;
+
+public partial class EmbeddingClient
+{
+    /// <inheritdoc cref="Internal.Embeddings.CreateEmbedding(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult GenerateEmbeddings(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateEmbedding(content, options);
+
+    /// <inheritdoc cref="Internal.Embeddings.CreateEmbeddingAsync(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> GenerateEmbeddingsAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateEmbeddingAsync(content, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/Embeddings/EmbeddingClient.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingClient.cs
@@ -1,8 +1,6 @@
 using System;
 using System.ClientModel;
-using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace OpenAI.Embeddings;
@@ -93,14 +91,6 @@ public partial class EmbeddingClient
         EmbeddingCollection resultCollection = EmbeddingCollection.CreateFromInternalResponse(response.Value);
         return ClientResult.FromValue(resultCollection, response.GetRawResponse());
     }
-
-    /// <inheritdoc cref="Internal.Embeddings.CreateEmbedding(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult GenerateEmbeddings(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateEmbedding(content, options);
-
-    /// <inheritdoc cref="Internal.Embeddings.CreateEmbeddingAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> GenerateEmbeddingsAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateEmbeddingAsync(content, options).ConfigureAwait(false);
 
     private Internal.Models.CreateEmbeddingRequest CreateInternalRequest(object inputObject, EmbeddingOptions options)
     {

--- a/.dotnet/src/Custom/Embeddings/EmbeddingClient.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingClient.cs
@@ -1,11 +1,8 @@
-using OpenAI.Internal.Models;
 using System;
-using System.ClientModel;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenAI.Embeddings;
@@ -13,7 +10,7 @@ namespace OpenAI.Embeddings;
 /// <summary> The service client for the OpenAI Embeddings endpoint. </summary>
 public partial class EmbeddingClient
 {
-    private OpenAIClientConnector _clientConnector;
+    private readonly OpenAIClientConnector _clientConnector;
     private Internal.Embeddings Shim => _clientConnector.InternalClient.GetEmbeddingsClient();
 
     public EmbeddingClient(Uri endpoint, string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
@@ -98,14 +95,12 @@ public partial class EmbeddingClient
     }
 
     /// <inheritdoc cref="Internal.Embeddings.CreateEmbedding(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GenerateEmbeddings(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateEmbedding(content, context);
+    public virtual ClientResult GenerateEmbeddings(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateEmbedding(content, options);
 
     /// <inheritdoc cref="Internal.Embeddings.CreateEmbeddingAsync(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GenerateEmbeddingsAsync(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateEmbeddingAsync(content, context);
+    public virtual async Task<ClientResult> GenerateEmbeddingsAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateEmbeddingAsync(content, options).ConfigureAwait(false);
 
     private Internal.Models.CreateEmbeddingRequest CreateInternalRequest(object inputObject, EmbeddingOptions options)
     {

--- a/.dotnet/src/Custom/Files/FileClient.Protocol.cs
+++ b/.dotnet/src/Custom/Files/FileClient.Protocol.cs
@@ -1,0 +1,49 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace OpenAI.Files;
+
+public partial class FileClient
+{
+    /// <inheritdoc cref="Internal.Files.RetrieveFile(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult GetFileInfo(string fileId, RequestOptions options)
+        => Shim.RetrieveFile(fileId, options);
+
+    /// <inheritdoc cref="Internal.Files.RetrieveFileAsync(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> GetFileInfoAsync(string fileId, RequestOptions options)
+        => await Shim.RetrieveFileAsync(fileId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.Files.GetFiles(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult GetFileInfoList(string purpose, RequestOptions options)
+        => Shim.GetFiles(purpose, options);
+
+    /// <inheritdoc cref="Internal.Files.GetFilesAsync(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> GetFileInfoListAsync(string purpose, RequestOptions options)
+        => await Shim.GetFilesAsync(purpose, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.Files.DownloadFile(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult DownloadFile(string fileId, RequestOptions options)
+        => Shim.DownloadFile(fileId, options);
+
+    /// <inheritdoc cref="Internal.Files.DownloadFileAsync(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> DownloadFileAsync(string fileId, RequestOptions options)
+        => await Shim.DownloadFileAsync(fileId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.Files.DeleteFile(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult DeleteFile(string fileId, RequestOptions options)
+        => Shim.DeleteFile(fileId, options);
+
+    /// <inheritdoc cref="Internal.Files.DeleteFileAsync(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> DeleteFileAsync(string fileId, RequestOptions options)
+        => await Shim.DeleteFileAsync(fileId, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -125,14 +124,6 @@ public partial class FileClient
         return ClientResult.FromValue(new OpenAIFileInfo(internalResult.Value), internalResult.GetRawResponse());
     }
 
-    /// <inheritdoc cref="Internal.Files.RetrieveFile(string, RequestOptions)"/>
-    public virtual ClientResult GetFileInfo(string fileId, RequestOptions options)
-        => Shim.RetrieveFile(fileId, options);
-
-    /// <inheritdoc cref="Internal.Files.RetrieveFileAsync(string, RequestOptions)"/>
-    public virtual async Task<ClientResult> GetFileInfoAsync(string fileId, RequestOptions options)
-        => await Shim.RetrieveFileAsync(fileId, options).ConfigureAwait(false);
-
     public virtual ClientResult<OpenAIFileInfoCollection> GetFileInfoList(OpenAIFilePurpose? purpose = null)
     {
         Internal.Models.OpenAIFilePurpose? internalPurpose = ToInternalFilePurpose(purpose);
@@ -166,14 +157,6 @@ public partial class FileClient
         }
         return ClientResult.FromValue(new OpenAIFileInfoCollection(infoItems), result.GetRawResponse());
     }
-
-    /// <inheritdoc cref="Internal.Files.GetFiles(string, RequestOptions)"/>
-    public virtual ClientResult GetFileInfoList(string purpose, RequestOptions options)
-        => Shim.GetFiles(purpose, options);
-
-    /// <inheritdoc cref="Internal.Files.GetFilesAsync(string, RequestOptions)"/>
-    public virtual async Task<ClientResult> GetFileInfoListAsync(string purpose, RequestOptions options)
-        => await Shim.GetFilesAsync(purpose, options).ConfigureAwait(false);
 
     public virtual ClientResult<BinaryData> DownloadFile(string fileId)
     {
@@ -220,14 +203,6 @@ public partial class FileClient
         return ClientResult.FromValue(message.Response.Content, message.Response);
     }
 
-    /// <inheritdoc cref="Internal.Files.DownloadFile(string, RequestOptions)"/>
-    public virtual ClientResult DownloadFile(string fileId, RequestOptions options)
-        => Shim.DownloadFile(fileId, options);
-
-    /// <inheritdoc cref="Internal.Files.DownloadFileAsync(string, RequestOptions)"/>
-    public virtual async Task<ClientResult> DownloadFileAsync(string fileId, RequestOptions options)
-        => await Shim.DownloadFileAsync(fileId, options).ConfigureAwait(false);
-
     public virtual void DeleteFile(string fileId)
     {
         _ = Shim.DeleteFile(fileId);
@@ -237,14 +212,6 @@ public partial class FileClient
     {
         _ = Shim.DeleteFileAsync(fileId);
     }
-
-    /// <inheritdoc cref="Internal.Files.DeleteFile(string, RequestOptions)"/>
-    public virtual ClientResult DeleteFile(string fileId, RequestOptions options)
-        => Shim.DeleteFile(fileId, options);
-
-    /// <inheritdoc cref="Internal.Files.DeleteFileAsync(string, RequestOptions)"/>
-    public virtual ClientResult DeleteFileAsync(string fileId, RequestOptions options)
-        => Shim.DeleteFile(fileId, options);
 
     internal PipelineMessage CreateInternalUploadMessage(BinaryData fileData, string filename, OpenAIFilePurpose purpose)
     {

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -113,14 +113,6 @@ public partial class FileClient
         return GetUploadResultFromResponse(uploadMessage.Response);
     }
 
-    /// <inheritdoc cref="Internal.Files.CreateFile(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult UploadFile(BinaryContent requestBody, RequestOptions options)
-        =>  Shim.CreateFile(requestBody, options);
-
-    /// <inheritdoc cref="Internal.Files.CreateFileAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> UploadFileAsync(BinaryContent requestBody, RequestOptions options)
-        => await Shim.CreateFileAsync(requestBody, options).ConfigureAwait(false);
-
     public virtual ClientResult<OpenAIFileInfo> GetFileInfo(string fileId)
     {
         ClientResult<Internal.Models.OpenAIFile> internalResult = Shim.RetrieveFile(fileId);

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -3,7 +3,6 @@ using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -14,7 +13,7 @@ namespace OpenAI.Files;
 /// </summary>
 public partial class FileClient
 {
-    private OpenAIClientConnector _clientConnector;
+    private readonly OpenAIClientConnector _clientConnector;
     private Internal.Files Shim => _clientConnector.InternalClient.GetFilesClient();
 
     /// <summary>
@@ -115,18 +114,12 @@ public partial class FileClient
     }
 
     /// <inheritdoc cref="Internal.Files.CreateFile(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult UploadFile(BinaryContent requestBody, RequestOptions context)
-    {
-        return Shim.CreateFile(requestBody, context);
-    }
+    public virtual ClientResult UploadFile(BinaryContent requestBody, RequestOptions options)
+        =>  Shim.CreateFile(requestBody, options);
 
     /// <inheritdoc cref="Internal.Files.CreateFileAsync(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> UploadFileAsync(BinaryContent requestBody, RequestOptions context)
-    {
-        return Shim.CreateFileAsync(requestBody, context);
-    }
+    public virtual async Task<ClientResult> UploadFileAsync(BinaryContent requestBody, RequestOptions options)
+        => await Shim.CreateFileAsync(requestBody, options).ConfigureAwait(false);
 
     public virtual ClientResult<OpenAIFileInfo> GetFileInfo(string fileId)
     {
@@ -141,18 +134,12 @@ public partial class FileClient
     }
 
     /// <inheritdoc cref="Internal.Files.RetrieveFile(string, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetFileInfo(string fileId, RequestOptions context)
-    {
-        return Shim.RetrieveFile(fileId, context);
-    }
+    public virtual ClientResult GetFileInfo(string fileId, RequestOptions options)
+        => Shim.RetrieveFile(fileId, options);
 
     /// <inheritdoc cref="Internal.Files.RetrieveFileAsync(string, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetFileInfoAsync(string fileId, RequestOptions context)
-    {
-        return Shim.RetrieveFileAsync(fileId, context);
-    }
+    public virtual async Task<ClientResult> GetFileInfoAsync(string fileId, RequestOptions options)
+        => await Shim.RetrieveFileAsync(fileId, options).ConfigureAwait(false);
 
     public virtual ClientResult<OpenAIFileInfoCollection> GetFileInfoList(OpenAIFilePurpose? purpose = null)
     {
@@ -189,18 +176,12 @@ public partial class FileClient
     }
 
     /// <inheritdoc cref="Internal.Files.GetFiles(string, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetFileInfoList(string purpose, RequestOptions context)
-    {
-        return Shim.GetFiles(purpose, context);
-    }
+    public virtual ClientResult GetFileInfoList(string purpose, RequestOptions options)
+        => Shim.GetFiles(purpose, options);
 
     /// <inheritdoc cref="Internal.Files.GetFilesAsync(string, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetFileInfoListAsync(string purpose, RequestOptions context)
-    {
-        return Shim.GetFilesAsync(purpose, context);
-    }
+    public virtual async Task<ClientResult> GetFileInfoListAsync(string purpose, RequestOptions options)
+        => await Shim.GetFilesAsync(purpose, options).ConfigureAwait(false);
 
     public virtual ClientResult<BinaryData> DownloadFile(string fileId)
     {
@@ -248,18 +229,12 @@ public partial class FileClient
     }
 
     /// <inheritdoc cref="Internal.Files.DownloadFile(string, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult DownloadFile(string fileId, RequestOptions context)
-    {
-        return Shim.DownloadFile(fileId, context);
-    }
+    public virtual ClientResult DownloadFile(string fileId, RequestOptions options)
+        => Shim.DownloadFile(fileId, options);
 
     /// <inheritdoc cref="Internal.Files.DownloadFileAsync(string, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> DownloadFileAsync(string fileId, RequestOptions context)
-    {
-        return Shim.DownloadFileAsync(fileId, context);
-    }
+    public virtual async Task<ClientResult> DownloadFileAsync(string fileId, RequestOptions options)
+        => await Shim.DownloadFileAsync(fileId, options).ConfigureAwait(false);
 
     public virtual void DeleteFile(string fileId)
     {
@@ -272,18 +247,12 @@ public partial class FileClient
     }
 
     /// <inheritdoc cref="Internal.Files.DeleteFile(string, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult DeleteFile(string fileId, RequestOptions context)
-    {
-        return Shim.DeleteFile(fileId, context);
-    }
+    public virtual ClientResult DeleteFile(string fileId, RequestOptions options)
+        => Shim.DeleteFile(fileId, options);
 
     /// <inheritdoc cref="Internal.Files.DeleteFileAsync(string, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult DeleteFileAsync(string fileId, RequestOptions context)
-    {
-        return Shim.DeleteFile(fileId, context);
-    }
+    public virtual ClientResult DeleteFileAsync(string fileId, RequestOptions options)
+        => Shim.DeleteFile(fileId, options);
 
     internal PipelineMessage CreateInternalUploadMessage(BinaryData fileData, string filename, OpenAIFilePurpose purpose)
     {

--- a/.dotnet/src/Custom/FineTuning/FineTuningClient.Protocol.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningClient.Protocol.cs
@@ -1,0 +1,74 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Threading.Tasks;
+
+namespace OpenAI.FineTuning;
+
+public partial class FineTuningClient
+{
+    /// <inheritdoc cref="Internal.FineTuning.CreateFineTuningJob(BinaryContent, RequestOptions)"/>
+    public virtual ClientResult CreateFineTuningJob(
+        BinaryContent content,
+        RequestOptions options = null)
+        => FineTuningShim.CreateFineTuningJob(content, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.CreateFineTuningJobAsync(BinaryContent, RequestOptions)"/>
+    public virtual async Task<ClientResult> CreateFineTuningJobAsync(
+        BinaryContent content,
+        RequestOptions options = null)
+        => await FineTuningShim.CreateFineTuningJobAsync(content, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.FineTuning.RetrieveFineTuningJob(string, RequestOptions)"/>
+    public virtual ClientResult GetFineTuningJob(
+        string jobId,
+        RequestOptions options)
+        => FineTuningShim.RetrieveFineTuningJob(jobId, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.RetrieveFineTuningJobAsync(string, RequestOptions)"/>
+    public virtual async Task<ClientResult> GetFineTuningJobAsync(
+        string jobId,
+        RequestOptions options)
+        => await FineTuningShim.RetrieveFineTuningJobAsync(jobId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.FineTuning.GetPaginatedFineTuningJobs(string, int?, RequestOptions)"/>
+    public virtual ClientResult GetFineTuningJobs(
+        string previousJobId,
+        int? maxResults,
+        RequestOptions options)
+        => FineTuningShim.GetPaginatedFineTuningJobs(previousJobId, maxResults, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.GetPaginatedFineTuningJobsAsync(string, int?, RequestOptions)"/>
+    public virtual async Task<ClientResult> GetFineTuningJobsAsync(
+        string previousJobId,
+        int? maxResults,
+        RequestOptions options)
+        => await FineTuningShim.GetPaginatedFineTuningJobsAsync(previousJobId, maxResults, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.FineTuning.CancelFineTuningJob(string, RequestOptions)"/>
+    public virtual ClientResult CancelFineTuningJob(
+        string jobId,
+        RequestOptions options)
+        => FineTuningShim.CancelFineTuningJob(jobId, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.CancelFineTuningJobAsync(string, RequestOptions)"/>
+    public virtual async Task<ClientResult> CancelFineTuningJobAsync(
+        string jobId,
+        RequestOptions options)
+        => await FineTuningShim.CancelFineTuningJobAsync(jobId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.FineTuning.GetFineTuningEvents(string, string, int?, RequestOptions)"/>
+    public virtual ClientResult GetFineTuningJobEvents(
+        string jobId,
+        string previousEventId,
+        int? maxResults,
+        RequestOptions options)
+        => FineTuningShim.GetFineTuningEvents(jobId, previousEventId, maxResults, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.GetFineTuningEventsAsync(string, string, int?, RequestOptions)"/>
+    public virtual async Task<ClientResult> GetFineTuningJobEventsAsync(
+        string jobId,
+        string previousEventId,
+        int? maxResults,
+        RequestOptions options)
+        => await FineTuningShim.GetFineTuningEventsAsync(jobId, previousEventId, maxResults, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/FineTuning/FineTuningClient.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningClient.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.ClientModel;
-using System.ClientModel.Primitives;
-using System.Threading.Tasks;
 
 namespace OpenAI.FineTuning;
 
@@ -89,44 +87,4 @@ public partial class FineTuningClient
     public FineTuningClient(OpenAIClientOptions options = null)
         : this(endpoint: null, credential: null, options)
     { }
-
-    /// <inheritdoc cref="Internal.FineTuning.CreateFineTuningJob(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult CreateFineTuningJob(BinaryContent content, RequestOptions options = null)
-        => FineTuningShim.CreateFineTuningJob(content, options);
-
-    /// <inheritdoc cref="Internal.FineTuning.CreateFineTuningJobAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> CreateFineTuningJobAsync(BinaryContent content, RequestOptions options = null)
-        => await FineTuningShim.CreateFineTuningJobAsync(content, options).ConfigureAwait(false);
-
-    /// <inheritdoc cref="Internal.FineTuning.RetrieveFineTuningJob(string, RequestOptions)"/>
-    public virtual ClientResult GetFineTuningJob(string jobId, RequestOptions options)
-        => FineTuningShim.RetrieveFineTuningJob(jobId, options);
-
-    /// <inheritdoc cref="Internal.FineTuning.RetrieveFineTuningJobAsync(string, RequestOptions)"/>
-    public virtual async Task<ClientResult> GetFineTuningJobAsync(string jobId, RequestOptions options)
-        => await FineTuningShim.RetrieveFineTuningJobAsync(jobId, options).ConfigureAwait(false);
-
-    /// <inheritdoc cref="Internal.FineTuning.GetPaginatedFineTuningJobs(string, int?, RequestOptions)"/>
-    public virtual ClientResult GetFineTuningJobs(string previousJobId, int? maxResults, RequestOptions options)
-        => FineTuningShim.GetPaginatedFineTuningJobs(previousJobId, maxResults, options);
-
-    /// <inheritdoc cref="Internal.FineTuning.GetPaginatedFineTuningJobsAsync(string, int?, RequestOptions)"/>
-    public virtual async Task<ClientResult> GetFineTuningJobsAsync(string previousJobId, int? maxResults, RequestOptions options)
-        => await FineTuningShim.GetPaginatedFineTuningJobsAsync(previousJobId, maxResults, options).ConfigureAwait(false);
-
-    /// <inheritdoc cref="Internal.FineTuning.CancelFineTuningJob(string, RequestOptions)"/>
-    public virtual ClientResult CancelFineTuningJob(string jobId, RequestOptions options)
-        => FineTuningShim.CancelFineTuningJob(jobId, options);
-
-    /// <inheritdoc cref="Internal.FineTuning.CancelFineTuningJobAsync(string, RequestOptions)"/>
-    public virtual async Task<ClientResult> CancelFineTuningJobAsync(string jobId, RequestOptions options)
-        => await FineTuningShim.CancelFineTuningJobAsync(jobId, options).ConfigureAwait(false);
-
-    /// <inheritdoc cref="Internal.FineTuning.GetFineTuningEvents(string, string, int?, RequestOptions)"/>
-    public virtual ClientResult GetFineTuningJobEvents(string jobId, string previousJobId, int? maxResults, RequestOptions options)
-        => FineTuningShim.GetFineTuningEvents(jobId, previousJobId, maxResults, options);
-
-    /// <inheritdoc cref="Internal.FineTuning.GetFineTuningEventsAsync(string, string, int?, RequestOptions)"/>
-    public virtual async Task<ClientResult> GetFineTuningJobEventsAsync(string jobId, string previousJobId, int? maxResults, RequestOptions options)
-        => await FineTuningShim.GetFineTuningEventsAsync(jobId, previousJobId, maxResults, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/FineTuning/FineTuningClient.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningClient.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Threading.Tasks;
+
+namespace OpenAI.FineTuning;
+
+/// <summary>
+///     The service client for OpenAI fine-tuning operations.
+/// </summary>
+public partial class FineTuningClient
+{
+    private readonly OpenAIClientConnector _clientConnector;
+    private Internal.FineTuning FineTuningShim => _clientConnector.InternalClient.GetFineTuningClient();
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FineTuningClient"/>, used for fine-tuning operation requests. 
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
+    ///     defined and otherwise use the default OpenAI v1 endpoint.
+    /// </para>
+    /// <para>
+    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
+    ///    if it is defined.
+    /// </para>
+    /// </remarks>
+    /// <param name="endpoint">The connection endpoint to use.</param>
+    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
+    /// <param name="options">Additional options to customize the client.</param>
+    public FineTuningClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    {
+        _clientConnector = new("none", endpoint, credential, options);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FineTuningClient"/>, used for fine-tuning operation requests. 
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
+    ///     defined and otherwise use the default OpenAI v1 endpoint.
+    /// </para>
+    /// <para>
+    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
+    ///    if it is defined.
+    /// </para>
+    /// </remarks>
+    /// <param name="endpoint">The connection endpoint to use.</param>
+    /// <param name="options">Additional options to customize the client.</param>
+    public FineTuningClient(Uri endpoint, OpenAIClientOptions options = null)
+        : this(endpoint, credential: null, options)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FineTuningClient"/>, used for fine-tuning operation requests. 
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
+    ///     defined and otherwise use the default OpenAI v1 endpoint.
+    /// </para>
+    /// <para>
+    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
+    ///    if it is defined.
+    /// </para>
+    /// </remarks>
+    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
+    /// <param name="options">Additional options to customize the client.</param>
+    public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
+        : this(endpoint: null, credential, options)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FineTuningClient"/>, used for fine-tuning operation requests. 
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
+    ///     defined and otherwise use the default OpenAI v1 endpoint.
+    /// </para>
+    /// <para>
+    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
+    ///    if it is defined.
+    /// </para>
+    /// </remarks>
+    /// <param name="options">Additional options to customize the client.</param>
+    public FineTuningClient(OpenAIClientOptions options = null)
+        : this(endpoint: null, credential: null, options)
+    { }
+
+    /// <inheritdoc cref="Internal.FineTuning.CreateFineTuningJob(BinaryContent, RequestOptions)"/>
+    public virtual ClientResult CreateFineTuningJob(BinaryContent content, RequestOptions options = null)
+        => FineTuningShim.CreateFineTuningJob(content, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.CreateFineTuningJobAsync(BinaryContent, RequestOptions)"/>
+    public virtual async Task<ClientResult> CreateFineTuningJobAsync(BinaryContent content, RequestOptions options = null)
+        => await FineTuningShim.CreateFineTuningJobAsync(content, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.FineTuning.RetrieveFineTuningJob(string, RequestOptions)"/>
+    public virtual ClientResult GetFineTuningJob(string jobId, RequestOptions options)
+        => FineTuningShim.RetrieveFineTuningJob(jobId, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.RetrieveFineTuningJobAsync(string, RequestOptions)"/>
+    public virtual async Task<ClientResult> GetFineTuningJobAsync(string jobId, RequestOptions options)
+        => await FineTuningShim.RetrieveFineTuningJobAsync(jobId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.FineTuning.GetPaginatedFineTuningJobs(string, int?, RequestOptions)"/>
+    public virtual ClientResult GetFineTuningJobs(string previousJobId, int? maxResults, RequestOptions options)
+        => FineTuningShim.GetPaginatedFineTuningJobs(previousJobId, maxResults, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.GetPaginatedFineTuningJobsAsync(string, int?, RequestOptions)"/>
+    public virtual async Task<ClientResult> GetFineTuningJobsAsync(string previousJobId, int? maxResults, RequestOptions options)
+        => await FineTuningShim.GetPaginatedFineTuningJobsAsync(previousJobId, maxResults, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.FineTuning.CancelFineTuningJob(string, RequestOptions)"/>
+    public virtual ClientResult CancelFineTuningJob(string jobId, RequestOptions options)
+        => FineTuningShim.CancelFineTuningJob(jobId, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.CancelFineTuningJobAsync(string, RequestOptions)"/>
+    public virtual async Task<ClientResult> CancelFineTuningJobAsync(string jobId, RequestOptions options)
+        => await FineTuningShim.CancelFineTuningJobAsync(jobId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.FineTuning.GetFineTuningEvents(string, string, int?, RequestOptions)"/>
+    public virtual ClientResult GetFineTuningJobEvents(string jobId, string previousJobId, int? maxResults, RequestOptions options)
+        => FineTuningShim.GetFineTuningEvents(jobId, previousJobId, maxResults, options);
+
+    /// <inheritdoc cref="Internal.FineTuning.GetFineTuningEventsAsync(string, string, int?, RequestOptions)"/>
+    public virtual async Task<ClientResult> GetFineTuningJobEventsAsync(string jobId, string previousJobId, int? maxResults, RequestOptions options)
+        => await FineTuningShim.GetFineTuningEventsAsync(jobId, previousJobId, maxResults, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/Images/ImageClient.Protocol.cs
+++ b/.dotnet/src/Custom/Images/ImageClient.Protocol.cs
@@ -1,0 +1,19 @@
+﻿using System.ClientModel.Primitives;
+using System.ClientModel;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace OpenAI.Images;
+
+public partial class ImageClient
+{
+    /// <inheritdoc cref="Internal.Images.CreateImage(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult GenerateImage(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateImage(content, options);
+
+    /// <inheritdoc cref="Internal.Images.CreateImageAsync(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> GenerateImageAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateImageAsync(content, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/Images/ImageClient.cs
+++ b/.dotnet/src/Custom/Images/ImageClient.cs
@@ -1,10 +1,8 @@
 using System;
 using System.ClientModel;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenAI.Images;
@@ -12,7 +10,7 @@ namespace OpenAI.Images;
 /// <summary> The service client for OpenAI image operations. </summary>
 public partial class ImageClient
 {
-    private OpenAIClientConnector _clientConnector;
+    private readonly OpenAIClientConnector _clientConnector;
     private Internal.Images Shim => _clientConnector.InternalClient.GetImagesClient();
 
     /// <summary>
@@ -172,15 +170,29 @@ public partial class ImageClient
         return ClientResult.FromValue(new ImageGenerationCollection(ImageGenerations), response.GetRawResponse());
     }
 
-    /// <inheritdoc cref="Internal.Models.Images.CreateImage(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GenerateImage(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateImage(content, context);
+    /// <inheritdoc cref="Internal.Images.CreateImage(BinaryContent, RequestOptions)"/>
+    public virtual ClientResult GenerateImage(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateImage(content, options);
 
-    /// <inheritdoc cref="Internal.Models.Images.CreateImageAsync(BinaryContent, RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GenerateImageAsync(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateImageAsync(content, context);
+    /// <inheritdoc cref="Internal.Images.CreateImageAsync(BinaryContent, RequestOptions)"/>
+    public virtual async Task<ClientResult> GenerateImageAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateImageAsync(content, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.Images.CreateImageEdit(BinaryContent, RequestOptions)"/>
+    public virtual ClientResult GenerateImageEdit(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateImageEdit(content, options);
+
+    /// <inheritdoc cref="Internal.Images.CreateImageEditAsync(BinaryContent, RequestOptions)"/>
+    public virtual async Task<ClientResult> GenerateImageEditAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateImageEditAsync(content, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.Images.CreateImageVariation(BinaryContent, RequestOptions)"/>
+    public virtual ClientResult GenerateImageVariation(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateImageVariation(content, options);
+
+    /// <inheritdoc cref="Internal.Images.CreateImageVariationAsync(BinaryContent, RequestOptions)"/>
+    public virtual async Task<ClientResult> GenerateImageVariationAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateImageVariationAsync(content, options).ConfigureAwait(false);
 
     private Internal.Models.CreateImageRequest CreateInternalRequest(
         string prompt,

--- a/.dotnet/src/Custom/Images/ImageClient.cs
+++ b/.dotnet/src/Custom/Images/ImageClient.cs
@@ -1,8 +1,6 @@
 using System;
 using System.ClientModel;
-using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace OpenAI.Images;
@@ -169,14 +167,6 @@ public partial class ImageClient
         }
         return ClientResult.FromValue(new ImageGenerationCollection(ImageGenerations), response.GetRawResponse());
     }
-
-    /// <inheritdoc cref="Internal.Images.CreateImage(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult GenerateImage(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateImage(content, options);
-
-    /// <inheritdoc cref="Internal.Images.CreateImageAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> GenerateImageAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateImageAsync(content, options).ConfigureAwait(false);
 
     private Internal.Models.CreateImageRequest CreateInternalRequest(
         string prompt,

--- a/.dotnet/src/Custom/Images/ImageClient.cs
+++ b/.dotnet/src/Custom/Images/ImageClient.cs
@@ -178,22 +178,6 @@ public partial class ImageClient
     public virtual async Task<ClientResult> GenerateImageAsync(BinaryContent content, RequestOptions options = null)
         => await Shim.CreateImageAsync(content, options).ConfigureAwait(false);
 
-    /// <inheritdoc cref="Internal.Images.CreateImageEdit(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult GenerateImageEdit(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateImageEdit(content, options);
-
-    /// <inheritdoc cref="Internal.Images.CreateImageEditAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> GenerateImageEditAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateImageEditAsync(content, options).ConfigureAwait(false);
-
-    /// <inheritdoc cref="Internal.Images.CreateImageVariation(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult GenerateImageVariation(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateImageVariation(content, options);
-
-    /// <inheritdoc cref="Internal.Images.CreateImageVariationAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> GenerateImageVariationAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateImageVariationAsync(content, options).ConfigureAwait(false);
-
     private Internal.Models.CreateImageRequest CreateInternalRequest(
         string prompt,
         int? imageCount = null,

--- a/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.Protocol.cs
+++ b/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.Protocol.cs
@@ -1,0 +1,16 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Threading.Tasks;
+
+namespace OpenAI.LegacyCompletions;
+
+public partial class LegacyCompletionClient
+{
+    /// <inheritdoc cref="Internal.Completions.CreateCompletion(BinaryContent, RequestOptions)"/>
+    public virtual ClientResult GenerateLegacyCompletions(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateCompletion(content, options);
+
+    /// <inheritdoc cref="Internal.Completions.CreateCompletionAsync(BinaryContent, RequestOptions)"/>
+    public virtual async Task<ClientResult> GenerateLegacyCompletionsAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateCompletionAsync(content, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
+++ b/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
@@ -1,8 +1,6 @@
 using System;
 using System.ClientModel;
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace OpenAI.LegacyCompletions;
@@ -16,7 +14,7 @@ namespace OpenAI.LegacyCompletions;
 /// </summary>
 public partial class LegacyCompletionClient
 {
-    private OpenAIClientConnector _clientConnector;
+    private readonly OpenAIClientConnector _clientConnector;
     private Internal.Completions Shim => _clientConnector.InternalClient.GetCompletionsClient();
 
     /// <summary>
@@ -97,10 +95,10 @@ public partial class LegacyCompletionClient
     { }
 
     /// <inheritdoc cref="Internal.Completions.CreateCompletion(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult GenerateLegacyCompletions(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateCompletion(content, context);
+    public virtual ClientResult GenerateLegacyCompletions(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateCompletion(content, options);
 
     /// <inheritdoc cref="Internal.Completions.CreateCompletionAsync(BinaryContent, RequestOptions)"/>
-    public virtual Task<ClientResult> GenerateLegacyCompletionsAsync(BinaryContent content, RequestOptions context = null)
-        => Shim.CreateCompletionAsync(content, context);
+    public virtual async Task<ClientResult> GenerateLegacyCompletionsAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateCompletionAsync(content, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
+++ b/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
@@ -1,7 +1,5 @@
 using System;
 using System.ClientModel;
-using System.ClientModel.Primitives;
-using System.Threading.Tasks;
 
 namespace OpenAI.LegacyCompletions;
 
@@ -93,12 +91,4 @@ public partial class LegacyCompletionClient
     public LegacyCompletionClient(OpenAIClientOptions options = null)
         : this(endpoint: null, credential: null, options)
     { }
-
-    /// <inheritdoc cref="Internal.Completions.CreateCompletion(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult GenerateLegacyCompletions(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateCompletion(content, options);
-
-    /// <inheritdoc cref="Internal.Completions.CreateCompletionAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> GenerateLegacyCompletionsAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateCompletionAsync(content, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/Models/ModelManagementClient.Protocol.cs
+++ b/.dotnet/src/Custom/Models/ModelManagementClient.Protocol.cs
@@ -1,0 +1,39 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace OpenAI.ModelManagement;
+
+public partial class ModelManagementClient
+{
+    /// <inheritdoc cref="Internal.ModelsOps.Retrieve(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult GetModelInfo(string modelId, RequestOptions options)
+        => Shim.Retrieve(modelId, options);
+
+    /// <inheritdoc cref="Internal.ModelsOps.RetrieveAsync(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> GetModelInfoAsync(string modelId, RequestOptions options)
+        => await Shim.RetrieveAsync(modelId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.ModelsOps.GetModels(RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult GetModels(RequestOptions options)
+        => Shim.GetModels(options);
+
+    /// <inheritdoc cref="Internal.ModelsOps.GetModelsAsync(RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> GetModelsAsync(RequestOptions options)
+        => await Shim.GetModelsAsync(options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.ModelsOps.Delete(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult DeleteModel(string modelId, RequestOptions options)
+        => Shim.Delete(modelId, options);
+
+    /// <inheritdoc cref="Internal.ModelsOps.DeleteAsync(string, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> DeleteModelAsync(string modelId, RequestOptions options)
+        => await Shim.DeleteAsync(modelId, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/Models/ModelManagementClient.cs
+++ b/.dotnet/src/Custom/Models/ModelManagementClient.cs
@@ -1,8 +1,6 @@
 using OpenAI.ClientShared.Internal;
 using System;
 using System.ClientModel;
-using System.ClientModel.Primitives;
-using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace OpenAI.ModelManagement;
@@ -104,14 +102,6 @@ public partial class ModelManagementClient
         return ClientResult.FromValue(new ModelDetails(internalResult.Value), internalResult.GetRawResponse());
     }
 
-    /// <inheritdoc cref="Internal.ModelsOps.Retrieve(string, RequestOptions)"/>
-    public virtual ClientResult GetModelInfo(string modelId, RequestOptions options)
-        => Shim.Retrieve(modelId, options);
-
-    /// <inheritdoc cref="Internal.ModelsOps.RetrieveAsync(string, RequestOptions)"/>
-    public virtual async Task<ClientResult> GetModelInfoAsync(string modelId, RequestOptions options)
-        => await Shim.RetrieveAsync(modelId, options).ConfigureAwait(false);
-
     public virtual ClientResult<ModelDetailCollection> GetModels()
     {
         ClientResult<Internal.Models.ListModelsResponse> internalResult = Shim.GetModels();
@@ -135,15 +125,6 @@ public partial class ModelManagementClient
         return ClientResult.FromValue(new ModelDetailCollection(modelEntries), internalResult.GetRawResponse());
     }
 
-    /// <inheritdoc cref="Internal.ModelsOps.GetModels(RequestOptions)"/>
-    public virtual ClientResult GetModels(RequestOptions options)
-        => Shim.GetModels(options);
-
-    /// <inheritdoc cref="Internal.ModelsOps.GetModelsAsync(RequestOptions)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> GetModelsAsync(RequestOptions options)
-        => await Shim.GetModelsAsync(options).ConfigureAwait(false);
-
     public virtual ClientResult<bool> DeleteModel(string modelId)
     {
         ClientResult<Internal.Models.DeleteModelResponse> internalResult = Shim.Delete(modelId);
@@ -156,12 +137,4 @@ public partial class ModelManagementClient
             = await Shim.DeleteAsync(modelId).ConfigureAwait(false);
         return ClientResult.FromValue(internalResult.Value.Deleted, internalResult.GetRawResponse());
     }
-
-    /// <inheritdoc cref="Internal.ModelsOps.Delete(string, RequestOptions)"/>
-    public virtual ClientResult DeleteModel(string modelId, RequestOptions options)
-        => Shim.Delete(modelId, options);
-
-    /// <inheritdoc cref="Internal.ModelsOps.DeleteAsync(string, RequestOptions)"/>
-    public virtual async Task<ClientResult> DeleteModelAsync(string modelId, RequestOptions options)
-        => await Shim.DeleteAsync(modelId, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/Models/ModelManagementClient.cs
+++ b/.dotnet/src/Custom/Models/ModelManagementClient.cs
@@ -12,10 +12,8 @@ namespace OpenAI.ModelManagement;
 /// </summary>
 public partial class ModelManagementClient
 {
-    private OpenAIClientConnector _clientConnector;
+    private readonly OpenAIClientConnector _clientConnector;
     private Internal.ModelsOps Shim => _clientConnector.InternalClient.GetModelsOpsClient();
-    private Internal.FineTuning FineTuningShim
-        => _clientConnector.InternalClient.GetFineTuningClient();
 
     /// <summary>
     /// Initializes a new instance of <see cref="ModelManagementClient"/>, used for model operation requests. 
@@ -94,30 +92,25 @@ public partial class ModelManagementClient
         : this(endpoint: null, credential: null, options)
     { }
 
-     public virtual ClientResult<ModelDetails> GetModelInfo(string modelId)
+    public virtual ClientResult<ModelDetails> GetModelInfo(string modelId)
     {
         ClientResult<Internal.Models.Model> internalResult = Shim.Retrieve(modelId);
         return ClientResult.FromValue(new ModelDetails(internalResult.Value), internalResult.GetRawResponse());
     }
 
-    public virtual async Task<ClientResult<ModelDetails>> GetModelInfoAsync(
-        string modelId)
+    public virtual async Task<ClientResult<ModelDetails>> GetModelInfoAsync(string modelId)
     {
         ClientResult<Internal.Models.Model> internalResult = await Shim.RetrieveAsync(modelId).ConfigureAwait(false);
         return ClientResult.FromValue(new ModelDetails(internalResult.Value), internalResult.GetRawResponse());
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetModelInfo(string modelId, RequestOptions context)
-    {
-        return Shim.Retrieve(modelId, context);
-    }
+    /// <inheritdoc cref="Internal.ModelsOps.Retrieve(string, RequestOptions)"/>
+    public virtual ClientResult GetModelInfo(string modelId, RequestOptions options)
+        => Shim.Retrieve(modelId, options);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetModelInfoAsync(string modelId, RequestOptions context)
-    {
-        return Shim.RetrieveAsync(modelId, context);
-    }
+    /// <inheritdoc cref="Internal.ModelsOps.RetrieveAsync(string, RequestOptions)"/>
+    public virtual async Task<ClientResult> GetModelInfoAsync(string modelId, RequestOptions options)
+        => await Shim.RetrieveAsync(modelId, options).ConfigureAwait(false);
 
     public virtual ClientResult<ModelDetailCollection> GetModels()
     {
@@ -142,56 +135,33 @@ public partial class ModelManagementClient
         return ClientResult.FromValue(new ModelDetailCollection(modelEntries), internalResult.GetRawResponse());
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetModels(RequestOptions context) => Shim.GetModels(context);
+    /// <inheritdoc cref="Internal.ModelsOps.GetModels(RequestOptions)"/>
+    public virtual ClientResult GetModels(RequestOptions options)
+        => Shim.GetModels(options);
 
+    /// <inheritdoc cref="Internal.ModelsOps.GetModelsAsync(RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> GetModelsAsync(RequestOptions context) => Shim.GetModelsAsync(context);
+    public virtual async Task<ClientResult> GetModelsAsync(RequestOptions options)
+        => await Shim.GetModelsAsync(options).ConfigureAwait(false);
 
-     public virtual ClientResult<bool> DeleteModel(string modelId)
+    public virtual ClientResult<bool> DeleteModel(string modelId)
     {
         ClientResult<Internal.Models.DeleteModelResponse> internalResult = Shim.Delete(modelId);
         return ClientResult.FromValue(internalResult.Value.Deleted, internalResult.GetRawResponse());
     }
 
-     public virtual async Task<ClientResult<bool>> DeleteModelAsync(string modelId)
+    public virtual async Task<ClientResult<bool>> DeleteModelAsync(string modelId)
     {
         ClientResult<Internal.Models.DeleteModelResponse> internalResult
             = await Shim.DeleteAsync(modelId).ConfigureAwait(false);
         return ClientResult.FromValue(internalResult.Value.Deleted, internalResult.GetRawResponse());
     }
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult DeleteModel(string modelId, RequestOptions context) => Shim.Delete(modelId, context);
+    /// <inheritdoc cref="Internal.ModelsOps.Delete(string, RequestOptions)"/>
+    public virtual ClientResult DeleteModel(string modelId, RequestOptions options)
+        => Shim.Delete(modelId, options);
 
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual Task<ClientResult> DeleteModelAsync(string modelId, RequestOptions context) => Shim.DeleteAsync(modelId, context);
-
-    public virtual ClientResult CreateFineTuningJob(BinaryContent content, RequestOptions context = null)
-        => FineTuningShim.CreateFineTuningJob(content, context);
-
-    public virtual Task<ClientResult> CreateFineTuningJobAsync(BinaryContent content, RequestOptions context = null)
-        => FineTuningShim.CreateFineTuningJobAsync(content, context);
-
-    public virtual ClientResult GetFineTuningJob(string jobId, RequestOptions context) => FineTuningShim.RetrieveFineTuningJob(jobId, context);
-
-    public virtual Task<ClientResult> GetFineTuningJobAsync(string jobId, RequestOptions context)
-        => FineTuningShim.RetrieveFineTuningJobAsync(jobId, context);
-
-    public virtual ClientResult GetFineTuningJobs(string previousJobId, int? maxResults, RequestOptions context)
-        => FineTuningShim.GetPaginatedFineTuningJobs(previousJobId, maxResults, context);
-
-    public virtual Task<ClientResult> GetFineTuningJobsAsync(int? maxResults, string previousJobId, RequestOptions context)
-        => FineTuningShim.GetPaginatedFineTuningJobsAsync(previousJobId, maxResults, context);
-
-    public virtual ClientResult GetFineTuningJobEvents(string jobId, int? maxResults, string previousJobId, RequestOptions context)
-        => FineTuningShim.GetFineTuningEvents(jobId, previousJobId, maxResults, context);
-
-    public virtual Task<ClientResult> GetFineTuningJobEventsAsync(string jobId, int? maxResults, string previousJobId, RequestOptions context)
-        => FineTuningShim.GetFineTuningEventsAsync(jobId, previousJobId, maxResults, context);
-
-    public virtual ClientResult CancelFineTuningJob(string jobId, RequestOptions context) => FineTuningShim.CancelFineTuningJob(jobId, context);
-
-    public virtual Task<ClientResult> CancelFineTuningJobAsync(string jobId, RequestOptions context)
-        => FineTuningShim.CancelFineTuningJobAsync(jobId, context);
+    /// <inheritdoc cref="Internal.ModelsOps.DeleteAsync(string, RequestOptions)"/>
+    public virtual async Task<ClientResult> DeleteModelAsync(string modelId, RequestOptions options)
+        => await Shim.DeleteAsync(modelId, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/Moderations/ModerationClient.Protocol.cs
+++ b/.dotnet/src/Custom/Moderations/ModerationClient.Protocol.cs
@@ -1,0 +1,16 @@
+﻿using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Threading.Tasks;
+
+namespace OpenAI.Moderations;
+
+public partial class ModerationClient
+{
+    /// <inheritdoc cref="Internal.Moderations.CreateModeration(BinaryContent, RequestOptions)"/>
+    public virtual ClientResult ClassifyText(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateModeration(content, options);
+
+    /// <inheritdoc cref="Internal.Moderations.CreateModerationAsync(BinaryContent, RequestOptions)"/>
+    public virtual async Task<ClientResult> ClassifyTextAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateModerationAsync(content, options).ConfigureAwait(false);
+}

--- a/.dotnet/src/Custom/Moderations/ModerationClient.cs
+++ b/.dotnet/src/Custom/Moderations/ModerationClient.cs
@@ -1,7 +1,5 @@
 using System;
 using System.ClientModel;
-using System.ClientModel.Primitives;
-using System.Threading.Tasks;
 
 namespace OpenAI.Moderations;
 
@@ -89,12 +87,4 @@ public partial class ModerationClient
     public ModerationClient(OpenAIClientOptions options = null)
         : this(endpoint: null, credential: null, options)
     { }
-
-    /// <inheritdoc cref="Internal.Moderations.CreateModeration(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult ClassifyText(BinaryContent content, RequestOptions options = null)
-        => Shim.CreateModeration(content, options);
-
-    /// <inheritdoc cref="Internal.Moderations.CreateModerationAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> ClassifyTextAsync(BinaryContent content, RequestOptions options = null)
-        => await Shim.CreateModerationAsync(content, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/Moderations/ModerationClient.cs
+++ b/.dotnet/src/Custom/Moderations/ModerationClient.cs
@@ -1,9 +1,6 @@
 using System;
 using System.ClientModel;
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.ComponentModel;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenAI.Moderations;
@@ -13,7 +10,7 @@ namespace OpenAI.Moderations;
 /// </summary>
 public partial class ModerationClient
 {
-    private OpenAIClientConnector _clientConnector;
+    private readonly OpenAIClientConnector _clientConnector;
     private Internal.Moderations Shim => _clientConnector.InternalClient.GetModerationsClient();
 
     /// <summary>
@@ -93,14 +90,11 @@ public partial class ModerationClient
         : this(endpoint: null, credential: null, options)
     { }
 
-    public virtual ClientResult ClassifyText(BinaryContent content, RequestOptions context = null)
-    {
-        return Shim.CreateModeration(content, context);
-    }
+    /// <inheritdoc cref="Internal.Moderations.CreateModeration(BinaryContent, RequestOptions)"/>
+    public virtual ClientResult ClassifyText(BinaryContent content, RequestOptions options = null)
+        => Shim.CreateModeration(content, options);
 
-    public virtual Task<ClientResult> ClassifyTextAsync(BinaryContent content, RequestOptions context = null)
-    {
-        return Shim.CreateModerationAsync(content, context);
-    }
-
+    /// <inheritdoc cref="Internal.Moderations.CreateModerationAsync(BinaryContent, RequestOptions)"/>
+    public virtual async Task<ClientResult> ClassifyTextAsync(BinaryContent content, RequestOptions options = null)
+        => await Shim.CreateModerationAsync(content, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -3,6 +3,7 @@ using OpenAI.Audio;
 using OpenAI.Chat;
 using OpenAI.Embeddings;
 using OpenAI.Files;
+using OpenAI.FineTuning;
 using OpenAI.Images;
 using OpenAI.LegacyCompletions;
 using OpenAI.ModelManagement;
@@ -91,7 +92,7 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="AssistantClient"/>. </returns>
     public AssistantClient GetAssistantClient()
-        => new AssistantClient(_cachedEndpoint, _cachedCredential, _cachedOptions);
+        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="AudioClient"/> that reuses the client configuration details provided to
@@ -103,7 +104,7 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="AudioClient"/>. </returns>
     public AudioClient GetAudioClient(string model)
-        => new AudioClient(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
+        => new(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="ChatClient"/> that reuses the client configuration details provided to
@@ -115,7 +116,7 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="ChatClient"/>. </returns>
     public ChatClient GetChatClient(string model)
-        => new ChatClient(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
+        => new(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="EmbeddingClient"/> that reuses the client configuration details provided to
@@ -127,7 +128,7 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="EmbeddingClient"/>. </returns>
     public EmbeddingClient GetEmbeddingClient(string model)
-        => new EmbeddingClient(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
+        => new(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="FileClient"/> that reuses the client configuration details provided to
@@ -139,7 +140,19 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="FileClient"/>. </returns>
     public FileClient GetFileClient()
-        => new FileClient(_cachedEndpoint, _cachedCredential, _cachedOptions);
+        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
+
+    /// <summary>
+    /// Gets a new instance of <see cref="FineTuningClient"/> that reuses the client configuration details provided to
+    /// the <see cref="OpenAIClient"/> instance.
+    /// </summary>
+    /// <remarks>
+    /// This method is functionally equivalent to using the <see cref="FineTuningClient"/> constructor directly with
+    /// the same configuration details.
+    /// </remarks>
+    /// <returns> A new <see cref="FineTuningClient"/>. </returns>
+    public FineTuningClient GetFineTuningClient()
+        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="ImageClient"/> that reuses the client configuration details provided to
@@ -151,7 +164,7 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="ImageClient"/>. </returns>
     public ImageClient GetImageClient(string model)
-        => new ImageClient(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
+        => new(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="LegacyCompletionClient"/> that reuses the client configuration details provided to
@@ -163,7 +176,7 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="LegacyCompletionClient"/>. </returns>
     public LegacyCompletionClient GetLegacyCompletionClient()
-        => new LegacyCompletionClient(_cachedEndpoint, _cachedCredential, _cachedOptions);
+        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="ModelManagementClient"/> that reuses the client configuration details provided to
@@ -175,7 +188,7 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="ModelManagementClient"/>. </returns>
     public ModelManagementClient GetModelManagementClient()
-        => new ModelManagementClient(_cachedEndpoint, _cachedCredential, _cachedOptions);
+        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="ModerationClient"/> that reuses the client configuration details provided to
@@ -187,5 +200,5 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="ModerationClient"/>. </returns>
     public ModerationClient GetModerationClient()
-        => new ModerationClient(_cachedEndpoint, _cachedCredential, _cachedOptions);
+        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
 }

--- a/.dotnet/src/Generated/FineTuning.cs
+++ b/.dotnet/src/Generated/FineTuning.cs
@@ -158,7 +158,7 @@ namespace OpenAI.Internal
         /// <summary> List your organization's fine-tuning jobs. </summary>
         /// <param name="after"> Identifier for the last job from the previous pagination request. </param>
         /// <param name="limit"> Number of fine-tuning jobs to retrieve. </param>
-        public virtual async Task<ClientResult<ListPaginatedFineTuningJobsResponse>> GetPaginatedFineTuningJobsAsync(string after = null, long? limit = null)
+        public virtual async Task<ClientResult<ListPaginatedFineTuningJobsResponse>> GetPaginatedFineTuningJobsAsync(string after = null, int? limit = null)
         {
             ClientResult result = await GetPaginatedFineTuningJobsAsync(after, limit, DefaultRequestContext).ConfigureAwait(false);
             return ClientResult.FromValue(ListPaginatedFineTuningJobsResponse.FromResponse(result.GetRawResponse()), result.GetRawResponse());
@@ -167,7 +167,7 @@ namespace OpenAI.Internal
         /// <summary> List your organization's fine-tuning jobs. </summary>
         /// <param name="after"> Identifier for the last job from the previous pagination request. </param>
         /// <param name="limit"> Number of fine-tuning jobs to retrieve. </param>
-        public virtual ClientResult<ListPaginatedFineTuningJobsResponse> GetPaginatedFineTuningJobs(string after = null, long? limit = null)
+        public virtual ClientResult<ListPaginatedFineTuningJobsResponse> GetPaginatedFineTuningJobs(string after = null, int? limit = null)
         {
             ClientResult result = GetPaginatedFineTuningJobs(after, limit, DefaultRequestContext);
             return ClientResult.FromValue(ListPaginatedFineTuningJobsResponse.FromResponse(result.GetRawResponse()), result.GetRawResponse());
@@ -183,7 +183,7 @@ namespace OpenAI.Internal
         /// </item>
         /// <item>
         /// <description>
-        /// Please try the simpler <see cref="GetPaginatedFineTuningJobsAsync(string,long?)"/> convenience overload with strongly typed models first.
+        /// Please try the simpler <see cref="GetPaginatedFineTuningJobsAsync(string,int?)"/> convenience overload with strongly typed models first.
         /// </description>
         /// </item>
         /// </list>
@@ -193,7 +193,7 @@ namespace OpenAI.Internal
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
-        public virtual async Task<ClientResult> GetPaginatedFineTuningJobsAsync(string after, long? limit, RequestOptions options)
+        public virtual async Task<ClientResult> GetPaginatedFineTuningJobsAsync(string after, int? limit, RequestOptions options)
         {
             options ??= new RequestOptions();
             using PipelineMessage message = CreateGetPaginatedFineTuningJobsRequest(after, limit, options);
@@ -218,7 +218,7 @@ namespace OpenAI.Internal
         /// </item>
         /// <item>
         /// <description>
-        /// Please try the simpler <see cref="GetPaginatedFineTuningJobs(string,long?)"/> convenience overload with strongly typed models first.
+        /// Please try the simpler <see cref="GetPaginatedFineTuningJobs(string,int?)"/> convenience overload with strongly typed models first.
         /// </description>
         /// </item>
         /// </list>
@@ -228,7 +228,7 @@ namespace OpenAI.Internal
         /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
         /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
         /// <returns> The response returned from the service. </returns>
-        public virtual ClientResult GetPaginatedFineTuningJobs(string after, long? limit, RequestOptions options)
+        public virtual ClientResult GetPaginatedFineTuningJobs(string after, int? limit, RequestOptions options)
         {
             options ??= new RequestOptions();
             using PipelineMessage message = CreateGetPaginatedFineTuningJobsRequest(after, limit, options);
@@ -587,7 +587,7 @@ namespace OpenAI.Internal
             return message;
         }
 
-        internal PipelineMessage CreateGetPaginatedFineTuningJobsRequest(string after, long? limit, RequestOptions options)
+        internal PipelineMessage CreateGetPaginatedFineTuningJobsRequest(string after, int? limit, RequestOptions options)
         {
             PipelineMessage message = _pipeline.CreateMessage();
             message.ResponseClassifier = ResponseErrorClassifier200;

--- a/fine-tuning/operations.tsp
+++ b/fine-tuning/operations.tsp
@@ -36,7 +36,7 @@ interface FineTuning {
     @query after?: string,
 
     /** Number of fine-tuning jobs to retrieve. */
-    @query limit?: safeint = 20,
+    @query limit?: int32 = 20,
   ): ListPaginatedFineTuningJobsResponse | ErrorResponse;
 
   @route("jobs/{fine_tuning_job_id}")
@@ -76,6 +76,6 @@ interface FineTuning {
     @query after?: string,
 
     /** Number of events to retrieve. */
-    @query limit?: integer = 20,
+    @query limit?: int32 = 20,
   ): ListFineTuningJobEventsResponse | ErrorResponse;
 }


### PR DESCRIPTION
* Exposed missing protocol methods publicly
* Removed protocol methods that use multipart/form-data for now (`TranscribeAudio`, `TranslateAudio`, `UploadFile`, `GenerateImageEdit`, and `GenerateImageVariation`)
* Removed `[EditorBrowsable(EditorBrowsableState.Never)]` attribute from existing protocol methods that do not have a convenience method counterpart
* Renamed `RequestOptions` parameter from "context" to "options" in existing protocol methods
* Added missing `async` keyword to existing protocol methods when applicable (also `await` and `.ConfigureAwait(false)`)
* Added doc comments to protocol methods
* Created the `FineTuningClient` to organize the library in a way that aligns more closely to OpenAI's REST API and documentation
* Made a small fix to the fine-tuning TypeSpec (the `limit` query parameter should be defined as an `int32`)
