### PR TITLE
Use 'int' instead of 'long' on custom surface

### DIFF
--- a/.dotnet/src/Custom/Assistants/RunTokenUsage.cs
+++ b/.dotnet/src/Custom/Assistants/RunTokenUsage.cs
@@ -2,11 +2,11 @@ namespace OpenAI.Assistants;
 
 public partial class RunTokenUsage
 {
-    public long InputTokens { get; }
-    public long OutputTokens { get; }
-    public long TotalTokens { get; }
+    public int InputTokens { get; }
+    public int OutputTokens { get; }
+    public int TotalTokens { get; }
 
-    internal RunTokenUsage(long inputTokens, long outputTokens, long totalTokens)
+    internal RunTokenUsage(int inputTokens, int outputTokens, int totalTokens)
     {
         InputTokens = inputTokens;
         OutputTokens = outputTokens;
@@ -14,7 +14,7 @@ public partial class RunTokenUsage
     }
 
     internal RunTokenUsage(Internal.Models.RunCompletionUsage internalUsage)
-        : this(internalUsage.PromptTokens, internalUsage.CompletionTokens, internalUsage.TotalTokens)
+        : this((int)internalUsage.PromptTokens, (int)internalUsage.CompletionTokens, (int)internalUsage.TotalTokens)
     {
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatClient.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.cs
@@ -165,7 +165,7 @@ public partial class ChatClient
         List<ChatCompletion> chatCompletions = [];
         for (int i = 0; i < response.Value.Choices.Count; i++)
         {
-            chatCompletions.Add(new(response.Value, response.Value.Choices[i].Index));
+            chatCompletions.Add(new(response.Value, (int)response.Value.Choices[i].Index));
         }
         return ClientResult.FromValue(new ChatCompletionCollection(chatCompletions), response.GetRawResponse());
     }
@@ -189,7 +189,7 @@ public partial class ChatClient
         List<ChatCompletion> chatCompletions = [];
         for (int i = 0; i < response.Value.Choices.Count; i++)
         {
-            chatCompletions.Add(new(response.Value, response.Value.Choices[i].Index));
+            chatCompletions.Add(new(response.Value, (int)response.Value.Choices[i].Index));
         }
         return ClientResult.FromValue(new ChatCompletionCollection(chatCompletions), response.GetRawResponse());
     }

