### PR TITLE
Simplify and standardize client constructors

### DIFF
--- a/.dotnet/src/Custom/Assistants/AssistantClient.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantClient.cs
@@ -30,73 +30,16 @@ public partial class AssistantClient
     ///    if it is defined.
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public AssistantClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public AssistantClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
     {
         options ??= new();
         options.AddPolicy(
             new GenericActionPipelinePolicy((m) => m.Request?.Headers.Set("OpenAI-Beta", "assistants=v1")),
             PipelinePosition.PerCall);
-        _clientConnector = new("none", endpoint, credential, options);
+        _clientConnector = new(model: "none", credential, options);
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AssistantClient"/>, used for assistant requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public AssistantClient(Uri endpoint, OpenAIClientOptions options = null)
-        : this(endpoint, credential: null, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AssistantClient"/>, used for assistant requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public AssistantClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, credential, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AssistantClient"/>, used for assistant requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">Additional options to customize the client.</param>
-    public AssistantClient(OpenAIClientOptions options = null)
-        : this(endpoint: null, credential: null, options)
-    { }
 
     public virtual ClientResult<Assistant> CreateAssistant(
         string modelName,

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -28,73 +28,13 @@ public partial class AudioClient
     ///    if it is defined.
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="model">The model name for audio operations that the client should use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public AudioClient(Uri endpoint, string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public AudioClient(string model, ApiKeyCredential credential = default, OpenAIClientOptions options = default)
     {
-        _clientConnector = new(model, endpoint, credential, options);
+        _clientConnector = new(model, credential, options);
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AudioClient"/>, used for audio operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
-    /// <param name="model">The model name for audio operations that the client should use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public AudioClient(Uri endpoint, string model, OpenAIClientOptions options = null)
-        : this(endpoint, model, credential: null, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AudioClient"/>, used for audio operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="model">The model name for audio operations that the client should use.</param>
-    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public AudioClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, model, credential, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AudioClient"/>, used for audio operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="model">The model name for audio operations that the client should use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public AudioClient(string model, OpenAIClientOptions options = null)
-        : this(endpoint: null, model, credential: null, options)
-    { }
 
     /// <summary>
     /// Creates text-to-speech audio that reflects the specified voice speaking the provided input text.

--- a/.dotnet/src/Custom/Chat/ChatClient.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.cs
@@ -26,73 +26,13 @@ public partial class ChatClient
     ///    if it is defined.
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="model">The model name for chat completions that the client should use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public ChatClient(Uri endpoint, string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public ChatClient(string model, ApiKeyCredential credential = default, OpenAIClientOptions options = null)
     {
-        _clientConnector = new(model, endpoint, credential, options);
+        _clientConnector = new(model, credential, options);
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ChatClient"/>, used for Chat Completion requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
-    /// <param name="model">The model name for chat completions that the client should use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ChatClient(Uri endpoint, string model, OpenAIClientOptions options = null)
-        : this(endpoint, model, credential: null, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ChatClient"/>, used for Chat Completion requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="model">The model name for chat completions that the client should use.</param>
-    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ChatClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, model, credential, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ChatClient"/>, used for Chat Completion requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="model">The model name for chat completions that the client should use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ChatClient(string model, OpenAIClientOptions options = null)
-        : this(endpoint: null, model, credential: null, options)
-    { }
 
     /// <summary>
     /// Generates a single chat completion result for a single, simple user message.

--- a/.dotnet/src/Custom/Embeddings/EmbeddingClient.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingClient.cs
@@ -11,22 +11,10 @@ public partial class EmbeddingClient
     private readonly OpenAIClientConnector _clientConnector;
     private Internal.Embeddings Shim => _clientConnector.InternalClient.GetEmbeddingsClient();
 
-    public EmbeddingClient(Uri endpoint, string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public EmbeddingClient(string model, ApiKeyCredential credential = default, OpenAIClientOptions options = default)
     {
-        _clientConnector = new(model, endpoint, credential, options);
+        _clientConnector = new(model, credential, options);
     }
-
-    public EmbeddingClient(Uri endpoint, string model, OpenAIClientOptions options = null)
-        : this(endpoint, model, credential: null, options)
-    { }
-
-    public EmbeddingClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, model, credential, options)
-    { }
-
-    public EmbeddingClient(string model, OpenAIClientOptions options = null)
-        : this(endpoint: null, model, credential: null, options)
-    { }
 
     public virtual ClientResult<Embedding> GenerateEmbedding(string input, EmbeddingOptions options = null)
     {

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -28,69 +28,12 @@ public partial class FileClient
     ///    if it is defined.
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public FileClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public FileClient(ApiKeyCredential credential = default, OpenAIClientOptions options = null)
     {
-        _clientConnector = new("none", endpoint, credential, options);
+        _clientConnector = new(model: null, credential, options);
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="FileClient"/>, used for file operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public FileClient(Uri endpoint, OpenAIClientOptions options = null)
-        : this(endpoint, credential: null, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="FileClient"/>, used for file operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public FileClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, credential, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="FileClient"/>, used for file operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">Additional options to customize the client.</param>
-    public FileClient(OpenAIClientOptions options = null)
-        : this(endpoint: null, credential: null, options)
-    { }
 
     public virtual ClientResult<OpenAIFileInfo> UploadFile(BinaryData file, string filename, OpenAIFilePurpose purpose)
     {

--- a/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
@@ -12,7 +12,7 @@ public partial class FineTuningManagementClient
     private Internal.FineTuning FineTuningShim => _clientConnector.InternalClient.GetFineTuningClient();
 
     /// <summary>
-    /// Initializes a new instance of <see cref="FineTuningClient"/>, used for fine-tuning operation requests. 
+    /// Initializes a new instance of <see cref="FineTuningManagementClient"/>, used for fine-tuning operation requests. 
     /// </summary>
     /// <remarks>
     /// <para>
@@ -24,67 +24,10 @@ public partial class FineTuningManagementClient
     ///    if it is defined.
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public FineTuningManagementClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public FineTuningManagementClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
     {
-        _clientConnector = new("none", endpoint, credential, options);
+        _clientConnector = new(model: null, credential, options);
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="FineTuningClient"/>, used for fine-tuning operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public FineTuningManagementClient(Uri endpoint, OpenAIClientOptions options = null)
-        : this(endpoint, credential: null, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="FineTuningClient"/>, used for fine-tuning operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public FineTuningManagementClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, credential, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="FineTuningClient"/>, used for fine-tuning operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">Additional options to customize the client.</param>
-    public FineTuningManagementClient(OpenAIClientOptions options = null)
-        : this(endpoint: null, credential: null, options)
-    { }
 }

--- a/.dotnet/src/Custom/Images/ImageClient.cs
+++ b/.dotnet/src/Custom/Images/ImageClient.cs
@@ -30,73 +30,13 @@ public partial class ImageClient
     ///    if it is defined.
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="model">The model name for image operations that the client should use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public ImageClient(Uri endpoint, string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public ImageClient(string model, ApiKeyCredential credential = default, OpenAIClientOptions options = null)
     {
-        _clientConnector = new(model, endpoint, credential, options);
+        _clientConnector = new(model, credential, options);
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ImageClient"/>, used for image operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
-    /// <param name="model">The model name for image operations that the client should use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ImageClient(Uri endpoint, string model, OpenAIClientOptions options = null)
-        : this(endpoint, model, credential: null, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ImageClient"/>, used for image operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="model">The model name for image operations that the client should use.</param>
-    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ImageClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, model, credential, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ImageClient"/>, used for image operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="model">The model name for image operations that the client should use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ImageClient(string model, OpenAIClientOptions options = null)
-        : this(endpoint: null, model, credential: null, options)
-    { }
 
     /// <summary>
     /// Generates a single image for a provided prompt.

--- a/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
+++ b/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
@@ -28,67 +28,10 @@ public partial class LegacyCompletionClient
     ///    if it is defined.
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public LegacyCompletionClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public LegacyCompletionClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
     {
-        _clientConnector = new("protocol", endpoint, credential, options);
+        _clientConnector = new(model: null, credential, options);
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="LegacyCompletionClient"/>, used for legacy completion operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public LegacyCompletionClient(Uri endpoint, OpenAIClientOptions options = null)
-        : this(endpoint, credential: null, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="LegacyCompletionClient"/>, used for legacy completion operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public LegacyCompletionClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, credential, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="LegacyCompletionClient"/>, used for legacy completion operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">Additional options to customize the client.</param>
-    public LegacyCompletionClient(OpenAIClientOptions options = null)
-        : this(endpoint: null, credential: null, options)
-    { }
 }

--- a/.dotnet/src/Custom/Models/ModelManagementClient.cs
+++ b/.dotnet/src/Custom/Models/ModelManagementClient.cs
@@ -26,69 +26,12 @@ public partial class ModelManagementClient
     ///    if it is defined.
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public ModelManagementClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public ModelManagementClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
     {
-        _clientConnector = new("none", endpoint, credential, options);
+        _clientConnector = new(model: "none", credential, options);
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModelManagementClient"/>, used for model operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ModelManagementClient(Uri endpoint, OpenAIClientOptions options = null)
-        : this(endpoint, credential: null, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModelManagementClient"/>, used for model operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ModelManagementClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, credential, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModelManagementClient"/>, used for model operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ModelManagementClient(OpenAIClientOptions options = null)
-        : this(endpoint: null, credential: null, options)
-    { }
 
     public virtual ClientResult<ModelDetails> GetModelInfo(string modelId)
     {

--- a/.dotnet/src/Custom/Moderations/ModerationClient.cs
+++ b/.dotnet/src/Custom/Moderations/ModerationClient.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ClientModel;
 
 namespace OpenAI.Moderations;
@@ -24,67 +23,10 @@ public partial class ModerationClient
     ///    if it is defined.
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public ModerationClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions options = null)
+    public ModerationClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
     {
-        _clientConnector = new("none", endpoint, credential, options);
+        _clientConnector = new(model: null, credential, options);
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModerationClient"/>, used for moderation operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="endpoint">The connection endpoint to use.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ModerationClient(Uri endpoint, OpenAIClientOptions options = null)
-        : this(endpoint, credential: null, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModerationClient"/>, used for moderation operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ModerationClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(endpoint: null, credential, options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModerationClient"/>, used for moderation operation requests. 
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    ///     If an endpoint is not provided, the client will use the <c>OPENAI_ENDPOINT</c> environment variable if it
-    ///     defined and otherwise use the default OpenAI v1 endpoint.
-    /// </para>
-    /// <para>
-    ///    If an authentication credential is not defined, the client use the <c>OPENAI_API_KEY</c> environment variable
-    ///    if it is defined.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">Additional options to customize the client.</param>
-    public ModerationClient(OpenAIClientOptions options = null)
-        : this(endpoint: null, credential: null, options)
-    { }
 }

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -5,6 +5,7 @@ using OpenAI.Embeddings;
 using OpenAI.Files;
 using OpenAI.FineTuningManagement;
 using OpenAI.Images;
+using OpenAI.Internal.Models;
 using OpenAI.LegacyCompletions;
 using OpenAI.ModelManagement;
 using OpenAI.Moderations;
@@ -19,7 +20,6 @@ namespace OpenAI;
 /// </summary>
 public partial class OpenAIClient
 {
-    private readonly Uri _cachedEndpoint = null;
     private readonly ApiKeyCredential _cachedCredential = null;
     private readonly OpenAIClientOptions _cachedOptions = null;
 
@@ -31,56 +31,13 @@ public partial class OpenAIClient
     /// This client does not provide any model functionality directly and is purely a helper to facilitate the creation
     /// of the scenario-specific subclients like <see cref="ChatClient"/>.
     /// </remarks>
-    /// <param name="endpoint"> An explicitly defined endpoint that all clients created by this <see cref="OpenAIClient"/> should use. </param>
     /// <param name="credential"> An explicitly defined credential that all clients created by this <see cref="OpenAIClient"/> should use. </param>
     /// <param name="clientOptions"> A common client options definition that all clients created by this <see cref="OpenAIClient"/> should use. </param>
-    public OpenAIClient(Uri endpoint, ApiKeyCredential credential, OpenAIClientOptions clientOptions = null)
+    public OpenAIClient(ApiKeyCredential credential = default, OpenAIClientOptions clientOptions = default)
     {
-        _cachedEndpoint = endpoint;
         _cachedCredential = credential;
         _cachedOptions = clientOptions;
     }
-
-    /// <summary>
-    /// Creates a new instance of <see cref="OpenAIClient"/> will store common client configuration details to permit
-    /// easy reuse and propagation to multiple, scenario-specific subclients.
-    /// </summary>
-    /// <remarks>
-    /// This client does not provide any model functionality directly and is purely a helper to facilitate the creation
-    /// of the scenario-specific subclients like <see cref="ChatClient"/>.
-    /// </remarks>
-    /// <param name="endpoint"> An explicitly defined endpoint that all clients created by this <see cref="OpenAIClient"/> should use. </param>
-    /// <param name="clientOptions"> A common client options definition that all clients created by this <see cref="OpenAIClient"/> should use. </param>
-    public OpenAIClient(Uri endpoint, OpenAIClientOptions clientOptions = null)
-        : this(endpoint, credential: null, clientOptions)
-    { }
-
-    /// <summary>
-    /// Creates a new instance of <see cref="OpenAIClient"/> will store common client configuration details to permit
-    /// easy reuse and propagation to multiple, scenario-specific subclients.
-    /// </summary>
-    /// <remarks>
-    /// This client does not provide any model functionality directly and is purely a helper to facilitate the creation
-    /// of the scenario-specific subclients like <see cref="ChatClient"/>.
-    /// </remarks>
-    /// <param name="credential"> An explicitly defined credential that all clients created by this <see cref="OpenAIClient"/> should use. </param>
-    /// <param name="clientOptions"> A common client options definition that all clients created by this <see cref="OpenAIClient"/> should use. </param>
-    public OpenAIClient(ApiKeyCredential credential, OpenAIClientOptions clientOptions = null)
-        : this(endpoint: null, credential, clientOptions)
-    { }
-
-    /// <summary>
-    /// Creates a new instance of <see cref="OpenAIClient"/> will store common client configuration details to permit
-    /// easy reuse and propagation to multiple, scenario-specific subclients.
-    /// </summary>
-    /// <remarks>
-    /// This client does not provide any model functionality directly and is purely a helper to facilitate the creation
-    /// of the scenario-specific subclients like <see cref="ChatClient"/>.
-    /// </remarks>
-    /// <param name="clientOptions"> A common client options definition that all clients created by this <see cref="OpenAIClient"/> should use. </param>
-    public OpenAIClient(OpenAIClientOptions clientOptions)
-        : this(endpoint: null, credential: null, clientOptions)
-    { }
 
     /// <summary>
     /// Gets a new instance of <see cref="AssistantClient"/> that reuses the client configuration details provided to
@@ -91,8 +48,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="AssistantClient"/>. </returns>
-    public AssistantClient GetAssistantClient()
-        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
+    public AssistantClient GetAssistantClient() => new(_cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="AudioClient"/> that reuses the client configuration details provided to
@@ -103,8 +59,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="AudioClient"/>. </returns>
-    public AudioClient GetAudioClient(string model)
-        => new(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
+    public AudioClient GetAudioClient(string model) => new(model, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="ChatClient"/> that reuses the client configuration details provided to
@@ -115,8 +70,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="ChatClient"/>. </returns>
-    public ChatClient GetChatClient(string model)
-        => new(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
+    public ChatClient GetChatClient(string model) => new(model, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="EmbeddingClient"/> that reuses the client configuration details provided to
@@ -127,8 +81,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="EmbeddingClient"/>. </returns>
-    public EmbeddingClient GetEmbeddingClient(string model)
-        => new(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
+    public EmbeddingClient GetEmbeddingClient(string model) => new(model, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="FileClient"/> that reuses the client configuration details provided to
@@ -139,8 +92,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="FileClient"/>. </returns>
-    public FileClient GetFileClient()
-        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
+    public FileClient GetFileClient() => new(_cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="FineTuningManagementClient"/> that reuses the client configuration details provided to
@@ -151,8 +103,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="FineTuningManagementClient"/>. </returns>
-    public FineTuningManagementClient GetFineTuningManagementClient()
-        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
+    public FineTuningManagementClient GetFineTuningManagementClient() => new(_cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="ImageClient"/> that reuses the client configuration details provided to
@@ -163,8 +114,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="ImageClient"/>. </returns>
-    public ImageClient GetImageClient(string model)
-        => new(_cachedEndpoint, model, _cachedCredential, _cachedOptions);
+    public ImageClient GetImageClient(string model) => new(model, _cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="LegacyCompletionClient"/> that reuses the client configuration details provided to
@@ -175,8 +125,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="LegacyCompletionClient"/>. </returns>
-    public LegacyCompletionClient GetLegacyCompletionClient()
-        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
+    public LegacyCompletionClient GetLegacyCompletionClient() => new(_cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="ModelManagementClient"/> that reuses the client configuration details provided to
@@ -187,8 +136,7 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="ModelManagementClient"/>. </returns>
-    public ModelManagementClient GetModelManagementClient()
-        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
+    public ModelManagementClient GetModelManagementClient() => new(_cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="ModerationClient"/> that reuses the client configuration details provided to
@@ -199,6 +147,5 @@ public partial class OpenAIClient
     /// the same configuration details.
     /// </remarks>
     /// <returns> A new <see cref="ModerationClient"/>. </returns>
-    public ModerationClient GetModerationClient()
-        => new(_cachedEndpoint, _cachedCredential, _cachedOptions);
+    public ModerationClient GetModerationClient() => new(_cachedCredential, _cachedOptions);
 }

--- a/.dotnet/src/Custom/OpenAIClientConnector.cs
+++ b/.dotnet/src/Custom/OpenAIClientConnector.cs
@@ -19,13 +19,12 @@ internal partial class OpenAIClientConnector
 
     internal OpenAIClientConnector(
         string model,
-        Uri endpoint = null,
         ApiKeyCredential credential = null,
         OpenAIClientOptions options = null)
     {
         if (model is null) throw new ArgumentNullException(nameof(model));
         Model = model;
-        Endpoint ??= new(Environment.GetEnvironmentVariable(s_OpenAIEndpointEnvironmentVariable) ?? s_defaultOpenAIV1Endpoint);
+        Endpoint ??= options?.Endpoint ?? new(Environment.GetEnvironmentVariable(s_OpenAIEndpointEnvironmentVariable) ?? s_defaultOpenAIV1Endpoint);
         credential ??= new(Environment.GetEnvironmentVariable(s_OpenAIApiKeyEnvironmentVariable) ?? string.Empty);
         options ??= new();
         InternalClient = new(Endpoint, credential, options.InternalOptions);

--- a/.dotnet/src/Custom/OpenAIClientOptions.cs
+++ b/.dotnet/src/Custom/OpenAIClientOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ClientModel;
 using System.ClientModel;
 using System.ClientModel.Primitives;
@@ -10,6 +11,11 @@ namespace OpenAI;
 /// </summary>
 public partial class OpenAIClientOptions : RequestOptions
 {
+    /// <summary>
+    /// Gets or sets a non-default base endpoint that clients should use when connecting.
+    /// </summary>
+    public Uri Endpoint { get; set; }
+
     // Note: this type currently proxies RequestOptions properties manually via the matching internal type. This is a
     //       temporary extra step pending richer integration with code generation.
 

--- a/.dotnet/tests/Utility/TestHelpers.cs
+++ b/.dotnet/tests/Utility/TestHelpers.cs
@@ -36,12 +36,12 @@ internal static class TestHelpers
         options.ErrorOptions = throwOnError ? ClientErrorBehaviors.Default : ClientErrorBehaviors.NoThrow;
         object clientObject = scenario switch
         {
-            TestScenario.Chat => new ChatClient(overrideModel ?? "gpt-3.5-turbo", options),
-            TestScenario.VisionChat => new ChatClient(overrideModel ?? "gpt-4-vision-preview", options),
-            TestScenario.Assistants => new AssistantClient(options),
-            TestScenario.Images => new ImageClient(overrideModel ?? "dall-e-3", options),
-            TestScenario.Files => new FileClient(options),
-            TestScenario.Transcription => new AudioClient(overrideModel ?? "whisper-1", options),
+            TestScenario.Chat => new ChatClient(overrideModel ?? "gpt-3.5-turbo", credential: null, options),
+            TestScenario.VisionChat => new ChatClient(overrideModel ?? "gpt-4-vision-preview", credential: null, options),
+            TestScenario.Assistants => new AssistantClient(credential: null, options),
+            TestScenario.Images => new ImageClient(overrideModel ?? "dall-e-3", credential: null, options),
+            TestScenario.Files => new FileClient(credential: null, options),
+            TestScenario.Transcription => new AudioClient(overrideModel ?? "whisper-1", credential: null, options),
             _ => throw new NotImplementedException(),
         };
         return (T)clientObject;


### PR DESCRIPTION
Per Krzysztof's feedback:

- Scenario clients that accept a model have a single `string model, ApiKeyCredential credential = default, OpenAIClientOptions options = default` constructor
- Scenario clients without models have a single `ApiKeyCredential credential = default, OpenAIClientOptions = default` constructor

To accomplish this, non-default override endpoint Uri specification is moved to `OpenAIClientOptions`:
```
ChatClient client = new("gpt-3.5-turbo", myApiKey, new OpenAIClientOptions()
{
    Endpoint = myNonDefaultUri,
});
```

This should greatly reduce the potential "gotchas."

Precedence order for endpoint remains unchanged:

1. Programmatically specified (as above)
2. Environment variable
3. Default v1 endpoint