### PR TITLE
Temporarily rename FineTuningClient for codegen

### DIFF
--- a/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.Protocol.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.Protocol.cs
@@ -2,9 +2,9 @@
 using System.ClientModel.Primitives;
 using System.Threading.Tasks;
 
-namespace OpenAI.FineTuning;
+namespace OpenAI.FineTuningManagement;
 
-public partial class FineTuningClient
+public partial class FineTuningManagementClient
 {
     /// <inheritdoc cref="Internal.FineTuning.CreateFineTuningJob(BinaryContent, RequestOptions)"/>
     public virtual ClientResult CreateFineTuningJob(

--- a/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.ClientModel;
 
-namespace OpenAI.FineTuning;
+namespace OpenAI.FineTuningManagement;
 
 /// <summary>
 ///     The service client for OpenAI fine-tuning operations.
 /// </summary>
-public partial class FineTuningClient
+public partial class FineTuningManagementClient
 {
     private readonly OpenAIClientConnector _clientConnector;
     private Internal.FineTuning FineTuningShim => _clientConnector.InternalClient.GetFineTuningClient();
@@ -27,7 +27,7 @@ public partial class FineTuningClient
     /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public FineTuningClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public FineTuningManagementClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions options = null)
     {
         _clientConnector = new("none", endpoint, credential, options);
     }
@@ -47,7 +47,7 @@ public partial class FineTuningClient
     /// </remarks>
     /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public FineTuningClient(Uri endpoint, OpenAIClientOptions options = null)
+    public FineTuningManagementClient(Uri endpoint, OpenAIClientOptions options = null)
         : this(endpoint, credential: null, options)
     { }
 
@@ -66,7 +66,7 @@ public partial class FineTuningClient
     /// </remarks>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public FineTuningManagementClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
         : this(endpoint: null, credential, options)
     { }
 
@@ -84,7 +84,7 @@ public partial class FineTuningClient
     /// </para>
     /// </remarks>
     /// <param name="options">Additional options to customize the client.</param>
-    public FineTuningClient(OpenAIClientOptions options = null)
+    public FineTuningManagementClient(OpenAIClientOptions options = null)
         : this(endpoint: null, credential: null, options)
     { }
 }

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -3,7 +3,7 @@ using OpenAI.Audio;
 using OpenAI.Chat;
 using OpenAI.Embeddings;
 using OpenAI.Files;
-using OpenAI.FineTuning;
+using OpenAI.FineTuningManagement;
 using OpenAI.Images;
 using OpenAI.LegacyCompletions;
 using OpenAI.ModelManagement;
@@ -143,15 +143,15 @@ public partial class OpenAIClient
         => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
 
     /// <summary>
-    /// Gets a new instance of <see cref="FineTuningClient"/> that reuses the client configuration details provided to
+    /// Gets a new instance of <see cref="FineTuningManagementClient"/> that reuses the client configuration details provided to
     /// the <see cref="OpenAIClient"/> instance.
     /// </summary>
     /// <remarks>
-    /// This method is functionally equivalent to using the <see cref="FineTuningClient"/> constructor directly with
+    /// This method is functionally equivalent to using the <see cref="FineTuningManagementClient"/> constructor directly with
     /// the same configuration details.
     /// </remarks>
-    /// <returns> A new <see cref="FineTuningClient"/>. </returns>
-    public FineTuningClient GetFineTuningClient()
+    /// <returns> A new <see cref="FineTuningManagementClient"/>. </returns>
+    public FineTuningManagementClient GetFineTuningManagementClient()
         => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
 
     /// <summary>


### PR DESCRIPTION
Due to our codegen workarounds, we cannot have a method with the following signature in the custom public `OpenAIClient` class:

```csharp
public FineTuningClient GetFineTuningClient()
```

This is because we need codegen to generate a different method that happens to have this same signature in the generated internal `OpenAIClient` class. Because making the generated `OpenAIClient` class internal is part of post-codegen processing, codegen has no way to know that these two are not the same class, so it skips generating the method thinking it has been customized instead. 

For now, we rename the `FineTuningClient` to `FineTuningManagementClient` to avoid this conflict. We will be able to fix it once we have codegen customizations available.