### PR TITLE
incorporate some of the lower-hanging ApiView feedback

### DIFF
--- a/.dotnet/src/Custom/Assistants/ToolOutput.cs
+++ b/.dotnet/src/Custom/Assistants/ToolOutput.cs
@@ -19,9 +19,4 @@ public partial class ToolOutput
         Id = toolCallId;
         Output = output;
     }
-
-    [SetsRequiredMembers]
-    public ToolOutput(RequiredToolCall toolCall, string output = null)
-        : this(toolCall.Id, output)
-    { }
 }

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -86,14 +86,14 @@ public partial class AudioClient
 
     // convenience method - sync; Stream overload
     // TODO: add refdoc comment
-    public virtual ClientResult<AudioTranscription> TranscribeAudio(Stream fileStream, string fileName, AudioTranscriptionOptions options = null)
+    public virtual ClientResult<AudioTranscription> TranscribeAudio(Stream audio, string fileName, AudioTranscriptionOptions options = null)
     {
-        Argument.AssertNotNull(fileStream, nameof(fileStream));
+        Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(fileStream, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
 
         ClientResult result = TranscribeAudio(content, content.ContentType);
 
@@ -106,14 +106,14 @@ public partial class AudioClient
 
     // convenience method - sync
     // TODO: add refdoc comment
-    public virtual ClientResult<AudioTranscription> TranscribeAudio(BinaryData audioBytes, string fileName, AudioTranscriptionOptions options = null)
+    public virtual ClientResult<AudioTranscription> TranscribeAudio(BinaryData audio, string fileName, AudioTranscriptionOptions options = null)
     {
-        Argument.AssertNotNull(audioBytes, nameof(audioBytes));
+        Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audioBytes, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
 
         ClientResult result = TranscribeAudio(content, content.ContentType);
 
@@ -126,14 +126,14 @@ public partial class AudioClient
 
     // convenience method - async
     // TODO: add refdoc comment
-    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(Stream fileStream, string filename, AudioTranscriptionOptions options = null)
+    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(Stream audio, string filename, AudioTranscriptionOptions options = null)
     {
-        Argument.AssertNotNull(fileStream, nameof(fileStream));
+        Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(filename, nameof(filename));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(fileStream, filename, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, filename, _clientConnector.Model);
 
         ClientResult result = await TranscribeAudioAsync(content, content.ContentType).ConfigureAwait(false);
 
@@ -146,14 +146,14 @@ public partial class AudioClient
 
     // convenience method - async
     // TODO: add refdoc comment
-    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(BinaryData audioBytes, string fileName, AudioTranscriptionOptions options = null)
+    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(BinaryData audio, string fileName, AudioTranscriptionOptions options = null)
     {
-        Argument.AssertNotNull(audioBytes, nameof(audioBytes));
+        Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audioBytes, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
 
         ClientResult result = await TranscribeAudioAsync(content, content.ContentType).ConfigureAwait(false);
 
@@ -191,14 +191,14 @@ public partial class AudioClient
 
     // convenience method - sync; Stream overload
     // TODO: add refdoc comment
-    public virtual ClientResult<AudioTranslation> TranslateAudio(Stream fileStream, string fileName, AudioTranslationOptions options = null)
+    public virtual ClientResult<AudioTranslation> TranslateAudio(Stream audio, string fileName, AudioTranslationOptions options = null)
     {
-        Argument.AssertNotNull(fileStream, nameof(fileStream));
+        Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(fileStream, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
 
         ClientResult result = TranslateAudio(content, content.ContentType);
 
@@ -211,14 +211,14 @@ public partial class AudioClient
 
     // convenience method - sync
     // TODO: add refdoc comment
-    public virtual ClientResult<AudioTranslation> TranslateAudio(BinaryData audioBytes, string fileName, AudioTranslationOptions options = null)
+    public virtual ClientResult<AudioTranslation> TranslateAudio(BinaryData audio, string fileName, AudioTranslationOptions options = null)
     {
-        Argument.AssertNotNull(audioBytes, nameof(audioBytes));
+        Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audioBytes, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
 
         ClientResult result = TranslateAudio(content, content.ContentType);
 
@@ -231,14 +231,14 @@ public partial class AudioClient
 
     // convenience method - async; Stream overload
     // TODO: add refdoc comment
-    public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(Stream fileStream, string fileName, AudioTranslationOptions options = null)
+    public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(Stream audio, string fileName, AudioTranslationOptions options = null)
     {
-        Argument.AssertNotNull(fileStream, nameof(fileStream));
+        Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(fileStream, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
 
         ClientResult result = await TranslateAudioAsync(content, content.ContentType).ConfigureAwait(false);
 
@@ -251,14 +251,14 @@ public partial class AudioClient
 
     // convenience method - async
     // TODO: add refdoc comment
-    public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(BinaryData audioBytes, string fileName, AudioTranslationOptions options = null)
+    public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(BinaryData audio, string fileName, AudioTranslationOptions options = null)
     {
-        Argument.AssertNotNull(audioBytes, nameof(audioBytes));
+        Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audioBytes, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
 
         ClientResult result = await TranslateAudioAsync(content, content.ContentType).ConfigureAwait(false);
 

--- a/.dotnet/src/Custom/Audio/AudioTranscriptionFormat.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscriptionFormat.cs
@@ -6,7 +6,7 @@ namespace OpenAI.Audio;
 public enum AudioTranscriptionFormat
 {
     Simple,
-    Detailed,
+    Verbose,
     Srt,
     Vtt,
 }

--- a/.dotnet/src/Custom/Audio/AudioTranscriptionOptions.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscriptionOptions.cs
@@ -56,7 +56,7 @@ public partial class AudioTranscriptionOptions
             string value = ResponseFormat switch
             {
                 AudioTranscriptionFormat.Simple => "json",
-                AudioTranscriptionFormat.Detailed => "verbose_json",
+                AudioTranscriptionFormat.Verbose => "verbose_json",
                 AudioTranscriptionFormat.Srt => "srt",
                 AudioTranscriptionFormat.Vtt => "vtt",
                 _ => throw new ArgumentException(nameof(ResponseFormat))

--- a/.dotnet/src/Custom/Audio/AudioTranslationOptions.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranslationOptions.cs
@@ -46,7 +46,7 @@ public partial class AudioTranslationOptions
             string value = ResponseFormat switch
             {
                 AudioTranscriptionFormat.Simple => "json",
-                AudioTranscriptionFormat.Detailed => "verbose_json",
+                AudioTranscriptionFormat.Verbose => "verbose_json",
                 AudioTranscriptionFormat.Srt => "srt",
                 AudioTranscriptionFormat.Vtt => "vtt",
                 _ => throw new ArgumentException(nameof(ResponseFormat))

--- a/.dotnet/src/Custom/Audio/TranscribedWord.cs
+++ b/.dotnet/src/Custom/Audio/TranscribedWord.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 
 namespace OpenAI.Audio;
 
-public partial class TranscribedWord
+public readonly partial struct TranscribedWord
 {
     public string Word { get; }
     public TimeSpan Start { get; }

--- a/.dotnet/src/Custom/Audio/TranscriptionSegment.cs
+++ b/.dotnet/src/Custom/Audio/TranscriptionSegment.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace OpenAI.Audio;
 
-public partial class TranscriptionSegment
+public readonly partial struct TranscriptionSegment
 {
     public int Id { get; }
     public int SeekOffset { get; }

--- a/.dotnet/src/Custom/Chat/ChatFunctionCall.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionCall.Serialization.cs
@@ -13,7 +13,7 @@ public partial class ChatFunctionCall :  IJsonModel<ChatFunctionCall>
     void IJsonModel<ChatFunctionCall>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
         writer.WriteStartObject();
-        writer.WriteString("name"u8, Name);
+        writer.WriteString("name"u8, FunctionName);
         writer.WriteString("arguments"u8, Arguments);
         writer.WriteEndObject();
     }

--- a/.dotnet/src/Custom/Chat/ChatFunctionCall.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionCall.cs
@@ -24,7 +24,7 @@ public partial class ChatFunctionCall
     /// <summary>
     /// The name of the function being called by the model.
     /// </summary>
-    public required string Name { get; set; }
+    public required string FunctionName { get; set; }
     /// <summary>
     /// The arguments to the function being called by the model.
     /// </summary>
@@ -41,7 +41,7 @@ public partial class ChatFunctionCall
     [SetsRequiredMembers]
     public ChatFunctionCall(string functionName, string arguments)
     {
-        Name = functionName;
+        FunctionName = functionName;
         Arguments = arguments;
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatRequestToolMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestToolMessage.cs
@@ -4,6 +4,7 @@ using System.ClientModel.Internal;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenAI.Chat;
 
@@ -29,7 +30,7 @@ public class ChatRequestToolMessage : ChatRequestMessage
     /// <summary>
     /// The <c>id</c> correlating to the prior <see cref="ChatToolCall"/> made by the model.
     /// </summary>
-    public string ToolCallId { get; set; }
+    public required string ToolCallId { get; set; }
 
     /// <summary>
     /// Creates a new instance of <see cref="ChatRequestToolMessage"/>.
@@ -40,6 +41,7 @@ public class ChatRequestToolMessage : ChatRequestMessage
     ///     that resolves the tool call and allows the logical conversation to continue. No format restrictions (e.g.
     ///     JSON) are imposed on the content emitted by tools.
     /// </param>
+    [SetsRequiredMembers]
     public ChatRequestToolMessage(string toolCallId, string content)
         : base(ChatRole.Tool, content)
     {

--- a/.dotnet/src/Custom/Chat/ChatRequestUserMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestUserMessage.cs
@@ -28,7 +28,7 @@ public class ChatRequestUserMessage : ChatRequestMessage
     /// </summary>
     /// <param name="content"> The textual content associated with the message. </param>
     public ChatRequestUserMessage(string content)
-        : base(ChatRole.User, ChatMessageContent.CreateText(content))
+        : base(ChatRole.User, ChatMessageContent.FromText(content))
     { }
 
     /// <summary>

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -33,11 +33,11 @@ public partial class OpenAIClient
     /// of the scenario-specific subclients like <see cref="ChatClient"/>.
     /// </remarks>
     /// <param name="credential"> An explicitly defined credential that all clients created by this <see cref="OpenAIClient"/> should use. </param>
-    /// <param name="clientOptions"> A common client options definition that all clients created by this <see cref="OpenAIClient"/> should use. </param>
-    public OpenAIClient(ApiKeyCredential credential = default, OpenAIClientOptions clientOptions = default)
+    /// <param name="options"> A common client options definition that all clients created by this <see cref="OpenAIClient"/> should use. </param>
+    public OpenAIClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
     {
         _cachedCredential = credential;
-        _cachedOptions = clientOptions;
+        _cachedOptions = options;
     }
 
     /// <summary>

--- a/.dotnet/tests/Samples/Chat/Sample05_ChatWithVision.cs
+++ b/.dotnet/tests/Samples/Chat/Sample05_ChatWithVision.cs
@@ -16,7 +16,7 @@ namespace OpenAI.Samples
             List<ChatRequestMessage> messages = [
                 new ChatRequestUserMessage(
                     "Describe this image for me",
-                    ChatMessageContent.CreateImage(imageUri))
+                    ChatMessageContent.FromImage(imageUri))
             ];
 
             ChatCompletion chatCompletion = client.CompleteChat(messages);

--- a/.dotnet/tests/Samples/Chat/Sample05_ChatWithVisionAsync.cs
+++ b/.dotnet/tests/Samples/Chat/Sample05_ChatWithVisionAsync.cs
@@ -17,7 +17,7 @@ namespace OpenAI.Samples
             List<ChatRequestMessage> messages = [
                 new ChatRequestUserMessage(
                     "Describe this image for me",
-                    ChatMessageContent.CreateImage(imageUri))
+                    ChatMessageContent.FromImage(imageUri))
             ];
 
             ChatCompletion chatCompletion = await client.CompleteChatAsync(messages);

--- a/.dotnet/tests/Samples/CombinationSamples.cs
+++ b/.dotnet/tests/Samples/CombinationSamples.cs
@@ -36,7 +36,7 @@ namespace OpenAI.Samples.Miscellaneous
                     + "evaluate imagery, focus on criticizing elements of subject, composition, and other details."),
                 new ChatRequestUserMessage(
                     "describe the following image in a few sentences",
-                    ChatMessageContent.CreateImage(imageGeneration.ImageUri)),
+                    ChatMessageContent.FromImage(imageGeneration.ImageUri)),
             ],
                 new ChatCompletionOptions()
                 {
@@ -121,7 +121,7 @@ namespace OpenAI.Samples.Miscellaneous
                     new ChatRequestSystemMessage("Assume the role of an art critic. Although usually cranky and occasionally even referred to as a 'curmudgeon', you're somehow entirely smitten with the subject presented to you and, despite your best efforts, can't help but lavish praise when you're asked to appraise a provided image."),
                 new ChatRequestUserMessage(
                     "Evaluate this image for me. What is it, and what do you think of it?",
-                    ChatMessageContent.CreateImage(imageLocation)),
+                    ChatMessageContent.FromImage(imageLocation)),
             ],
                 new ChatCompletionOptions()
                 {

--- a/.dotnet/tests/TestScenarios/AssistantTests.cs
+++ b/.dotnet/tests/TestScenarios/AssistantTests.cs
@@ -121,7 +121,7 @@ public partial class AssistantTests
         Assert.That(requiredFunctionToolCall, Is.Not.Null);
         _ = await client.SubmitToolOutputsAsync(threadResult.Value.Id, runResult.Value.Id,
             [
-                new ToolOutput(requiredFunctionToolCall, "tacos"),
+                new ToolOutput(requiredFunctionToolCall.Id, "tacos"),
             ]);
         runResult = await client.GetRunAsync(threadResult.Value.Id, runResult.Value.Id);
         Assert.That(runResult.Value.Status, Is.Not.EqualTo(RunStatus.RequiresAction));

--- a/.dotnet/tests/TestScenarios/ChatWithVision.cs
+++ b/.dotnet/tests/TestScenarios/ChatWithVision.cs
@@ -13,8 +13,8 @@ public partial class ChatWithVision
     [Test]
     public void DescribeAnImage()
     {
-        var stopSignPath = Path.Combine("Assets", "stop_sign.png");
-        var stopSignData = BinaryData.FromBytes(File.ReadAllBytes(stopSignPath));
+        string stopSignPath = Path.Combine("Assets", "stop_sign.png");
+        using Stream stopSignStream = File.OpenRead(stopSignPath);
 
         ChatClient client = GetTestClient<ChatClient>(TestScenario.VisionChat);
 
@@ -22,7 +22,7 @@ public partial class ChatWithVision
             [
                 new ChatRequestUserMessage(
                     "Describe this image for me",
-                    ChatMessageContent.CreateImage(stopSignData, "image/png")),
+                    ChatMessageContent.FromImage(stopSignStream, "image/png")),
             ], new ChatCompletionOptions()
             {
                 MaxTokens = 2048,

--- a/.dotnet/tests/TestScenarios/TranscriptionTests.cs
+++ b/.dotnet/tests/TestScenarios/TranscriptionTests.cs
@@ -30,7 +30,7 @@ public partial class TranscriptionTests
         {
              EnableWordTimestamps = true,
              EnableSegmentTimestamps = true,
-             ResponseFormat = AudioTranscriptionFormat.Detailed,
+             ResponseFormat = AudioTranscriptionFormat.Verbose,
         });
         Assert.That(transcriptionResult.Value, Is.Not.Null);
         // Assert.That(transcriptionResult.Value.Segments, Is.Null);


### PR DESCRIPTION
This isn't intended to be exhaustive; just a quick defrag to avoid having too many "easy" things pile up around the "harder" things.

- Removes the convenience `ToolOutput(RequiredToolCall)` constructor
- Renames audio data inputs to `audio` (vs. `audioBytes` and `fileStream`)
- Renames `AudioTranscriptionFormat.Detailed` to `Verbose`
- Renames `ChatFunctionCall.Name` to `FunctionName`
- Converts `TranscribedWord` and `TranscribedSegment` to structs
- Switches `ChatRequestMessage` image representation to `Stream`
- Renames `CreateText` and `CreateImage` to `FromText` and `FromImage`
- Applies missing `required` pattern to `ChatRequestToolMessage`