--- a/.dotnet/src/Custom/Chat/ChatCompletion.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletion.cs
@@ -8,7 +8,7 @@ namespace OpenAI.Chat;
 public class ChatCompletion
 {
     private Internal.Models.CreateChatCompletionResponse _internalResponse;
-    private long _internalChoiceIndex;
+    private int _internalChoiceIndex;
 
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponse.Id"/>
     public string Id => _internalResponse.Id;
@@ -31,9 +31,9 @@ public class ChatCompletion
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponseChoice.Logprobs"/>
     public ChatLogProbabilityCollection LogProbabilities { get; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponseChoice.Index"/>
-    public long Index => _internalResponse.Choices[(int)_internalChoiceIndex].Index;
+    public int Index => (int)_internalResponse.Choices[(int)_internalChoiceIndex].Index;
 
-    internal ChatCompletion(Internal.Models.CreateChatCompletionResponse internalResponse, long internalChoiceIndex)
+    internal ChatCompletion(Internal.Models.CreateChatCompletionResponse internalResponse, int internalChoiceIndex)
     {
         Internal.Models.CreateChatCompletionResponseChoice internalChoice = internalResponse.Choices[(int)internalChoiceIndex];
         _internalResponse = internalResponse;

--- a/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
@@ -15,19 +15,19 @@ public partial class ChatCompletionOptions
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.FrequencyPenalty" />
     public double? FrequencyPenalty { get; set; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.LogitBias" />
-    public IDictionary<long, long> TokenSelectionBiases { get; set; } = new OptionalDictionary<long, long>();
+    public IDictionary<int, int> TokenSelectionBiases { get; set; } = new OptionalDictionary<int, int>();
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Logprobs" />
     public bool? IncludeLogProbabilities { get; set; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.TopLogprobs" />
-    public long? LogProbabilityCount { get; set; }
+    public int? LogProbabilityCount { get; set; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.MaxTokens" />
-    public long? MaxTokens { get; set; }
+    public int? MaxTokens { get; set; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.PresencePenalty" />
     public double? PresencePenalty { get; set; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.ResponseFormat" />
     public ChatResponseFormat? ResponseFormat { get; set; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Seed" />
-    public long? Seed { get; set; }
+    public int? Seed { get; set; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Stop" />
     public IList<string> StopSequences { get; } = new OptionalList<string>();
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Temperature" />
@@ -57,7 +57,7 @@ public partial class ChatCompletionOptions
     internal IDictionary<string, long> GetInternalLogitBias()
     {
         OptionalDictionary<string, long> packedLogitBias = [];
-        foreach (KeyValuePair<long, long> pair in TokenSelectionBiases)
+        foreach (KeyValuePair<int, int> pair in TokenSelectionBiases)
         {
             packedLogitBias[$"{pair.Key}"] = pair.Value;
         }
@@ -84,7 +84,7 @@ public partial class ChatCompletionOptions
 
     internal IList<Internal.Models.ChatCompletionFunctions> GetInternalFunctions()
     {
-        OptionalList<Internal.Models.ChatCompletionFunctions> internalFunctions = [];
+        OptionalList<Internal.Models.ChatCompletionFunctions> internalFunctions = new();
         foreach (ChatFunctionDefinition function in Functions)
         {
             Internal.Models.ChatCompletionFunctions internalFunction = new(

--- a/.dotnet/src/Custom/Chat/ChatLogProbabilityCollection.cs
+++ b/.dotnet/src/Custom/Chat/ChatLogProbabilityCollection.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace OpenAI.Chat;
 
@@ -26,16 +27,18 @@ public class ChatLogProbabilityCollection : ReadOnlyCollection<ChatLogProbabilit
                 alternateLogProbabilities = [];
                 foreach (Internal.Models.ChatCompletionTokenLogprobTopLogprob internalTopLogprob in internalLogprob.TopLogprobs)
                 {
+                    List<int> convertedByteValues = internalLogprob.Bytes.Select(longByteValue => (int)longByteValue).ToList();
                     alternateLogProbabilities.Add(new(
                         internalLogprob.Token,
                         internalLogprob.Logprob,
-                        internalLogprob.Bytes));
+                        convertedByteValues));
                 }
             }
+            List<int> convertedResultByteValues = internalLogprob.Bytes.Select(longByteValue => (int)longByteValue).ToList();
             logProbabilities.Add(new(
                 internalLogprob.Token,
                 internalLogprob.Logprob,
-                internalLogprob.Bytes,
+                convertedResultByteValues,
                 alternateLogProbabilities));
         }
         return new ChatLogProbabilityCollection(logProbabilities);

--- a/.dotnet/src/Custom/Chat/ChatLogProbabilityResult.cs
+++ b/.dotnet/src/Custom/Chat/ChatLogProbabilityResult.cs
@@ -22,7 +22,7 @@ public class ChatLogProbabilityResult
     /// characters are represented by multiple tokens and their byte representations must be combined to generate
     /// the correct text representation. Can be null if there is no bytes representation for the token.
     /// </summary>
-    public IReadOnlyList<long> Utf8ByteValues { get; }
+    public IReadOnlyList<int> Utf8ByteValues { get; }
     /// <summary>
     /// List of the most likely tokens and their log probability at this token position. In rare cases,
     /// there may be fewer than the number of requested top_logprobs returned, as supplied via
@@ -32,7 +32,7 @@ public class ChatLogProbabilityResult
     internal ChatLogProbabilityResult(
         string token,
         double logProbability,
-        IEnumerable<long> byteValues,
+        IEnumerable<int> byteValues,
         IEnumerable<ChatLogProbabilityResultItem> alternateLogProbabilities)
         {
             Token = token;

--- a/.dotnet/src/Custom/Chat/ChatLogProbabilityResultItem.cs
+++ b/.dotnet/src/Custom/Chat/ChatLogProbabilityResultItem.cs
@@ -22,7 +22,7 @@ public class ChatLogProbabilityResultItem
     /// characters are represented by multiple tokens and their byte representations must be combined to generate
     /// the correct text representation. Can be null if there is no bytes representation for the token.
     /// </summary>
-    public IReadOnlyList<long> Utf8ByteValues { get; }
+    public IReadOnlyList<int> Utf8ByteValues { get; }
     /// <summary>
     /// Creates a new instance of <see cref="ChatLogProbabilityResultItem"/>.
     /// </summary>
@@ -33,10 +33,10 @@ public class ChatLogProbabilityResultItem
     /// <param name="token"> The token represented by this item. </param>
     /// <param name="logProbability"> The <c>logprob</c> for the token. </param>
     /// <param name="byteValues"> The UTF8 byte value sequence representation for the token. </param>
-    internal ChatLogProbabilityResultItem(string token, double logProbability, IEnumerable<long> byteValues)
+    internal ChatLogProbabilityResultItem(string token, double logProbability, IEnumerable<int> byteValues)
     {
         Token = token;
         LogProbability = logProbability;
-        Utf8ByteValues = new List<long>(byteValues);
+        Utf8ByteValues = new List<int>(byteValues);
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatTokenUsage.cs
+++ b/.dotnet/src/Custom/Chat/ChatTokenUsage.cs
@@ -6,16 +6,16 @@ namespace OpenAI.Chat;
 public class ChatTokenUsage
 {
     /// <inheritdoc cref="Internal.Models.CompletionUsage.PromptTokens"/>
-    public long InputTokens { get; }
+    public int InputTokens { get; }
     /// <inheritdoc cref="Internal.Models.CompletionUsage.CompletionTokens"/>
-    public long OutputTokens { get; }
+    public int OutputTokens { get; }
     /// <inheritdoc cref="Internal.Models.CompletionUsage.TotalTokens"/>
-    public long TotalTokens { get; }
+    public int TotalTokens { get; }
 
     internal ChatTokenUsage(Internal.Models.CompletionUsage internalUsage)
     {
-        InputTokens = internalUsage.PromptTokens;
-        OutputTokens = internalUsage.CompletionTokens;
-        TotalTokens = internalUsage.TotalTokens;
+        InputTokens = (int)internalUsage.PromptTokens;
+        OutputTokens = (int)internalUsage.CompletionTokens;
+        TotalTokens = (int)internalUsage.TotalTokens;
     }
 }

--- a/.dotnet/src/Custom/Embeddings/Embedding.cs
+++ b/.dotnet/src/Custom/Embeddings/Embedding.cs
@@ -12,13 +12,13 @@ public partial class Embedding
     /// </summary>
     public ReadOnlyMemory<float> Vector { get; }
     /// <inheritdoc cref="Internal.Models.Embedding.Index"/>
-    public long Index { get; }
+    public int Index { get; }
     /// <inheritdoc cref="Internal.Models.CreateEmbeddingResponse.Model"/>
     public string Model { get; }
     /// <inheritdoc cref="Internal.Models.CreateEmbeddingResponse.Usage"/>
     public EmbeddingTokenUsage Usage { get; }
 
-    internal Embedding(ReadOnlyMemory<float> vector, long index, EmbeddingTokenUsage usage)
+    internal Embedding(ReadOnlyMemory<float> vector, int index, EmbeddingTokenUsage usage)
     {
         Vector = vector;
         Index = index;
@@ -27,7 +27,7 @@ public partial class Embedding
 
     internal Embedding(
         Internal.Models.CreateEmbeddingResponse internalResponse,
-        long internalDataIndex,
+        int internalDataIndex,
         EmbeddingTokenUsage usage = null)
     {
         Internal.Models.Embedding dataItem = internalResponse.Data[(int)internalDataIndex];
@@ -37,7 +37,7 @@ public partial class Embedding
         float[] vector = new float[bytes.Length / sizeof(float)];
         Buffer.BlockCopy(bytes, 0, vector, 0, bytes.Length);
         Vector = new ReadOnlyMemory<float>(vector);
-        Index = dataItem.Index;
+        Index = (int)dataItem.Index;
         Usage = usage ?? new(internalResponse.Usage);
         Model = internalResponse.Model;
     }

--- a/.dotnet/src/Custom/Embeddings/EmbeddingOptions.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingOptions.cs
@@ -4,5 +4,5 @@ public class EmbeddingOptions
 {
     public string User { get; set; }
 
-    public long? Dimensions { get; set; }
+    public int? Dimensions { get; set; }
 }

--- a/.dotnet/src/Custom/Embeddings/EmbeddingTokenUsage.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingTokenUsage.cs
@@ -5,9 +5,9 @@ public partial class EmbeddingTokenUsage
     private Internal.Models.EmbeddingUsage _internalUsage;
 
     /// <inheritdoc cref="Internal.Models.EmbeddingUsage.PromptTokens"/>
-    public long InputTokens => _internalUsage.PromptTokens;
+    public int InputTokens => (int)_internalUsage.PromptTokens;
     /// <inheritdoc cref="Internal.Models.EmbeddingUsage.TotalTokens"/>
-    public long TotalTokens => _internalUsage.TotalTokens;
+    public int TotalTokens => (int)_internalUsage.TotalTokens;
 
     internal EmbeddingTokenUsage(Internal.Models.EmbeddingUsage internalUsage)
     {

--- a/.dotnet/src/Custom/Files/OpenAIFileInfo.cs
+++ b/.dotnet/src/Custom/Files/OpenAIFileInfo.cs
@@ -16,7 +16,7 @@ public partial class OpenAIFileInfo
         Purpose = internalFile.Purpose.ToString() switch
         {
             "fine-tune" => OpenAIFilePurpose.FineTuning,
-            "fine-tune-result" => OpenAIFilePurpose.FineTuningResults,
+            "fine-tune-results" => OpenAIFilePurpose.FineTuningResults,
             "assistants" => OpenAIFilePurpose.Assistants,
             "assistants_output" => OpenAIFilePurpose.AssistantOutputs,
             _ => throw new ArgumentException(nameof(internalFile)),

--- a/.dotnet/src/Custom/Images/GeneratedImage.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImage.cs
@@ -38,7 +38,7 @@ public class GeneratedImage
     /// </summary>
     public DateTimeOffset CreatedAt { get; }
 
-    internal GeneratedImage(Internal.Models.ImagesResponse internalResponse, long internalDataIndex)
+    internal GeneratedImage(Internal.Models.ImagesResponse internalResponse, int internalDataIndex)
     {
         CreatedAt = internalResponse.Created;
         ImageBytes = internalResponse.Data[(int)internalDataIndex].B64Json;

--- a/.dotnet/tests/Samples/Images/Sample02_SimpleImageEdit.cs
+++ b/.dotnet/tests/Samples/Images/Sample02_SimpleImageEdit.cs
@@ -8,7 +8,7 @@ namespace OpenAI.Samples
     public partial class ImageSamples
     {
         [Test]
-        // [Ignore("Compilation validation only")]
+        [Ignore("Compilation validation only")]
         public void Sample02_SimpleImageEdit()
         {
             ImageClient client = new("dall-e-2", Environment.GetEnvironmentVariable("OpenAIClient_KEY"));

--- a/.dotnet/tests/Samples/Images/Sample02_SimpleImageEditAsync.cs
+++ b/.dotnet/tests/Samples/Images/Sample02_SimpleImageEditAsync.cs
@@ -9,7 +9,7 @@ namespace OpenAI.Samples
     public partial class ImageSamples
     {
         [Test]
-        // [Ignore("Compilation validation only")]
+        [Ignore("Compilation validation only")]
         public async Task Sample02_SimpleImageEditAsync()
         {
             ImageClient client = new("dall-e-2", Environment.GetEnvironmentVariable("OpenAIClient_KEY"));

--- a/.dotnet/tests/TestScenarios/FileClientTests.cs
+++ b/.dotnet/tests/TestScenarios/FileClientTests.cs
@@ -11,7 +11,7 @@ public partial class FileClientTests
     [Test]
     public void ListFilesWorks()
     {
-        FileClient client = new();
+        FileClient client = GetTestClient();
         ClientResult<OpenAIFileInfoCollection> result = client.GetFileInfoList();
         Assert.That(result.Value.Count, Is.GreaterThan(0));
         Console.WriteLine(result.Value.Count);


### PR DESCRIPTION
Note that this is likely a bit of a stopgap pending discussion of migrating from `safeint` to `int32` in the TypeSpec codegen basis.