### PR TITLE
Add `ModifyMessage` methods to `AssistantClient`

### DIFF
--- a/.dotnet/src/Custom/Assistants/AssistantClient.Protocol.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantClient.Protocol.cs
@@ -120,7 +120,7 @@ public partial class AssistantClient
 
     /// <inheritdoc cref="Internal.Assistants.GetAssistantFiles(string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GetAssistantFileAssociation(
+    public virtual ClientResult GetAssistantFileAssociations(
         string assistantId,
         int? maxResults,
         string createdSortOrder,
@@ -131,7 +131,7 @@ public partial class AssistantClient
 
     /// <inheritdoc cref="Internal.Assistants.GetAssistantFilesAsync(string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> GetAssistantFileAssociationAsync(
+    public virtual async Task<ClientResult> GetAssistantFileAssociationsAsync(
         string assistantId,
         int? maxResults,
         string createdSortOrder,
@@ -245,6 +245,24 @@ public partial class AssistantClient
         string messageId,
         RequestOptions options)
         => await MessageShim.GetMessageAsync(threadId, messageId, options).ConfigureAwait(false);
+
+    /// <inheritdoc cref="Internal.Messages.ModifyMessage(string, string, BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult ModifyMessage(
+        string threadId,
+        string messageId,
+        BinaryContent content,
+        RequestOptions options)
+        => MessageShim.ModifyMessage(threadId, messageId, content, options);
+
+    /// <inheritdoc cref="Internal.Messages.ModifyMessageAsync(string, string, BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> ModifyMessageAsync(
+        string threadId,
+        string messageId,
+        BinaryContent content,
+        RequestOptions options)
+        => await MessageShim.ModifyMessageAsync(threadId, messageId, content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Messages.GetMessages(string, int?, string, string, string, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/.dotnet/src/Custom/Assistants/AssistantClient.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantClient.cs
@@ -1,4 +1,3 @@
-using OpenAI.ClientShared.Internal;
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
@@ -113,8 +112,7 @@ public partial class AssistantClient
         AssistantCreationOptions options = null)
     {
         Internal.Models.CreateAssistantRequest request = CreateInternalCreateAssistantRequest(modelName, options);
-        ClientResult<Internal.Models.AssistantObject> internalResult
-            = await Shim.CreateAssistantAsync(request).ConfigureAwait(false);
+        ClientResult<Internal.Models.AssistantObject> internalResult = await Shim.CreateAssistantAsync(request).ConfigureAwait(false);
         return ClientResult.FromValue(new Assistant(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -127,8 +125,7 @@ public partial class AssistantClient
     public virtual async Task<ClientResult<Assistant>> GetAssistantAsync(
         string assistantId)
     {
-        ClientResult<Internal.Models.AssistantObject> internalResult
-            = await Shim.GetAssistantAsync(assistantId).ConfigureAwait(false);
+        ClientResult<Internal.Models.AssistantObject> internalResult = await Shim.GetAssistantAsync(assistantId).ConfigureAwait(false);
         return ClientResult.FromValue(new Assistant(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -174,8 +171,7 @@ public partial class AssistantClient
         AssistantModificationOptions options)
     {
         Internal.Models.ModifyAssistantRequest request = CreateInternalModifyAssistantRequest(options);
-        ClientResult<Internal.Models.AssistantObject> internalResult
-            = await Shim.ModifyAssistantAsync(assistantId, request).ConfigureAwait(false);
+        ClientResult<Internal.Models.AssistantObject> internalResult = await Shim.ModifyAssistantAsync(assistantId, request).ConfigureAwait(false);
         return ClientResult.FromValue(new Assistant(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -189,8 +185,7 @@ public partial class AssistantClient
     public virtual async Task<ClientResult<bool>> DeleteAssistantAsync(
         string assistantId)
     {
-        ClientResult<Internal.Models.DeleteAssistantResponse> internalResponse
-            = await Shim.DeleteAssistantAsync(assistantId).ConfigureAwait(false);
+        ClientResult<Internal.Models.DeleteAssistantResponse> internalResponse = await Shim.DeleteAssistantAsync(assistantId).ConfigureAwait(false);
         return ClientResult.FromValue(internalResponse.Value.Deleted, internalResponse.GetRawResponse());
     }
 
@@ -207,8 +202,7 @@ public partial class AssistantClient
         string assistantId,
         string fileId)
     {
-        ClientResult<Internal.Models.AssistantFileObject> internalResult
-            = await Shim.CreateAssistantFileAsync(assistantId, new(fileId)).ConfigureAwait(false);
+        ClientResult<Internal.Models.AssistantFileObject> internalResult = await Shim.CreateAssistantFileAsync(assistantId, new(fileId)).ConfigureAwait(false);
         return ClientResult.FromValue(new AssistantFileAssociation(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -224,8 +218,7 @@ public partial class AssistantClient
         string assistantId,
         string fileId)
     {
-        ClientResult<Internal.Models.AssistantFileObject> internalResult
-            = await Shim.GetAssistantFileAsync(assistantId, fileId).ConfigureAwait(false);
+        ClientResult<Internal.Models.AssistantFileObject> internalResult = await Shim.GetAssistantFileAsync(assistantId, fileId).ConfigureAwait(false);
         return ClientResult.FromValue(new AssistantFileAssociation(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -275,8 +268,7 @@ public partial class AssistantClient
         string assistantId,
         string fileId)
     {
-        ClientResult<Internal.Models.DeleteAssistantFileResponse> internalResult
-            = await Shim.DeleteAssistantFileAsync(assistantId, fileId).ConfigureAwait(false);
+        ClientResult<Internal.Models.DeleteAssistantFileResponse> internalResult = await Shim.DeleteAssistantFileAsync(assistantId, fileId).ConfigureAwait(false);
         return ClientResult.FromValue(internalResult.Value.Deleted, internalResult.GetRawResponse());
     }
 
@@ -292,8 +284,7 @@ public partial class AssistantClient
         ThreadCreationOptions options = null)
     {
         Internal.Models.CreateThreadRequest request = CreateInternalCreateThreadRequest(options);
-        ClientResult<Internal.Models.ThreadObject> internalResult
-            = await ThreadShim.CreateThreadAsync(request).ConfigureAwait(false);
+        ClientResult<Internal.Models.ThreadObject> internalResult = await ThreadShim.CreateThreadAsync(request).ConfigureAwait(false);
         return ClientResult.FromValue(new AssistantThread(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -306,8 +297,7 @@ public partial class AssistantClient
     public virtual async Task<ClientResult<AssistantThread>> GetThreadAsync(
         string threadId)
     {
-        ClientResult<Internal.Models.ThreadObject> internalResult
-            = await ThreadShim.GetThreadAsync(threadId).ConfigureAwait(false);
+        ClientResult<Internal.Models.ThreadObject> internalResult = await ThreadShim.GetThreadAsync(threadId).ConfigureAwait(false);
         return ClientResult.FromValue(new AssistantThread(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -329,8 +319,7 @@ public partial class AssistantClient
         Internal.Models.ModifyThreadRequest request = new(
             options.Metadata,
             serializedAdditionalRawData: null);
-        ClientResult<Internal.Models.ThreadObject> internalResult
-            = await ThreadShim.ModifyThreadAsync(threadId, request);
+        ClientResult<Internal.Models.ThreadObject> internalResult = await ThreadShim.ModifyThreadAsync(threadId, request).ConfigureAwait(false);
         return ClientResult.FromValue(new AssistantThread(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -342,8 +331,7 @@ public partial class AssistantClient
 
      public virtual async Task<ClientResult<bool>> DeleteThreadAsync(string threadId)
     {
-        ClientResult<Internal.Models.DeleteThreadResponse> internalResult
-            = await ThreadShim.DeleteThreadAsync(threadId).ConfigureAwait(false);
+        ClientResult<Internal.Models.DeleteThreadResponse> internalResult = await ThreadShim.DeleteThreadAsync(threadId).ConfigureAwait(false);
         return ClientResult.FromValue(internalResult.Value.Deleted, internalResult.GetRawResponse());
     }
 
@@ -375,8 +363,7 @@ public partial class AssistantClient
             options.FileIds,
             options.Metadata,
             serializedAdditionalRawData: null);
-        ClientResult<Internal.Models.MessageObject> internalResult
-            = await MessageShim.CreateMessageAsync(threadId, request).ConfigureAwait(false);
+        ClientResult<Internal.Models.MessageObject> internalResult = await MessageShim.CreateMessageAsync(threadId, request).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadMessage(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -392,8 +379,31 @@ public partial class AssistantClient
         string threadId,
         string messageId)
     {
-        ClientResult<Internal.Models.MessageObject> internalResult
-            = await MessageShim.GetMessageAsync(threadId, messageId).ConfigureAwait(false);
+        ClientResult<Internal.Models.MessageObject> internalResult = await MessageShim.GetMessageAsync(threadId, messageId).ConfigureAwait(false);
+        return ClientResult.FromValue(new ThreadMessage(internalResult.Value), internalResult.GetRawResponse());
+    }
+
+    public virtual ClientResult<ThreadMessage> ModifyMessage(
+        string threadId,
+        string messageId,
+        MessageModificationOptions options)
+    {
+        Internal.Models.ModifyMessageRequest request = new(
+            options.Metadata,
+            serializedAdditionalRawData: null);
+        ClientResult<Internal.Models.MessageObject> internalResult = MessageShim.ModifyMessage(threadId, messageId, request);
+        return ClientResult.FromValue(new ThreadMessage(internalResult.Value), internalResult.GetRawResponse());
+    }
+
+    public virtual async Task<ClientResult<ThreadMessage>> ModifyMessageAsync(
+        string threadId,
+        string messageId,
+        MessageModificationOptions options)
+    {
+        Internal.Models.ModifyMessageRequest request = new(
+            options.Metadata,
+            serializedAdditionalRawData: null);
+        ClientResult<Internal.Models.MessageObject> internalResult = await MessageShim.ModifyMessageAsync(threadId, messageId, request).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadMessage(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -444,8 +454,7 @@ public partial class AssistantClient
         string messageId,
         string fileId)
     {
-        ClientResult<Internal.Models.MessageFileObject> internalResult
-            = await MessageShim.GetMessageFileAsync(threadId, messageId, fileId).ConfigureAwait(false);
+        ClientResult<Internal.Models.MessageFileObject> internalResult = await MessageShim.GetMessageFileAsync(threadId, messageId, fileId).ConfigureAwait(false);
         return ClientResult.FromValue(new MessageFileAssociation(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -501,8 +510,7 @@ public partial class AssistantClient
         RunCreationOptions options = null)
     {
         Internal.Models.CreateRunRequest request = CreateInternalCreateRunRequest(assistantId, options);
-        ClientResult<Internal.Models.RunObject> internalResult
-            = await RunShim.CreateRunAsync(threadId, request).ConfigureAwait(false);
+        ClientResult<Internal.Models.RunObject> internalResult = await RunShim.CreateRunAsync(threadId, request).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadRun(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -524,8 +532,7 @@ public partial class AssistantClient
     {
         Internal.Models.CreateThreadAndRunRequest request
             = CreateInternalCreateThreadAndRunRequest(assistantId, threadOptions, runOptions);
-        ClientResult<Internal.Models.RunObject> internalResult
-            = await RunShim.CreateThreadAndRunAsync(request).ConfigureAwait(false);
+        ClientResult<Internal.Models.RunObject> internalResult = await RunShim.CreateThreadAndRunAsync(request).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadRun(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -537,8 +544,7 @@ public partial class AssistantClient
 
     public virtual async Task<ClientResult<ThreadRun>> GetRunAsync(string threadId, string runId)
     {
-        ClientResult<Internal.Models.RunObject> internalResult
-            = await RunShim.GetRunAsync(threadId, runId).ConfigureAwait(false);
+        ClientResult<Internal.Models.RunObject> internalResult = await RunShim.GetRunAsync(threadId, runId).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadRun(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -584,8 +590,7 @@ public partial class AssistantClient
     public virtual async Task<ClientResult<ThreadRun>> ModifyRunAsync(string threadId, string runId, RunModificationOptions options)
     {
         Internal.Models.ModifyRunRequest request = new(options.Metadata, serializedAdditionalRawData: null);
-        ClientResult<Internal.Models.RunObject> internalResult
-            = await RunShim.ModifyRunAsync(threadId, runId, request).ConfigureAwait(false);
+        ClientResult<Internal.Models.RunObject> internalResult = await RunShim.ModifyRunAsync(threadId, runId, request).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadRun(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -597,8 +602,7 @@ public partial class AssistantClient
 
     public virtual async Task<ClientResult<bool>> CancelRunAsync(string threadId, string runId)
     {
-        ClientResult<Internal.Models.RunObject> internalResult
-            = await RunShim.CancelRunAsync(threadId, runId);
+        ClientResult<Internal.Models.RunObject> internalResult = await RunShim.CancelRunAsync(threadId, runId).ConfigureAwait(false);
         return ClientResult.FromValue(true, internalResult.GetRawResponse());
     }
 
@@ -646,7 +650,8 @@ public partial class AssistantClient
             serializedAdditionalRawData: null);
     }
 
-    internal static Internal.Models.ModifyAssistantRequest CreateInternalModifyAssistantRequest(AssistantModificationOptions options)
+    internal static Internal.Models.ModifyAssistantRequest CreateInternalModifyAssistantRequest(
+        AssistantModificationOptions options)
     {
         return new Internal.Models.ModifyAssistantRequest(
             options.Model,
@@ -659,7 +664,8 @@ public partial class AssistantClient
             serializedAdditionalRawData: null);
     }
 
-    internal static Internal.Models.CreateThreadRequest CreateInternalCreateThreadRequest(ThreadCreationOptions options)
+    internal static Internal.Models.CreateThreadRequest CreateInternalCreateThreadRequest(
+        ThreadCreationOptions options)
     {
         options ??= new();
         return new Internal.Models.CreateThreadRequest(
@@ -762,7 +768,7 @@ public partial class AssistantClient
         where T : class
         where U : class
     {
-        ClientResult<U> internalResult = await internalAsyncFunc.Invoke();
+        ClientResult<U> internalResult = await internalAsyncFunc.Invoke().ConfigureAwait(false);
         ListQueryPage<T> convertedValue = ListQueryPage.Create(internalResult.Value) as ListQueryPage<T>;
         return ClientResult.FromValue(convertedValue, internalResult.GetRawResponse());
     }

--- a/.dotnet/src/Custom/Assistants/MessageModificationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/MessageModificationOptions.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 namespace OpenAI.Assistants;
 
 /// <summary>
-/// Represents additional options available when modifying an existing <see cref="AssistantThread"/>.
+/// Represents additional options available when modifying an existing <see cref="ThreadMessage"/>.
 /// </summary>
-public partial class ThreadModificationOptions
+public partial class MessageModificationOptions
 {
     /// <summary>
     /// A replacement for the optional key/value mapping of additional, supplemental data items to attach to the
-    /// <see cref="AssistantThread"/>. This information may be useful for storing custom details in a structured format.
+    /// <see cref="ThreadMessage"/>. This information may be useful for storing custom details in a structured format.
     /// </summary>
     /// <remarks>
     /// <list type="bullet">


### PR DESCRIPTION
* Added `ModifyMessage` and `ModifyMessageAsync` protocol and convenience methods to `AssistantClient`.
* Fixed typo: `GetAssistantFileAssociation` --> `GetAssistantFileAssociations`
* Fixed typo: `GetAssistantFileAssociationAsync` --> `GetAssistantFileAssociationsAsync`
* Added missing usages of `ConfigureAwait(false)` in `AssistantClient`.