### PR TITLE
Incorporate further ApiView feedback

### DIFF
--- a/.dotnet/src/Custom/Assistants/Assistant.cs
+++ b/.dotnet/src/Custom/Assistants/Assistant.cs
@@ -8,11 +8,11 @@ public partial class Assistant
 {
     public string Id { get; }
     public DateTimeOffset CreatedAt { get; }
-    public string Name { get; }
-    public string Description { get; }
+    public string? Name { get; }
+    public string? Description { get; }
     public string DefaultModel { get; }
-    public string DefaultInstructions { get; }
-    public IReadOnlyList<ToolDefinition> DefaultTools { get; }
+    public string? DefaultInstructions { get; }
+    public IReadOnlyList<ToolDefinition>? DefaultTools { get; }
     /// <summary>
     /// An optional key/value mapping of additional, supplemental data items to attach to the <see cref="Assistant"/>.
     /// This information may be useful for storing custom details in a structured format.
@@ -23,7 +23,7 @@ public partial class Assistant
     ///     <item><b>Values</b> can be a maximum of 512 characters in length.</item>
     /// </list>
     /// </remarks>
-    public IReadOnlyDictionary<string, string> Metadata { get; }
+    public IReadOnlyDictionary<string, string>? Metadata { get; }
 
     internal Assistant(Internal.Models.AssistantObject internalAssistant)
     {

--- a/.dotnet/src/Custom/Assistants/Assistant.cs
+++ b/.dotnet/src/Custom/Assistants/Assistant.cs
@@ -12,7 +12,7 @@ public partial class Assistant
     public string? Description { get; }
     public string DefaultModel { get; }
     public string? DefaultInstructions { get; }
-    public IReadOnlyList<ToolDefinition>? DefaultTools { get; }
+    public IReadOnlyList<ToolDefinition> DefaultTools { get; } = [];
     /// <summary>
     /// An optional key/value mapping of additional, supplemental data items to attach to the <see cref="Assistant"/>.
     /// This information may be useful for storing custom details in a structured format.
@@ -23,7 +23,7 @@ public partial class Assistant
     ///     <item><b>Values</b> can be a maximum of 512 characters in length.</item>
     /// </list>
     /// </remarks>
-    public IReadOnlyDictionary<string, string>? Metadata { get; }
+    public IReadOnlyDictionary<string, string> Metadata { get; }
 
     internal Assistant(Internal.Models.AssistantObject internalAssistant)
     {
@@ -33,16 +33,22 @@ public partial class Assistant
         Description = internalAssistant.Description;
         DefaultModel = internalAssistant.Model;
         DefaultInstructions = internalAssistant.Instructions;
-        Metadata = internalAssistant.Metadata;
+        DefaultTools = GetToolsFromInternalTools(internalAssistant.Tools);
+        Metadata = internalAssistant.Metadata ?? new Dictionary<string, string>();
+    }
 
-        if (internalAssistant.Tools != null)
+    private static IReadOnlyList<ToolDefinition> GetToolsFromInternalTools(IReadOnlyList<BinaryData>? internalTools)
+    {
+        if (internalTools is not null)
         {
             List<ToolDefinition> tools = [];
-            foreach (BinaryData unionToolDefinitionData in internalAssistant.Tools)
+            foreach (BinaryData unionToolDefinitionData in internalTools)
             {
-                tools.Add(ToolDefinition.DeserializeToolDefinition(JsonDocument.Parse(unionToolDefinitionData).RootElement));
+                using JsonDocument toolDocument = JsonDocument.Parse(unionToolDefinitionData);
+                tools.Add(ToolDefinition.DeserializeToolDefinition(toolDocument.RootElement));
             }
-            DefaultTools = tools;
+            return tools;
         }
+        return [];
     }
 }

--- a/.dotnet/src/Custom/Assistants/AssistantClient.Protocol.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantClient.Protocol.cs
@@ -11,14 +11,14 @@ public partial class AssistantClient
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ClientResult CreateAssistant(
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => Shim.CreateAssistant(content, options);
 
     /// <inheritdoc cref="Internal.Assistants.CreateAssistantAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual async Task<ClientResult> CreateAssistantAsync(
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await Shim.CreateAssistantAsync(content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Assistants.GetAssistant(string, RequestOptions)"/>
@@ -61,7 +61,7 @@ public partial class AssistantClient
     public virtual ClientResult ModifyAssistant(
         string assistantId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => Shim.ModifyAssistant(assistantId, content, options);
 
     /// <inheritdoc cref="Internal.Assistants.ModifyAssistantAsync(string, BinaryContent, RequestOptions)"/>
@@ -69,7 +69,7 @@ public partial class AssistantClient
     public virtual async Task<ClientResult> ModifyAssistantAsync(
         string assistantId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await Shim.ModifyAssistantAsync(assistantId, content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Assistants.DeleteAssistant(string, RequestOptions)"/>
@@ -91,7 +91,7 @@ public partial class AssistantClient
     public virtual ClientResult CreateAssistantFileAssociation(
         string assistantId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => Shim.CreateAssistantFile(assistantId, content, options);
 
     /// <inheritdoc cref="Internal.Assistants.CreateAssistantFileAsync(string, BinaryContent, RequestOptions)"/>
@@ -99,7 +99,7 @@ public partial class AssistantClient
     public virtual async Task<ClientResult> CreateAssistantFileAssociationAsync(
         string assistantId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await Shim.CreateAssistantFileAsync(assistantId, content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Assistants.GetAssistantFile(string, string, RequestOptions)"/>
@@ -160,14 +160,14 @@ public partial class AssistantClient
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ClientResult CreateThread(
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => ThreadShim.CreateThread(content, options);
 
     /// <inheritdoc cref="Internal.Threads.CreateThreadAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual async Task<ClientResult> CreateThreadAsync(
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await ThreadShim.CreateThreadAsync(content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Threads.GetThread(string, RequestOptions)"/>
@@ -189,7 +189,7 @@ public partial class AssistantClient
     public virtual ClientResult ModifyThread(
         string threadId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => ThreadShim.ModifyThread(threadId, content, options);
 
     /// <inheritdoc cref="Internal.Threads.ModifyThreadAsync(string, BinaryContent, RequestOptions)"/>
@@ -197,7 +197,7 @@ public partial class AssistantClient
     public virtual async Task<ClientResult> ModifyThreadAsync(
         string threadId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await ThreadShim.ModifyThreadAsync(threadId, content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Threads.DeleteThread(string, RequestOptions)"/>
@@ -219,7 +219,7 @@ public partial class AssistantClient
     public virtual ClientResult CreateMessage(
         string threadId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => MessageShim.CreateMessage(threadId, content, options);
 
     /// <inheritdoc cref="Internal.Messages.CreateMessageAsync(string, BinaryContent, RequestOptions)"/>
@@ -227,7 +227,7 @@ public partial class AssistantClient
     public virtual async Task<ClientResult> CreateMessageAsync(
         string threadId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await MessageShim.CreateMessageAsync(threadId, content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Messages.GetMessage(string, string, RequestOptions)"/>
@@ -333,7 +333,7 @@ public partial class AssistantClient
     public virtual ClientResult CreateRun(
         string threadId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => RunShim.CreateRun(threadId, content, options);
 
     /// <inheritdoc cref="Internal.Runs.CreateRunAsync(string, BinaryContent, RequestOptions)"/>
@@ -341,21 +341,21 @@ public partial class AssistantClient
     public virtual async Task<ClientResult> CreateRunAsync(
         string threadId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await RunShim.CreateRunAsync(threadId, content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Runs.CreateThreadAndRun(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ClientResult CreateThreadAndRun(
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => RunShim.CreateThreadAndRun(content, options);
 
     /// <inheritdoc cref="Internal.Runs.CreateThreadAndRunAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual async Task<ClientResult> CreateThreadAndRunAsync(
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await RunShim.CreateThreadAndRunAsync(content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Runs.GetRun(string, string, RequestOptions)"/>
@@ -402,7 +402,7 @@ public partial class AssistantClient
         string threadId,
         string runId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => RunShim.ModifyRun(threadId, runId, content, options);
 
     /// <inheritdoc cref="Internal.Runs.ModifyRunAsync(string, string, BinaryContent, RequestOptions)"/>
@@ -411,7 +411,7 @@ public partial class AssistantClient
         string threadId,
         string runId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await RunShim.ModifyRunAsync(threadId, runId, content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Runs.CancelRun(string, string, RequestOptions)"/>
@@ -436,7 +436,7 @@ public partial class AssistantClient
         string threadId,
         string runId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => RunShim.SubmitToolOuputsToRun(threadId, runId, content, options);
 
     /// <inheritdoc cref="Internal.Runs.SubmitToolOuputsToRunAsync(string, string, BinaryContent, RequestOptions)"/>
@@ -445,7 +445,7 @@ public partial class AssistantClient
         string threadId,
         string runId,
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await RunShim.SubmitToolOuputsToRunAsync(threadId, runId, content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.Runs.GetRunStep(string, string, string, RequestOptions)"/>

--- a/.dotnet/src/Custom/Assistants/AssistantClient.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantClient.cs
@@ -3,6 +3,7 @@ using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace OpenAI.Assistants;
@@ -13,7 +14,7 @@ namespace OpenAI.Assistants;
 [Experimental("OPENAI001")]
 public partial class AssistantClient
 {
-    private OpenAIClientConnector _clientConnector;
+    private readonly OpenAIClientConnector _clientConnector;
     private Internal.Assistants Shim => _clientConnector.InternalClient.GetAssistantsClient();
     private Internal.Threads ThreadShim => _clientConnector.InternalClient.GetThreadsClient();
     private Internal.Messages MessageShim => _clientConnector.InternalClient.GetMessagesClient();
@@ -34,7 +35,7 @@ public partial class AssistantClient
     /// </remarks>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public AssistantClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
+    public AssistantClient(ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         options ??= new();
         options.AddPolicy(
@@ -45,7 +46,7 @@ public partial class AssistantClient
 
     public virtual ClientResult<Assistant> CreateAssistant(
         string modelName,
-        AssistantCreationOptions options = null)
+        AssistantCreationOptions? options = default)
     {
         Internal.Models.CreateAssistantRequest request = CreateInternalCreateAssistantRequest(modelName, options);
         ClientResult<Internal.Models.AssistantObject> internalResult = Shim.CreateAssistant(request);
@@ -54,7 +55,7 @@ public partial class AssistantClient
 
     public virtual async Task<ClientResult<Assistant>> CreateAssistantAsync(
         string modelName,
-        AssistantCreationOptions options = null)
+        AssistantCreationOptions? options = default)
     {
         Internal.Models.CreateAssistantRequest request = CreateInternalCreateAssistantRequest(modelName, options);
         ClientResult<Internal.Models.AssistantObject> internalResult = await Shim.CreateAssistantAsync(request).ConfigureAwait(false);
@@ -77,8 +78,8 @@ public partial class AssistantClient
     public virtual ClientResult<ListQueryPage<Assistant>> GetAssistants(
         int? maxResults = null,
         CreatedAtSortOrder? createdSortOrder = null,
-        string previousAssistantId = null,
-        string subsequentAssistantId = null)
+        string? previousAssistantId = null,
+        string? subsequentAssistantId = null)
     {
         ClientResult<Internal.Models.ListAssistantsResponse> internalFunc() => Shim.GetAssistants(
             maxResults,
@@ -91,8 +92,8 @@ public partial class AssistantClient
     public virtual Task<ClientResult<ListQueryPage<Assistant>>> GetAssistantsAsync(
         int? maxResults = null,
         CreatedAtSortOrder? createdSortOrder = null,
-        string previousAssistantId = null,
-        string subsequentAssistantId = null)
+        string? previousAssistantId = null,
+        string? subsequentAssistantId = null)
     {
         Task<ClientResult<Internal.Models.ListAssistantsResponse>> internalAsyncFunc() => Shim.GetAssistantsAsync(
             maxResults,
@@ -171,8 +172,8 @@ public partial class AssistantClient
         string assistantId,
         int? maxResults = null,
         CreatedAtSortOrder? createdSortOrder = null,
-        string previousId = null,
-        string subsequentId = null)
+        string? previousId = null,
+        string? subsequentId = null)
     {
         ClientResult<Internal.Models.ListAssistantFilesResponse> internalFunc() => Shim.GetAssistantFiles(
             assistantId,
@@ -187,17 +188,17 @@ public partial class AssistantClient
         string assistantId,
         int? maxResults = null,
         CreatedAtSortOrder? createdSortOrder = null,
-        string previousId = null,
-        string subsequentId = null)
+        string? previousId = null,
+        string? subsequentId = null)
     {
-        Func<Task<ClientResult<Internal.Models.ListAssistantFilesResponse>>> internalFunc
-            = () => Shim.GetAssistantFilesAsync(
+        Task<ClientResult<Internal.Models.ListAssistantFilesResponse>> InternalFunc()
+            => Shim.GetAssistantFilesAsync(
                 assistantId,
                 maxResults,
                 ToInternalListOrder(createdSortOrder),
                 previousId,
                 subsequentId);
-        return GetListQueryPageAsync<AssistantFileAssociation, Internal.Models.ListAssistantFilesResponse>(internalFunc);
+        return GetListQueryPageAsync<AssistantFileAssociation, Internal.Models.ListAssistantFilesResponse>(InternalFunc);
     }
 
     public virtual ClientResult<bool> RemoveAssistantFileAssociation(
@@ -213,12 +214,13 @@ public partial class AssistantClient
         string assistantId,
         string fileId)
     {
-        ClientResult<Internal.Models.DeleteAssistantFileResponse> internalResult = await Shim.DeleteAssistantFileAsync(assistantId, fileId).ConfigureAwait(false);
+        ClientResult<Internal.Models.DeleteAssistantFileResponse> internalResult
+            = await Shim.DeleteAssistantFileAsync(assistantId, fileId).ConfigureAwait(false);
         return ClientResult.FromValue(internalResult.Value.Deleted, internalResult.GetRawResponse());
     }
 
     public virtual ClientResult<AssistantThread> CreateThread(
-        ThreadCreationOptions options = null)
+        ThreadCreationOptions? options = default)
     {
         Internal.Models.CreateThreadRequest request = CreateInternalCreateThreadRequest(options);
         ClientResult<Internal.Models.ThreadObject> internalResult = ThreadShim.CreateThread(request);
@@ -226,10 +228,11 @@ public partial class AssistantClient
     }
 
     public virtual async Task<ClientResult<AssistantThread>> CreateThreadAsync(
-        ThreadCreationOptions options = null)
+        ThreadCreationOptions? options = default)
     {
         Internal.Models.CreateThreadRequest request = CreateInternalCreateThreadRequest(options);
-        ClientResult<Internal.Models.ThreadObject> internalResult = await ThreadShim.CreateThreadAsync(request).ConfigureAwait(false);
+        ClientResult<Internal.Models.ThreadObject> internalResult
+            = await ThreadShim.CreateThreadAsync(request).ConfigureAwait(false);
         return ClientResult.FromValue(new AssistantThread(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -239,16 +242,14 @@ public partial class AssistantClient
         return ClientResult.FromValue(new AssistantThread(internalResult.Value), internalResult.GetRawResponse());
     }
 
-    public virtual async Task<ClientResult<AssistantThread>> GetThreadAsync(
-        string threadId)
+    public virtual async Task<ClientResult<AssistantThread>> GetThreadAsync(string threadId)
     {
-        ClientResult<Internal.Models.ThreadObject> internalResult = await ThreadShim.GetThreadAsync(threadId).ConfigureAwait(false);
+        ClientResult<Internal.Models.ThreadObject> internalResult
+            = await ThreadShim.GetThreadAsync(threadId).ConfigureAwait(false);
         return ClientResult.FromValue(new AssistantThread(internalResult.Value), internalResult.GetRawResponse());
     }
 
-    public virtual ClientResult<AssistantThread> ModifyThread(
-        string threadId,
-        ThreadModificationOptions options)
+    public virtual ClientResult<AssistantThread> ModifyThread(string threadId, ThreadModificationOptions options)
     {
         Internal.Models.ModifyThreadRequest request = new(
             options.Metadata,
@@ -257,18 +258,17 @@ public partial class AssistantClient
         return ClientResult.FromValue(new AssistantThread(internalResult.Value), internalResult.GetRawResponse());
     }
 
-    public virtual async Task<ClientResult<AssistantThread>> ModifyThreadAsync(
-        string threadId,
-        ThreadModificationOptions options)
+    public virtual async Task<ClientResult<AssistantThread>> ModifyThreadAsync(string threadId, ThreadModificationOptions options)
     {
         Internal.Models.ModifyThreadRequest request = new(
             options.Metadata,
             serializedAdditionalRawData: null);
-        ClientResult<Internal.Models.ThreadObject> internalResult = await ThreadShim.ModifyThreadAsync(threadId, request).ConfigureAwait(false);
+        ClientResult<Internal.Models.ThreadObject> internalResult
+            = await ThreadShim.ModifyThreadAsync(threadId, request).ConfigureAwait(false);
         return ClientResult.FromValue(new AssistantThread(internalResult.Value), internalResult.GetRawResponse());
     }
 
-     public virtual ClientResult<bool> DeleteThread(string threadId)
+    public virtual ClientResult<bool> DeleteThread(string threadId)
     {
         ClientResult<Internal.Models.DeleteThreadResponse> internalResult = ThreadShim.DeleteThread(threadId);
         return ClientResult.FromValue(internalResult.Value.Deleted, internalResult.GetRawResponse());
@@ -284,15 +284,10 @@ public partial class AssistantClient
         string threadId,
         MessageRole role,
         string content,
-        MessageCreationOptions options = null)
+        MessageCreationOptions? options = default)
     {
-        Internal.Models.CreateMessageRequest request = new(
-            ToInternalRequestRole(role),
-            content,
-            options.FileIds,
-            options.Metadata,
-            serializedAdditionalRawData: null);
-        ClientResult<Internal.Models.MessageObject> internalResult = MessageShim.CreateMessage(threadId, request);
+        Internal.Models.CreateMessageRequest internalRequest = CreateInternalCreateMessageRequest(role, content, options);
+        ClientResult<Internal.Models.MessageObject> internalResult = MessageShim.CreateMessage(threadId, internalRequest);
         return ClientResult.FromValue(new ThreadMessage(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -300,15 +295,11 @@ public partial class AssistantClient
         string threadId,
         MessageRole role,
         string content,
-        MessageCreationOptions options = null)
+        MessageCreationOptions? options = default)
     {
-        Internal.Models.CreateMessageRequest request = new(
-            ToInternalRequestRole(role),
-            content,
-            options.FileIds,
-            options.Metadata,
-            serializedAdditionalRawData: null);
-        ClientResult<Internal.Models.MessageObject> internalResult = await MessageShim.CreateMessageAsync(threadId, request).ConfigureAwait(false);
+        Internal.Models.CreateMessageRequest internalRequest = CreateInternalCreateMessageRequest(role, content, options);
+        ClientResult<Internal.Models.MessageObject> internalResult
+            = await MessageShim.CreateMessageAsync(threadId, internalRequest).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadMessage(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -324,7 +315,8 @@ public partial class AssistantClient
         string threadId,
         string messageId)
     {
-        ClientResult<Internal.Models.MessageObject> internalResult = await MessageShim.GetMessageAsync(threadId, messageId).ConfigureAwait(false);
+        ClientResult<Internal.Models.MessageObject> internalResult
+            = await MessageShim.GetMessageAsync(threadId, messageId).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadMessage(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -348,7 +340,8 @@ public partial class AssistantClient
         Internal.Models.ModifyMessageRequest request = new(
             options.Metadata,
             serializedAdditionalRawData: null);
-        ClientResult<Internal.Models.MessageObject> internalResult = await MessageShim.ModifyMessageAsync(threadId, messageId, request).ConfigureAwait(false);
+        ClientResult<Internal.Models.MessageObject> internalResult
+            = await MessageShim.ModifyMessageAsync(threadId, messageId, request).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadMessage(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -356,16 +349,17 @@ public partial class AssistantClient
         string threadId,
         int? maxResults = null,
         CreatedAtSortOrder? createdSortOrder = null,
-        string previousMessageId = null,
-        string subsequentMessageId = null)
+        string? previousMessageId = null,
+        string? subsequentMessageId = null)
     {
-        ClientResult<Internal.Models.ListMessagesResponse> internalFunc() => MessageShim.GetMessages(
-            threadId,
-            maxResults,
-            ToInternalListOrder(createdSortOrder),
-            previousMessageId,
-            subsequentMessageId);
-        return GetListQueryPage<ThreadMessage, Internal.Models.ListMessagesResponse>(internalFunc);
+        ClientResult<Internal.Models.ListMessagesResponse> InternalFunc()
+            => MessageShim.GetMessages(
+                threadId,
+                maxResults,
+                ToInternalListOrder(createdSortOrder),
+                previousMessageId,
+                subsequentMessageId);
+        return GetListQueryPage<ThreadMessage, Internal.Models.ListMessagesResponse>(InternalFunc);
     }
 
     public virtual Task<ClientResult<ListQueryPage<ThreadMessage>>> GetMessagesAsync(
@@ -375,13 +369,14 @@ public partial class AssistantClient
         string previousMessageId = null,
         string subsequentMessageId = null)
     {
-        Func<Task<ClientResult<Internal.Models.ListMessagesResponse>>> internalFunc = () => MessageShim.GetMessagesAsync(
+        Task<ClientResult<Internal.Models.ListMessagesResponse>> InternalFunc()
+            => MessageShim.GetMessagesAsync(
                 threadId,
                 maxResults,
                 ToInternalListOrder(createdSortOrder),
                 previousMessageId,
                 subsequentMessageId);
-        return GetListQueryPageAsync<ThreadMessage, Internal.Models.ListMessagesResponse>(internalFunc);
+        return GetListQueryPageAsync<ThreadMessage, Internal.Models.ListMessagesResponse>(InternalFunc);
     }
 
     public virtual ClientResult<MessageFileAssociation> GetMessageFileAssociation(
@@ -399,7 +394,8 @@ public partial class AssistantClient
         string messageId,
         string fileId)
     {
-        ClientResult<Internal.Models.MessageFileObject> internalResult = await MessageShim.GetMessageFileAsync(threadId, messageId, fileId).ConfigureAwait(false);
+        ClientResult<Internal.Models.MessageFileObject> internalResult
+            = await MessageShim.GetMessageFileAsync(threadId, messageId, fileId).ConfigureAwait(false);
         return ClientResult.FromValue(new MessageFileAssociation(internalResult.Value), internalResult.GetRawResponse());
     }
 
@@ -408,17 +404,17 @@ public partial class AssistantClient
         string messageId,
         int? maxResults = null,
         CreatedAtSortOrder? createdSortOrder = null,
-        string previousId = null,
-        string subsequentId = null)
+        string? previousId = null,
+        string? subsequentId = null)
     {
-        ClientResult<Internal.Models.ListMessageFilesResponse> internalFunc() => MessageShim.GetMessageFiles(
+        ClientResult<Internal.Models.ListMessageFilesResponse> InternalFunc() => MessageShim.GetMessageFiles(
             threadId,
             messageId,
             maxResults,
             ToInternalListOrder(createdSortOrder),
             previousId,
             subsequentId);
-        return GetListQueryPage<MessageFileAssociation, Internal.Models.ListMessageFilesResponse>(internalFunc);
+        return GetListQueryPage<MessageFileAssociation, Internal.Models.ListMessageFilesResponse>(InternalFunc);
     }
 
     public virtual Task<ClientResult<ListQueryPage<MessageFileAssociation>>> GetMessageFileAssociationsAsync(
@@ -426,23 +422,23 @@ public partial class AssistantClient
         string messageId,
         int? maxResults = null,
         CreatedAtSortOrder? createdSortOrder = null,
-        string previousId = null,
-        string subsequentId = null)
+        string? previousId = null,
+        string? subsequentId = null)
     {
-        Task<ClientResult<Internal.Models.ListMessageFilesResponse>> internalFunc() => MessageShim.GetMessageFilesAsync(
+        Task<ClientResult<Internal.Models.ListMessageFilesResponse>> InternalFunc() => MessageShim.GetMessageFilesAsync(
             threadId,
             messageId,
             maxResults,
             ToInternalListOrder(createdSortOrder),
             previousId,
             subsequentId);
-        return GetListQueryPageAsync<MessageFileAssociation, Internal.Models.ListMessageFilesResponse>(internalFunc);
+        return GetListQueryPageAsync<MessageFileAssociation, Internal.Models.ListMessageFilesResponse>(InternalFunc);
     }
 
     public virtual ClientResult<ThreadRun> CreateRun(
         string threadId,
         string assistantId,
-        RunCreationOptions options = null)
+        RunCreationOptions? options = default)
     {
         Internal.Models.CreateRunRequest request = CreateInternalCreateRunRequest(assistantId, options);
         ClientResult<Internal.Models.RunObject> internalResult = RunShim.CreateRun(threadId, request);
@@ -452,17 +448,18 @@ public partial class AssistantClient
     public virtual async Task<ClientResult<ThreadRun>> CreateRunAsync(
         string threadId,
         string assistantId,
-        RunCreationOptions options = null)
+        RunCreationOptions? options = default)
     {
         Internal.Models.CreateRunRequest request = CreateInternalCreateRunRequest(assistantId, options);
-        ClientResult<Internal.Models.RunObject> internalResult = await RunShim.CreateRunAsync(threadId, request).ConfigureAwait(false);
+        ClientResult<Internal.Models.RunObject> internalResult
+            = await RunShim.CreateRunAsync(threadId, request).ConfigureAwait(false);
         return ClientResult.FromValue(new ThreadRun(internalResult.Value), internalResult.GetRawResponse());
     }
 
     public virtual ClientResult<ThreadRun> CreateThreadAndRun(
         string assistantId,
-        ThreadCreationOptions threadOptions = null,
-        RunCreationOptions runOptions = null)
+        ThreadCreationOptions? threadOptions = null,
+        RunCreationOptions? runOptions = null)
     {
         Internal.Models.CreateThreadAndRunRequest request
             = CreateInternalCreateThreadAndRunRequest(assistantId, threadOptions, runOptions);
@@ -472,8 +469,8 @@ public partial class AssistantClient
 
     public virtual async Task<ClientResult<ThreadRun>> CreateThreadAndRunAsync(
         string assistantId,
-        ThreadCreationOptions threadOptions = null,
-        RunCreationOptions runOptions = null)
+        ThreadCreationOptions? threadOptions = default,
+        RunCreationOptions? runOptions = default)
     {
         Internal.Models.CreateThreadAndRunRequest request
             = CreateInternalCreateThreadAndRunRequest(assistantId, threadOptions, runOptions);
@@ -581,14 +578,14 @@ public partial class AssistantClient
 
     internal static Internal.Models.CreateAssistantRequest CreateInternalCreateAssistantRequest(
         string modelName,
-        AssistantCreationOptions options)
+        AssistantCreationOptions? options = null)
     {
         options ??= new();
         return new Internal.Models.CreateAssistantRequest(
             modelName,
             options.Name,
             options.Description,
-            options.Instructions,
+            options.DefaultInstructions,
             ToInternalBinaryDataList(options.Tools),
             options.FileIds,
             options.Metadata,
@@ -610,7 +607,7 @@ public partial class AssistantClient
     }
 
     internal static Internal.Models.CreateThreadRequest CreateInternalCreateThreadRequest(
-        ThreadCreationOptions options)
+        ThreadCreationOptions? options = default)
     {
         options ??= new();
         return new Internal.Models.CreateThreadRequest(
@@ -619,9 +616,24 @@ public partial class AssistantClient
             serializedAdditionalRawData: null);
     }
 
+    internal static Internal.Models.CreateMessageRequest CreateInternalCreateMessageRequest(
+        MessageRole role,
+        string content,
+        MessageCreationOptions? options = default)
+    {
+        options ??= new();
+        Internal.Models.CreateMessageRequest request = new(
+            ToInternalRequestRole(role),
+            content,
+            options.FileIds,
+            options.Metadata,
+            serializedAdditionalRawData: null);
+        return request;
+    }
+
     internal static Internal.Models.CreateRunRequest CreateInternalCreateRunRequest(
         string assistantId,
-        RunCreationOptions options = null)
+        RunCreationOptions? options = default)
     {
         options ??= new();
         return new(
@@ -636,8 +648,8 @@ public partial class AssistantClient
 
     internal static Internal.Models.CreateThreadAndRunRequest CreateInternalCreateThreadAndRunRequest(
         string assistantId,
-        ThreadCreationOptions threadOptions,
-        RunCreationOptions runOptions)
+        ThreadCreationOptions? threadOptions = default,
+        RunCreationOptions? runOptions = default)
     {
         threadOptions ??= new();
         runOptions ??= new();
@@ -645,18 +657,18 @@ public partial class AssistantClient
         return new Internal.Models.CreateThreadAndRunRequest(
             assistantId,
             internalThreadOptions,
-            runOptions?.OverrideModel,
+            runOptions.OverrideModel,
             runOptions.OverrideInstructions,
-            ToInternalBinaryDataList(runOptions?.OverrideTools),
-            runOptions?.Metadata,
+            ToInternalBinaryDataList(runOptions.OverrideTools),
+            runOptions.Metadata,
             serializedAdditionalRawData: null);
     }
 
-    internal static ChangeTrackingList<BinaryData> ToInternalBinaryDataList<T>(IEnumerable<T> values)
+    internal static ChangeTrackingList<BinaryData> ToInternalBinaryDataList<T>(IEnumerable<T>? values)
         where T : IPersistableModel<T>
     {
         ChangeTrackingList<BinaryData> internalList = [];
-        foreach (T value in values)
+        foreach (T value in values ?? [])
         {
             internalList.Add(ModelReaderWriter.Write(value));
         }
@@ -705,8 +717,8 @@ public partial class AssistantClient
         where U : class
     {
         ClientResult<U> internalResult = internalFunc.Invoke();
-        ListQueryPage<T> convertedValue = ListQueryPage.Create(internalResult.Value) as ListQueryPage<T>;
-        return ClientResult.FromValue(convertedValue, internalResult.GetRawResponse());
+        ListQueryPage<T>? convertedValue = ListQueryPage.Create(internalResult.Value) as ListQueryPage<T>;
+        return ClientResult.FromValue(convertedValue!, internalResult.GetRawResponse());
     }
 
     internal virtual async Task<ClientResult<ListQueryPage<T>>> GetListQueryPageAsync<T, U>(Func<Task<ClientResult<U>>> internalAsyncFunc)
@@ -714,7 +726,7 @@ public partial class AssistantClient
         where U : class
     {
         ClientResult<U> internalResult = await internalAsyncFunc.Invoke().ConfigureAwait(false);
-        ListQueryPage<T> convertedValue = ListQueryPage.Create(internalResult.Value) as ListQueryPage<T>;
-        return ClientResult.FromValue(convertedValue, internalResult.GetRawResponse());
+        ListQueryPage<T>? convertedValue = ListQueryPage.Create(internalResult.Value) as ListQueryPage<T>;
+        return ClientResult.FromValue(convertedValue!, internalResult.GetRawResponse());
     }
 }

--- a/.dotnet/src/Custom/Assistants/AssistantClient.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantClient.cs
@@ -3,7 +3,6 @@ using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/AssistantCreationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantCreationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/AssistantCreationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantCreationOptions.cs
@@ -13,16 +13,16 @@ public partial class AssistantCreationOptions
     /// <summary>
     /// An optional display name for the assistant.
     /// </summary>
-    public string Name { get; set; }
+    public string? Name { get; set; }
     /// <summary>
     /// A description to associate with the assistant.
     /// </summary>
-    public string Description { get; set; }
+    public string? Description { get; set; }
 
     /// <summary>
     /// Default instructions for the assistant to use when creating messages.
     /// </summary>
-    public string Instructions { get; set; }
+    public string? DefaultInstructions { get; set; }
 
     /// <summary>
     /// A collection of default tool definitions to enable for the assistant. Available tools include:

--- a/.dotnet/src/Custom/Assistants/AssistantModificationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantModificationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/AssistantModificationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantModificationOptions.cs
@@ -13,22 +13,22 @@ public partial class AssistantModificationOptions
     /// <summary>
     /// The new model that the assistant should use when creating messages.
     /// </summary>
-    public string Model { get; }
+    public string? Model { get; }
 
     /// <summary>
     /// A new, friendly name for the assistant. Its <see cref="Assistant.Id"/> will remain unchanged.
     /// </summary>
-    public string Name { get; }
+    public string? Name { get; }
 
     /// <summary>
     /// A new description to associate with the assistant.
     /// </summary>
-    public string Description { get; }
+    public string? Description { get; }
 
     /// <summary>
     /// New, default instructions for the assistant to use when creating messages.
     /// </summary>
-    public string Instructions { get; }
+    public string? Instructions { get; }
 
     /// <summary>
     /// A new collection of default tool definitions to enable for the assistant. Available tools include:

--- a/.dotnet/src/Custom/Assistants/AssistantThread.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantThread.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+
 namespace OpenAI.Assistants;
 
 public partial class AssistantThread

--- a/.dotnet/src/Custom/Assistants/CodeInterpreterToolDefinition.cs
+++ b/.dotnet/src/Custom/Assistants/CodeInterpreterToolDefinition.cs
@@ -11,7 +11,7 @@ public partial class CodeInterpreterToolDefinition : ToolDefinition
 
     internal static CodeInterpreterToolDefinition DeserializeCodeInterpreterToolDefinition(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/CodeInterpreterToolDefinition.cs
+++ b/.dotnet/src/Custom/Assistants/CodeInterpreterToolDefinition.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/CodeInterpreterToolInfo.cs
+++ b/.dotnet/src/Custom/Assistants/CodeInterpreterToolInfo.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/FunctionToolDefinition.cs
+++ b/.dotnet/src/Custom/Assistants/FunctionToolDefinition.cs
@@ -11,14 +11,14 @@ namespace OpenAI.Assistants;
 
 public partial class FunctionToolDefinition : ToolDefinition
 {
-    public required string Name { get; set; }
-    public string Description { get; set; }
-    public BinaryData Parameters { get; set; }
+    public required string FunctionName { get; init; }
+    public string? Description { get; init; }
+    public BinaryData? Parameters { get; init; }
 
     [SetsRequiredMembers]
-    public FunctionToolDefinition(string name, string description = null, BinaryData parameters = null)
+    public FunctionToolDefinition(string name, string? description = null, BinaryData? parameters = null)
     {
-        Name = name;
+        FunctionName = name;
         Description = description;
         Parameters = parameters;
     }
@@ -28,7 +28,7 @@ public partial class FunctionToolDefinition : ToolDefinition
 
     internal static FunctionToolDefinition DeserializeFunctionToolDefinition(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 
@@ -74,7 +74,7 @@ public partial class FunctionToolDefinition : ToolDefinition
         writer.WriteString("type"u8, "function"u8);
         writer.WritePropertyName("function"u8);
         writer.WriteStartObject();
-        writer.WriteString("name"u8, Name);
+        writer.WriteString("name"u8, FunctionName);
         if (Optional.IsDefined(Description))
         {
             writer.WriteString("description"u8, Description);

--- a/.dotnet/src/Custom/Assistants/FunctionToolDefinition.cs
+++ b/.dotnet/src/Custom/Assistants/FunctionToolDefinition.cs
@@ -1,11 +1,7 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Assistants;
 

--- a/.dotnet/src/Custom/Assistants/FunctionToolInfo.cs
+++ b/.dotnet/src/Custom/Assistants/FunctionToolInfo.cs
@@ -1,10 +1,6 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Assistants;
 

--- a/.dotnet/src/Custom/Assistants/FunctionToolInfo.cs
+++ b/.dotnet/src/Custom/Assistants/FunctionToolInfo.cs
@@ -10,13 +10,13 @@ namespace OpenAI.Assistants;
 
 public partial class FunctionToolInfo : ToolInfo
 {
-    public string Name { get; }
+    public string FunctionName { get; }
     public string Description { get; }
     public BinaryData Parameters { get; }
 
     internal FunctionToolInfo(string name, string description, BinaryData parameters)
     {
-        Name = name;
+        FunctionName = name;
         Description = description;
         Parameters = parameters;
     }
@@ -68,7 +68,7 @@ public partial class FunctionToolInfo : ToolInfo
         writer.WriteString("type"u8, "function"u8);
         writer.WritePropertyName("function"u8);
         writer.WriteStartObject();
-        writer.WriteString("name"u8, Name);
+        writer.WriteString("name"u8, FunctionName);
         if (Optional.IsDefined(Description))
         {
             writer.WriteString("description"u8, Description);

--- a/.dotnet/src/Custom/Assistants/ListQueryPage.cs
+++ b/.dotnet/src/Custom/Assistants/ListQueryPage.cs
@@ -1,6 +1,4 @@
-using OpenAI.ClientShared.Internal;
 using System;
-using System.ClientModel.Internal;
 
 using System.Collections;
 using System.Collections.Generic;

--- a/.dotnet/src/Custom/Assistants/MessageContent.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/MessageContent.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/MessageContent.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/MessageContent.Serialization.cs
@@ -62,7 +62,7 @@ public abstract partial class MessageContent :  IJsonModel<MessageContent>
 
     internal static MessageContent DeserializeMessageContent(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/MessageCreationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/MessageCreationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/MessageImageFileContent.cs
+++ b/.dotnet/src/Custom/Assistants/MessageImageFileContent.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/MessageImageFileContent.cs
+++ b/.dotnet/src/Custom/Assistants/MessageImageFileContent.cs
@@ -25,7 +25,7 @@ public class MessageImageFileContent : MessageContent
 
     internal static MessageContent DeserializeMessageImageFileContent(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/MessageTextContent.cs
+++ b/.dotnet/src/Custom/Assistants/MessageTextContent.cs
@@ -32,7 +32,7 @@ public class MessageTextContent : MessageContent
 
     internal static MessageContent DeserializeMessageTextContent(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/MessageTextContent.cs
+++ b/.dotnet/src/Custom/Assistants/MessageTextContent.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;

--- a/.dotnet/src/Custom/Assistants/RequiredFunctionToolCall.cs
+++ b/.dotnet/src/Custom/Assistants/RequiredFunctionToolCall.cs
@@ -6,13 +6,13 @@ namespace OpenAI.Assistants;
 
 public partial class RequiredFunctionToolCall : RequiredToolCall
 {
-    public string Name { get; }
+    public string FunctionName { get; }
     public string Arguments { get; }
 
     internal RequiredFunctionToolCall(string id, string name, string arguments)
         : base(id)
     {
-        Name = name;
+        FunctionName = name;
         Arguments = arguments;
     }
 

--- a/.dotnet/src/Custom/Assistants/RequiredFunctionToolCall.cs
+++ b/.dotnet/src/Custom/Assistants/RequiredFunctionToolCall.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/RequiredToolCall.cs
+++ b/.dotnet/src/Custom/Assistants/RequiredToolCall.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/RetrievalToolDefinition.cs
+++ b/.dotnet/src/Custom/Assistants/RetrievalToolDefinition.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/RetrievalToolDefinition.cs
+++ b/.dotnet/src/Custom/Assistants/RetrievalToolDefinition.cs
@@ -11,7 +11,7 @@ public partial class RetrievalToolDefinition : ToolDefinition
 
     internal static RetrievalToolDefinition DeserializeRetrievalToolDefinition(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/RetrievalToolInfo.cs
+++ b/.dotnet/src/Custom/Assistants/RetrievalToolInfo.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/RunCreationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/RunCreationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/RunError.cs
+++ b/.dotnet/src/Custom/Assistants/RunError.cs
@@ -1,5 +1,3 @@
-using OpenAI.Chat;
-
 namespace OpenAI.Assistants;
 
 public partial class RunError

--- a/.dotnet/src/Custom/Assistants/RunModificationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/RunModificationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/RunRequiredAction.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/RunRequiredAction.Serialization.cs
@@ -8,36 +8,16 @@ namespace OpenAI.Assistants;
 public abstract partial class RunRequiredAction :  IJsonModel<IList<RunRequiredAction>>
 {
     IList<RunRequiredAction> IJsonModel<IList<RunRequiredAction>>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<IList<RunRequiredAction>>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(RunRequiredAction)} does not support '{format}' format.");
-        }
-        using JsonDocument document = JsonDocument.ParseValue(ref reader);
-        return DeserializeRunRequiredActions(document.RootElement, options);
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeRunRequiredActions, ref reader, options);
 
     IList<RunRequiredAction> IPersistableModel<IList<RunRequiredAction>>.Create(BinaryData data, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<IList<RunRequiredAction>>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                {
-                    using JsonDocument document = JsonDocument.Parse(data);
-                    return DeserializeRunRequiredActions(document.RootElement, options);
-                }
-            default:
-                throw new FormatException($"The model {nameof(RunRequiredAction)} does not support '{options.Format}' format.");
-        }
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeRunRequiredActions, data, options);
 
     string IPersistableModel<IList<RunRequiredAction>>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
     void IJsonModel<IList<RunRequiredAction>>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat<IList<RunRequiredAction>,RunRequiredAction>(this, options);
         writer.WriteStartObject();
         WriteDerived(writer, options);
         writer.WriteEndObject();
@@ -45,6 +25,7 @@ public abstract partial class RunRequiredAction :  IJsonModel<IList<RunRequiredA
 
     BinaryData IPersistableModel<IList<RunRequiredAction>>.Write(ModelReaderWriterOptions options)
     {
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat<IList<RunRequiredAction>,RunRequiredAction>(this, options);
         var format = options.Format == "W" ? ((IPersistableModel<IList<RunRequiredAction>>)this).GetFormatFromOptions(options) : options.Format;
 
         switch (format)

--- a/.dotnet/src/Custom/Assistants/RunRequiredAction.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/RunRequiredAction.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;

--- a/.dotnet/src/Custom/Assistants/RunRequiredAction.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/RunRequiredAction.Serialization.cs
@@ -63,7 +63,7 @@ public abstract partial class RunRequiredAction :  IJsonModel<IList<RunRequiredA
 
     internal static IList<RunRequiredAction> DeserializeRunRequiredActions(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/RunRequiredAction.cs
+++ b/.dotnet/src/Custom/Assistants/RunRequiredAction.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenAI.Assistants;
 
 public partial class RunRequiredAction

--- a/.dotnet/src/Custom/Assistants/TextContentAnnotation.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentAnnotation.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/TextContentAnnotation.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentAnnotation.Serialization.cs
@@ -7,36 +7,16 @@ namespace OpenAI.Assistants;
 public abstract partial class TextContentAnnotation :  IJsonModel<TextContentAnnotation>
 {
     TextContentAnnotation IJsonModel<TextContentAnnotation>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<TextContentAnnotation>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(TextContentAnnotation)} does not support '{format}' format.");
-        }
-        using JsonDocument document = JsonDocument.ParseValue(ref reader);
-        return DeserializeTextContentAnnotation(document.RootElement, options);
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeTextContentAnnotation, ref reader, options);
 
     TextContentAnnotation IPersistableModel<TextContentAnnotation>.Create(BinaryData data, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<TextContentAnnotation>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                {
-                    using JsonDocument document = JsonDocument.Parse(data);
-                    return DeserializeTextContentAnnotation(document.RootElement, options);
-                }
-            default:
-                throw new FormatException($"The model {nameof(TextContentAnnotation)} does not support '{options.Format}' format.");
-        }
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeTextContentAnnotation, data, options);
 
     string IPersistableModel<TextContentAnnotation>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
     void IJsonModel<TextContentAnnotation>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
         writer.WriteStartObject();
         WriteDerived(writer, options);
         writer.WriteEndObject();
@@ -44,15 +24,8 @@ public abstract partial class TextContentAnnotation :  IJsonModel<TextContentAnn
 
     BinaryData IPersistableModel<TextContentAnnotation>.Write(ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<TextContentAnnotation>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                return ModelReaderWriter.Write(this, options);
-            default:
-                throw new FormatException($"The model {nameof(TextContentAnnotation)} does not support '{options.Format}' format.");
-        }
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
     }
 
     internal static TextContentAnnotation DeserializeTextContentAnnotation(

--- a/.dotnet/src/Custom/Assistants/TextContentAnnotation.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentAnnotation.Serialization.cs
@@ -60,7 +60,7 @@ public abstract partial class TextContentAnnotation :  IJsonModel<TextContentAnn
 
     internal static TextContentAnnotation DeserializeTextContentAnnotation(
       JsonElement element,
-      ModelReaderWriterOptions options = null)
+      ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/TextContentFileCitationAnnotation.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentFileCitationAnnotation.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/TextContentFileCitationAnnotation.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentFileCitationAnnotation.cs
@@ -41,7 +41,7 @@ public class TextContentFileCitationAnnotation : TextContentAnnotation
 
     internal static TextContentFileCitationAnnotation DeserializeTextContentFileCitationAnnotation(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/TextContentFilePathAnnotation.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentFilePathAnnotation.cs
@@ -36,7 +36,7 @@ public class TextContentFilePathAnnotation : TextContentAnnotation
 
     internal static TextContentFilePathAnnotation DeserializeTextContentFilePathAnnotation(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/TextContentFilePathAnnotation.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentFilePathAnnotation.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/ThreadCreationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/ThreadCreationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/ThreadInitializationMessage.cs
+++ b/.dotnet/src/Custom/Assistants/ThreadInitializationMessage.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 

--- a/.dotnet/src/Custom/Assistants/ThreadInitializationMessage.cs
+++ b/.dotnet/src/Custom/Assistants/ThreadInitializationMessage.cs
@@ -8,9 +8,9 @@ namespace OpenAI.Assistants;
 
 public partial class ThreadInitializationMessage
 {
-    public required MessageRole Role { get; set; }
+    public required MessageRole Role { get; init; }
 
-    public required string Content { get; set; }
+    public required string Content { get; init; }
 
     /// <summary>
     /// A list of File IDs that the message should use.There can be a maximum of 10 files attached to a message. Useful

--- a/.dotnet/src/Custom/Assistants/ThreadRun.cs
+++ b/.dotnet/src/Custom/Assistants/ThreadRun.cs
@@ -13,9 +13,9 @@ public partial class ThreadRun
 
     public RunStatus Status { get; }
 
-    public IReadOnlyList<RunRequiredAction> RequiredActions { get; }
+    public IReadOnlyList<RunRequiredAction>? RequiredActions { get; }
 
-    public RunError LastError { get; }
+    public RunError? LastError { get; }
     public DateTimeOffset? ExpiresAt { get; }
     public DateTimeOffset? StartedAt { get; } 
     public DateTimeOffset? CancelledAt { get; }
@@ -35,7 +35,7 @@ public partial class ThreadRun
     ///     <item><b>Values</b> can be a maximum of 512 characters in length.</item>
     /// </list>
     /// </remarks>
-    public IReadOnlyDictionary<string, string> Metadata { get; }
+    public IReadOnlyDictionary<string, string>? Metadata { get; }
     public RunTokenUsage Usage { get; }
 
     internal ThreadRun(Internal.Models.RunObject internalRun)

--- a/.dotnet/src/Custom/Assistants/ToolDefinition.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolDefinition.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/ToolDefinition.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolDefinition.Serialization.cs
@@ -7,36 +7,16 @@ namespace OpenAI.Assistants;
 public abstract partial class ToolDefinition :  IJsonModel<ToolDefinition>
 {
     ToolDefinition IJsonModel<ToolDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<ToolDefinition>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(ToolDefinition)} does not support '{format}' format.");
-        }
-        using JsonDocument document = JsonDocument.ParseValue(ref reader);
-        return DeserializeToolDefinition(document.RootElement, options);
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeToolDefinition, ref reader, options);
 
     ToolDefinition IPersistableModel<ToolDefinition>.Create(BinaryData data, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<ToolDefinition>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                {
-                    using JsonDocument document = JsonDocument.Parse(data);
-                    return DeserializeToolDefinition(document.RootElement, options);
-                }
-            default:
-                throw new FormatException($"The model {nameof(ToolDefinition)} does not support '{options.Format}' format.");
-        }
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeToolDefinition, data, options);
 
     string IPersistableModel<ToolDefinition>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
     void IJsonModel<ToolDefinition>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
         writer.WriteStartObject();
         WriteDerived(writer, options);
         writer.WriteEndObject();
@@ -44,15 +24,8 @@ public abstract partial class ToolDefinition :  IJsonModel<ToolDefinition>
 
     BinaryData IPersistableModel<ToolDefinition>.Write(ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<ToolDefinition>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                return ModelReaderWriter.Write(this, options);
-            default:
-                throw new FormatException($"The model {nameof(ToolDefinition)} does not support '{options.Format}' format.");
-        }
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
     }
 
     internal abstract void WriteDerived(Utf8JsonWriter writer, ModelReaderWriterOptions options);

--- a/.dotnet/src/Custom/Assistants/ToolDefinition.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolDefinition.Serialization.cs
@@ -62,7 +62,7 @@ public abstract partial class ToolDefinition :  IJsonModel<ToolDefinition>
 
     internal static ToolDefinition DeserializeToolDefinition(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/ToolInfo.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolInfo.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/ToolInfo.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolInfo.Serialization.cs
@@ -7,36 +7,16 @@ namespace OpenAI.Assistants;
 public abstract partial class ToolInfo :  IJsonModel<ToolInfo>
 {
     ToolInfo IJsonModel<ToolInfo>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<ToolInfo>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(ToolInfo)} does not support '{format}' format.");
-        }
-        using JsonDocument document = JsonDocument.ParseValue(ref reader);
-        return DeserializeToolInfo(document.RootElement, options);
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeToolInfo, ref reader, options);
 
     ToolInfo IPersistableModel<ToolInfo>.Create(BinaryData data, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<ToolInfo>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                {
-                    using JsonDocument document = JsonDocument.Parse(data);
-                    return DeserializeToolInfo(document.RootElement, options);
-                }
-            default:
-                throw new FormatException($"The model {nameof(ToolInfo)} does not support '{options.Format}' format.");
-        }
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeToolInfo, data, options);
 
     string IPersistableModel<ToolInfo>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
     void IJsonModel<ToolInfo>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
         writer.WriteStartObject();
         WriteDerived(writer, options);
         writer.WriteEndObject();
@@ -44,15 +24,8 @@ public abstract partial class ToolInfo :  IJsonModel<ToolInfo>
 
     BinaryData IPersistableModel<ToolInfo>.Write(ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<ToolInfo>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                return ModelReaderWriter.Write(this, options);
-            default:
-                throw new FormatException($"The model {nameof(ToolInfo)} does not support '{options.Format}' format.");
-        }
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
     }
 
     internal abstract void WriteDerived(Utf8JsonWriter writer, ModelReaderWriterOptions options);

--- a/.dotnet/src/Custom/Assistants/ToolInfo.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolInfo.Serialization.cs
@@ -62,7 +62,7 @@ public abstract partial class ToolInfo :  IJsonModel<ToolInfo>
 
     internal static ToolInfo DeserializeToolInfo(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/ToolOutput.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolOutput.Serialization.cs
@@ -7,36 +7,16 @@ namespace OpenAI.Assistants;
 public partial class ToolOutput :  IJsonModel<ToolOutput>
 {
     ToolOutput IJsonModel<ToolOutput>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<ToolOutput>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(ToolOutput)} does not support '{format}' format.");
-        }
-        using JsonDocument document = JsonDocument.ParseValue(ref reader);
-        return DeserializeToolOutput(document.RootElement, options);
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeToolOutput, ref reader, options);
 
     ToolOutput IPersistableModel<ToolOutput>.Create(BinaryData data, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<ToolOutput>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                {
-                    using JsonDocument document = JsonDocument.Parse(data);
-                    return DeserializeToolOutput(document.RootElement, options);
-                }
-            default:
-                throw new FormatException($"The model {nameof(ToolOutput)} does not support '{options.Format}' format.");
-        }
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeToolOutput, data, options);
 
     string IPersistableModel<ToolOutput>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
     void IJsonModel<ToolOutput>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
         writer.WriteStartObject();
         if (Optional.IsDefined(Id))
         {
@@ -51,15 +31,8 @@ public partial class ToolOutput :  IJsonModel<ToolOutput>
 
     BinaryData IPersistableModel<ToolOutput>.Write(ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<ToolOutput>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                return ModelReaderWriter.Write(this, options);
-            default:
-                throw new FormatException($"The model {nameof(ToolOutput)} does not support '{options.Format}' format.");
-        }
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
     }
 
     internal static ToolOutput DeserializeToolOutput(

--- a/.dotnet/src/Custom/Assistants/ToolOutput.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolOutput.Serialization.cs
@@ -1,10 +1,6 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Assistants;
 

--- a/.dotnet/src/Custom/Assistants/ToolOutput.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolOutput.Serialization.cs
@@ -68,7 +68,7 @@ public partial class ToolOutput :  IJsonModel<ToolOutput>
 
     internal static ToolOutput DeserializeToolOutput(
         JsonElement element,
-        ModelReaderWriterOptions options = null)
+        ModelReaderWriterOptions? options = default)
     {
         options ??= new ModelReaderWriterOptions("W");
 

--- a/.dotnet/src/Custom/Assistants/ToolOutput.cs
+++ b/.dotnet/src/Custom/Assistants/ToolOutput.cs
@@ -6,15 +6,15 @@ namespace OpenAI.Assistants;
 public partial class ToolOutput
 {
     [JsonPropertyName("tool_call_id")]
-    public required string Id { get; set; }
+    public required string Id { get; init; }
     [JsonPropertyName("output")]
-    public string Output { get; set; }
+    public string? Output { get; set; }
 
     public ToolOutput()
     { }
 
     [SetsRequiredMembers]
-    public ToolOutput(string toolCallId, string output = null)
+    public ToolOutput(string toolCallId, string? output = null)
     {
         Id = toolCallId;
         Output = output;

--- a/.dotnet/src/Custom/Audio/AudioClient.Protocol.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.Protocol.cs
@@ -11,12 +11,12 @@ public partial class AudioClient
 {
     /// <inheritdoc cref="Internal.Audio.CreateSpeech(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions options = null)
+    public virtual ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions? options = default)
         => Shim.CreateSpeech(content, options);
 
     /// <inheritdoc cref="Internal.Audio.CreateSpeechAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions options = null)
+    public virtual async Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions? options = default)
         => await Shim.CreateSpeechAsync(content, options).ConfigureAwait(false);
 
     /// <summary>
@@ -42,7 +42,7 @@ public partial class AudioClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult TranscribeAudio(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual ClientResult TranscribeAudio(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));
@@ -86,7 +86,7 @@ public partial class AudioClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> TranscribeAudioAsync(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual async Task<ClientResult> TranscribeAudioAsync(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));
@@ -130,7 +130,7 @@ public partial class AudioClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult TranslateAudio(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual ClientResult TranslateAudio(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));
@@ -174,7 +174,7 @@ public partial class AudioClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> TranslateAudioAsync(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual async Task<ClientResult> TranslateAudioAsync(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -31,7 +31,7 @@ public partial class AudioClient
     /// <param name="model">The model name for audio operations that the client should use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public AudioClient(string model, ApiKeyCredential credential = default, OpenAIClientOptions options = default)
+    public AudioClient(string model, ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         _clientConnector = new(model, credential, options);
     }
@@ -54,7 +54,7 @@ public partial class AudioClient
     public virtual ClientResult<BinaryData> GenerateSpeechFromText(
         string text,
         TextToSpeechVoice voice,
-        TextToSpeechOptions options = null)
+        TextToSpeechOptions? options = default)
     {
         Internal.Models.CreateSpeechRequest request = CreateInternalTtsRequest(text, voice, options);
         return Shim.CreateSpeech(request);
@@ -78,7 +78,7 @@ public partial class AudioClient
     public virtual Task<ClientResult<BinaryData>> GenerateSpeechFromTextAsync(
         string text,
         TextToSpeechVoice voice,
-        TextToSpeechOptions options = null)
+        TextToSpeechOptions? options = default)
     {
         Internal.Models.CreateSpeechRequest request = CreateInternalTtsRequest(text, voice, options);
         return Shim.CreateSpeechAsync(request);
@@ -86,14 +86,14 @@ public partial class AudioClient
 
     // convenience method - sync; Stream overload
     // TODO: add refdoc comment
-    public virtual ClientResult<AudioTranscription> TranscribeAudio(Stream audio, string fileName, AudioTranscriptionOptions options = null)
+    public virtual ClientResult<AudioTranscription> TranscribeAudio(Stream audio, string fileName, AudioTranscriptionOptions? options = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model!);
 
         ClientResult result = TranscribeAudio(content, content.ContentType);
 
@@ -106,14 +106,14 @@ public partial class AudioClient
 
     // convenience method - sync
     // TODO: add refdoc comment
-    public virtual ClientResult<AudioTranscription> TranscribeAudio(BinaryData audio, string fileName, AudioTranscriptionOptions options = null)
+    public virtual ClientResult<AudioTranscription> TranscribeAudio(BinaryData audio, string fileName, AudioTranscriptionOptions? options = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model!);
 
         ClientResult result = TranscribeAudio(content, content.ContentType);
 
@@ -126,7 +126,7 @@ public partial class AudioClient
 
     // convenience method - async
     // TODO: add refdoc comment
-    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(Stream audio, string filename, AudioTranscriptionOptions options = null)
+    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(Stream audio, string filename, AudioTranscriptionOptions? options = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(filename, nameof(filename));
@@ -146,14 +146,14 @@ public partial class AudioClient
 
     // convenience method - async
     // TODO: add refdoc comment
-    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(BinaryData audio, string fileName, AudioTranscriptionOptions options = null)
+    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(BinaryData audio, string fileName, AudioTranscriptionOptions? options = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model!);
 
         ClientResult result = await TranscribeAudioAsync(content, content.ContentType).ConfigureAwait(false);
 
@@ -167,7 +167,7 @@ public partial class AudioClient
     private PipelineMessage CreateCreateTranscriptionRequest(BinaryContent content, string contentType, RequestOptions options)
     {
         PipelineMessage message = Shim.Pipeline.CreateMessage();
-        message.ResponseClassifier = ResponseErrorClassifier200;
+        message.ResponseClassifier = PipelineMessageClassifiers.ResponseErrorClassifier200;
 
         PipelineRequest request = message.Request;
         request.Method = "POST";
@@ -191,14 +191,14 @@ public partial class AudioClient
 
     // convenience method - sync; Stream overload
     // TODO: add refdoc comment
-    public virtual ClientResult<AudioTranslation> TranslateAudio(Stream audio, string fileName, AudioTranslationOptions options = null)
+    public virtual ClientResult<AudioTranslation> TranslateAudio(Stream audio, string fileName, AudioTranslationOptions? options = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model!);
 
         ClientResult result = TranslateAudio(content, content.ContentType);
 
@@ -211,14 +211,14 @@ public partial class AudioClient
 
     // convenience method - sync
     // TODO: add refdoc comment
-    public virtual ClientResult<AudioTranslation> TranslateAudio(BinaryData audio, string fileName, AudioTranslationOptions options = null)
+    public virtual ClientResult<AudioTranslation> TranslateAudio(BinaryData audio, string fileName, AudioTranslationOptions? options = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model!);
 
         ClientResult result = TranslateAudio(content, content.ContentType);
 
@@ -231,14 +231,14 @@ public partial class AudioClient
 
     // convenience method - async; Stream overload
     // TODO: add refdoc comment
-    public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(Stream audio, string fileName, AudioTranslationOptions options = null)
+    public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(Stream audio, string fileName, AudioTranslationOptions? options = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model!);
 
         ClientResult result = await TranslateAudioAsync(content, content.ContentType).ConfigureAwait(false);
 
@@ -251,14 +251,14 @@ public partial class AudioClient
 
     // convenience method - async
     // TODO: add refdoc comment
-    public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(BinaryData audio, string fileName, AudioTranslationOptions options = null)
+    public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(BinaryData audio, string fileName, AudioTranslationOptions? options = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
         Argument.AssertNotNull(fileName, nameof(fileName));
 
         options ??= new();
 
-        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model);
+        using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, fileName, _clientConnector.Model!);
 
         ClientResult result = await TranslateAudioAsync(content, content.ContentType).ConfigureAwait(false);
 
@@ -272,7 +272,7 @@ public partial class AudioClient
     private PipelineMessage CreateCreateTranslationRequest(BinaryContent content, string contentType, RequestOptions options)
     {
         PipelineMessage message = Shim.Pipeline.CreateMessage();
-        message.ResponseClassifier = ResponseErrorClassifier200;
+        message.ResponseClassifier = PipelineMessageClassifiers.ResponseErrorClassifier200;
 
         PipelineRequest request = message.Request;
         request.Method = "POST";
@@ -297,7 +297,7 @@ public partial class AudioClient
     private Internal.Models.CreateSpeechRequest CreateInternalTtsRequest(
         string input,
         TextToSpeechVoice voice,
-        TextToSpeechOptions options = null)
+        TextToSpeechOptions? options = default)
     {
         options ??= new();
         Internal.Models.CreateSpeechRequestResponseFormat? internalResponseFormat = null;
@@ -327,7 +327,4 @@ public partial class AudioClient
             options?.SpeedMultiplier,
             serializedAdditionalRawData: null);
     }
-
-    private static PipelineMessageClassifier _responseErrorClassifier200;
-    private static PipelineMessageClassifier ResponseErrorClassifier200 => _responseErrorClassifier200 ??= PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
 }

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -3,7 +3,6 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.IO;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/.dotnet/src/Custom/Audio/AudioTranscription.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscription.cs
@@ -7,19 +7,19 @@ namespace OpenAI.Audio;
 
 public partial class AudioTranscription
 {
-    public string Language { get; }
+    public string? Language { get; }
     public TimeSpan? Duration { get; }
     public string Text { get; }
-    public IReadOnlyList<TranscribedWord>? Words { get; }
-    public IReadOnlyList<TranscriptionSegment>? Segments { get; }
+    public IReadOnlyList<TranscribedWord> Words { get; }
+    public IReadOnlyList<TranscribedSegment> Segments { get; }
 
-    internal AudioTranscription(string language, TimeSpan? duration, string text, IReadOnlyList<TranscribedWord> words, IReadOnlyList<TranscriptionSegment> segments)
+    internal AudioTranscription(string? language, TimeSpan? duration, string? text, IReadOnlyList<TranscribedWord>? words, IReadOnlyList<TranscribedSegment>? segments)
     {
         Language = language;
         Duration = duration;
-        Text = text;
-        Words = words;
-        Segments = segments;
+        Text = text!;
+        Words = words ?? [];
+        Segments = segments ?? [];
     }
 
     internal static AudioTranscription Deserialize(BinaryData content)
@@ -30,11 +30,11 @@ public partial class AudioTranscription
 
     internal static AudioTranscription DeserializeAudioTranscription(JsonElement element, ModelReaderWriterOptions? options = default)
     {
-        string language = null;
+        string? language = null;
         TimeSpan? duration = null;
-        string text = null;
-        List<TranscribedWord> words = null;
-        List<TranscriptionSegment> segments = null;
+        string? text = null;
+        List<TranscribedWord>? words = null;
+        List<TranscribedSegment>? segments = null;
 
         foreach (JsonProperty topLevelProperty in element.EnumerateObject())
         {
@@ -67,7 +67,7 @@ public partial class AudioTranscription
                 segments = [];
                 foreach (JsonElement segmentElement in topLevelProperty.Value.EnumerateArray())
                 {
-                    segments.Add(TranscriptionSegment.DeserializeTranscriptionSegment(segmentElement, options));
+                    segments.Add(TranscribedSegment.DeserializeTranscribedSegment(segmentElement, options));
                 }
                 continue;
             }

--- a/.dotnet/src/Custom/Audio/AudioTranscription.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscription.cs
@@ -10,8 +10,8 @@ public partial class AudioTranscription
     public string Language { get; }
     public TimeSpan? Duration { get; }
     public string Text { get; }
-    public IReadOnlyList<TranscribedWord> Words { get; }
-    public IReadOnlyList<TranscriptionSegment> Segments { get; }
+    public IReadOnlyList<TranscribedWord>? Words { get; }
+    public IReadOnlyList<TranscriptionSegment>? Segments { get; }
 
     internal AudioTranscription(string language, TimeSpan? duration, string text, IReadOnlyList<TranscribedWord> words, IReadOnlyList<TranscriptionSegment> segments)
     {
@@ -28,7 +28,7 @@ public partial class AudioTranscription
         return DeserializeAudioTranscription(responseDocument.RootElement);
     }
 
-    internal static AudioTranscription DeserializeAudioTranscription(JsonElement element, ModelReaderWriterOptions options = default)
+    internal static AudioTranscription DeserializeAudioTranscription(JsonElement element, ModelReaderWriterOptions? options = default)
     {
         string language = null;
         TimeSpan? duration = null;

--- a/.dotnet/src/Custom/Audio/AudioTranscriptionFormat.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscriptionFormat.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace OpenAI.Audio;
 
 public enum AudioTranscriptionFormat

--- a/.dotnet/src/Custom/Audio/AudioTranslation.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranslation.cs
@@ -19,7 +19,7 @@ public partial class AudioTranslation
         return DeserializeAudioTranslation(responseDocument.RootElement);
     }
 
-    internal static AudioTranslation DeserializeAudioTranslation(JsonElement element, ModelReaderWriterOptions options = default)
+    internal static AudioTranslation DeserializeAudioTranslation(JsonElement element, ModelReaderWriterOptions? options = default)
     {
         string text = null;
 

--- a/.dotnet/src/Custom/Audio/AudioTranslation.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranslation.cs
@@ -8,9 +8,10 @@ public partial class AudioTranslation
 {
     public string Text { get; }
 
-    internal AudioTranslation(string text)
+    internal AudioTranslation(string? text)
     {
-        Text = text;
+        Argument.AssertNotNull(text, nameof(text));
+        Text = text!;
     }
 
     internal static AudioTranslation Deserialize(BinaryData content)
@@ -21,7 +22,7 @@ public partial class AudioTranslation
 
     internal static AudioTranslation DeserializeAudioTranslation(JsonElement element, ModelReaderWriterOptions? options = default)
     {
-        string text = null;
+        string? text = null;
 
         foreach (JsonProperty property in element.EnumerateObject())
         {

--- a/.dotnet/src/Custom/Audio/AudioTranslationOptions.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranslationOptions.cs
@@ -6,9 +6,9 @@ namespace OpenAI.Audio;
 
 public partial class AudioTranslationOptions
 {
-    public string Prompt { get; set;  }
-    public AudioTranscriptionFormat? ResponseFormat { get; set; }
-    public float? Temperature { get; set; }
+    public string? Prompt { get; init;  }
+    public AudioTranscriptionFormat? ResponseFormat { get; init; }
+    public float? Temperature { get; init; }
 
     internal MultipartFormDataBinaryContent ToMultipartContent(Stream fileStream, string fileName, string model)
     {

--- a/.dotnet/src/Custom/Audio/TranscribedSegment.cs
+++ b/.dotnet/src/Custom/Audio/TranscribedSegment.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 namespace OpenAI.Audio;
 
-public readonly partial struct TranscriptionSegment
+public readonly partial struct TranscribedSegment
 {
     public int Id { get; }
     public int SeekOffset { get; }
@@ -18,7 +18,7 @@ public readonly partial struct TranscriptionSegment
     public float CompressionRatio { get; }
     public float NoSpeechProbability { get; }
 
-    internal TranscriptionSegment(int id, int seekOffset, TimeSpan start, TimeSpan end, string text, IReadOnlyList<int> tokenIds, float temperature, float averageLogProbability, float compressionRatio, float noSpeechProbability)
+    internal TranscribedSegment(int id, int seekOffset, TimeSpan start, TimeSpan end, string text, IReadOnlyList<int> tokenIds, float temperature, float averageLogProbability, float compressionRatio, float noSpeechProbability)
     {
         Id = id;
         SeekOffset = seekOffset;
@@ -32,7 +32,7 @@ public readonly partial struct TranscriptionSegment
         NoSpeechProbability = noSpeechProbability;
     }
 
-    internal static TranscriptionSegment DeserializeTranscriptionSegment(JsonElement element, ModelReaderWriterOptions? options = default)
+    internal static TranscribedSegment DeserializeTranscribedSegment(JsonElement element, ModelReaderWriterOptions? options = default)
     {
         int id = 0;
         int seekOffset = 0;
@@ -103,6 +103,6 @@ public readonly partial struct TranscriptionSegment
             }
         }
 
-        return new TranscriptionSegment(id, seekOffset, start, end, text, tokenIds, temperature, averageLogProbability, compressionRatio, noSpeechProbability);
+        return new TranscribedSegment(id, seekOffset, start, end, text, tokenIds, temperature, averageLogProbability, compressionRatio, noSpeechProbability);
     }
 }

--- a/.dotnet/src/Custom/Audio/TranscribedWord.cs
+++ b/.dotnet/src/Custom/Audio/TranscribedWord.cs
@@ -17,7 +17,7 @@ public readonly partial struct TranscribedWord
         End = end;
     }
 
-    internal static TranscribedWord DeserializeTranscribedWord(JsonElement element, ModelReaderWriterOptions options = default)
+    internal static TranscribedWord DeserializeTranscribedWord(JsonElement element, ModelReaderWriterOptions? options = default)
     {
         string word = null;
         TimeSpan? start = null;

--- a/.dotnet/src/Custom/Audio/TranscriptionSegment.cs
+++ b/.dotnet/src/Custom/Audio/TranscriptionSegment.cs
@@ -2,7 +2,6 @@ using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Threading;
 
 namespace OpenAI.Audio;
 

--- a/.dotnet/src/Custom/Audio/TranscriptionSegment.cs
+++ b/.dotnet/src/Custom/Audio/TranscriptionSegment.cs
@@ -33,7 +33,7 @@ public readonly partial struct TranscriptionSegment
         NoSpeechProbability = noSpeechProbability;
     }
 
-    internal static TranscriptionSegment DeserializeTranscriptionSegment(JsonElement element, ModelReaderWriterOptions options = default)
+    internal static TranscriptionSegment DeserializeTranscriptionSegment(JsonElement element, ModelReaderWriterOptions? options = default)
     {
         int id = 0;
         int seekOffset = 0;

--- a/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
@@ -1,6 +1,10 @@
-﻿using System.ClientModel;
+﻿using System;
+using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace OpenAI.Chat;
@@ -10,11 +14,36 @@ public partial class ChatClient
 {
     /// <inheritdoc cref="Internal.Chat.CreateChatCompletion(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult CompleteChat(BinaryContent content, RequestOptions options = null)
+    public virtual ClientResult CompleteChat(BinaryContent content, RequestOptions? options = default)
         => Shim.CreateChatCompletion(content, options);
 
     /// <inheritdoc cref="Internal.Chat.CreateChatCompletionAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> CompleteChatAsync(BinaryContent content, RequestOptions options = null)
+    public virtual async Task<ClientResult> CompleteChatAsync(BinaryContent content, RequestOptions? options = default)
         => await Shim.CreateChatCompletionAsync(content, options).ConfigureAwait(false);
+
+    private PipelineMessage CreateCustomRequestMessage(BinaryContent content, bool? stream = null, RequestOptions? options = default)
+    {
+        options ??= new();
+
+        PipelineMessage message = Shim.Pipeline.CreateMessage();
+        message.ResponseClassifier = PipelineMessageClassifiers.ResponseErrorClassifier200;
+        if (stream is not null)
+        {
+            message.BufferResponse = !stream.Value;
+        }
+        PipelineRequest request = message.Request;
+        request.Method = "POST";
+        UriBuilder uriBuilder = new(_clientConnector.Endpoint.AbsoluteUri);
+        StringBuilder path = new();
+        path.Append("/chat/completions");
+        uriBuilder.Path += path.ToString();
+        request.Uri = uriBuilder.Uri;
+        request.Headers.Set("Accept", "application/json");
+        request.Headers.Set("Content-Type", "application/json");
+        request.Content = content;
+
+        message.Apply(options);
+        return message;
+    }
 }

--- a/.dotnet/src/Custom/Chat/ChatClient.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace OpenAI.Chat;

--- a/.dotnet/src/Custom/Chat/ChatClient.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.cs
@@ -29,7 +29,7 @@ public partial class ChatClient
     /// <param name="model">The model name for chat completions that the client should use.</param>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public ChatClient(string model, ApiKeyCredential credential = default, OpenAIClientOptions options = null)
+    public ChatClient(string model, ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         _clientConnector = new(model, credential, options);
     }
@@ -40,7 +40,7 @@ public partial class ChatClient
     /// <param name="message"> The user message to provide as a prompt for chat completion. </param>
     /// <param name="options"> Additional options for the chat completion request. </param>
     /// <returns> A result for a single chat completion. </returns>
-     public virtual ClientResult<ChatCompletion> CompleteChat(string message, ChatCompletionOptions options = null)
+     public virtual ClientResult<ChatCompletion> CompleteChat(string message, ChatCompletionOptions? options = default)
          => CompleteChat(new List<ChatRequestMessage>() { new ChatRequestUserMessage(message) }, options);
 
     /// <summary>
@@ -49,7 +49,7 @@ public partial class ChatClient
     /// <param name="message"> The user message to provide as a prompt for chat completion. </param>
     /// <param name="options"> Additional options for the chat completion request. </param>
     /// <returns> A result for a single chat completion. </returns>
-     public virtual Task<ClientResult<ChatCompletion>> CompleteChatAsync(string message, ChatCompletionOptions options = null)
+     public virtual Task<ClientResult<ChatCompletion>> CompleteChatAsync(string message, ChatCompletionOptions? options = default)
         => CompleteChatAsync(
              new List<ChatRequestMessage>() { new ChatRequestUserMessage(message) }, options);
 
@@ -61,7 +61,7 @@ public partial class ChatClient
     /// <returns> A result for a single chat completion. </returns>
     public virtual ClientResult<ChatCompletion> CompleteChat(
         IEnumerable<ChatRequestMessage> messages,
-        ChatCompletionOptions options = null)
+        ChatCompletionOptions? options = default)
     {
         Internal.Models.CreateChatCompletionRequest request = CreateInternalRequest(messages, options); 
         ClientResult<Internal.Models.CreateChatCompletionResponse> response = Shim.CreateChatCompletion(request);
@@ -77,7 +77,7 @@ public partial class ChatClient
     /// <returns> A result for a single chat completion. </returns>
     public virtual async Task<ClientResult<ChatCompletion>> CompleteChatAsync(
         IEnumerable<ChatRequestMessage> messages,
-        ChatCompletionOptions options = null)
+        ChatCompletionOptions? options = default)
     {
         Internal.Models.CreateChatCompletionRequest request = CreateInternalRequest(messages, options);
         ClientResult<Internal.Models.CreateChatCompletionResponse> response = await Shim.CreateChatCompletionAsync(request).ConfigureAwait(false);
@@ -93,12 +93,11 @@ public partial class ChatClient
     ///     The number of independent, alternative response choices that should be generated.
     /// </param>
     /// <param name="options"> Additional options for the chat completion request. </param>
-    /// <param name="cancellationToken"> The cancellation token for the operation. </param>
     /// <returns> A result for a single chat completion. </returns>
     public virtual ClientResult<ChatCompletionCollection> CompleteChat(
         IEnumerable<ChatRequestMessage> messages,
         int choiceCount,
-        ChatCompletionOptions options = null)
+        ChatCompletionOptions? options = default)
     {
         Internal.Models.CreateChatCompletionRequest request = CreateInternalRequest(messages, options, choiceCount);
         ClientResult<Internal.Models.CreateChatCompletionResponse> response = Shim.CreateChatCompletion(request);
@@ -122,7 +121,7 @@ public partial class ChatClient
     public virtual async Task<ClientResult<ChatCompletionCollection>> CompleteChatAsync(
         IEnumerable<ChatRequestMessage> messages,
         int choiceCount,
-        ChatCompletionOptions options = null)
+        ChatCompletionOptions? options = default)
     {
         Internal.Models.CreateChatCompletionRequest request = CreateInternalRequest(messages, options, choiceCount);
         ClientResult<Internal.Models.CreateChatCompletionResponse> response = await Shim.CreateChatCompletionAsync(request).ConfigureAwait(false);
@@ -150,7 +149,7 @@ public partial class ChatClient
    public virtual StreamingClientResult<StreamingChatUpdate> CompleteChatStreaming(
         string message,
         int? choiceCount = null,
-        ChatCompletionOptions options = null)
+        ChatCompletionOptions? options = default)
         => CompleteChatStreaming(
             new List<ChatRequestMessage> { new ChatRequestUserMessage(message) },
             choiceCount,
@@ -172,7 +171,7 @@ public partial class ChatClient
     public virtual Task<StreamingClientResult<StreamingChatUpdate>> CompleteChatStreamingAsync(
         string message,
         int? choiceCount = null,
-        ChatCompletionOptions options = null)
+        ChatCompletionOptions? options = default)
     => CompleteChatStreamingAsync(
         new List<ChatRequestMessage> { new ChatRequestUserMessage(message) },
         choiceCount,
@@ -191,14 +190,13 @@ public partial class ChatClient
     ///     The number of independent, alternative choices that the chat completion request should generate.
     /// </param>
     /// <param name="options"> Additional options for the chat completion request. </param>
-    /// <param name="cancellationToken"> The cancellation token for the operation. </param>
     /// <returns> A streaming result with incremental chat completion updates. </returns>
     public virtual StreamingClientResult<StreamingChatUpdate> CompleteChatStreaming(
         IEnumerable<ChatRequestMessage> messages,
         int? choiceCount = null,
-        ChatCompletionOptions options = null)
+        ChatCompletionOptions? options = default)
     {
-        PipelineMessage requestMessage = CreateCustomRequestMessage(messages, choiceCount, options);
+        PipelineMessage requestMessage = CreateCustomRequestMessage(messages, choiceCount, stream: true, options);
         requestMessage.BufferResponse = false;
         Shim.Pipeline.Send(requestMessage);
         PipelineResponse response = requestMessage.ExtractResponse();
@@ -234,12 +232,12 @@ public partial class ChatClient
     public virtual async Task<StreamingClientResult<StreamingChatUpdate>> CompleteChatStreamingAsync(
         IEnumerable<ChatRequestMessage> messages,
         int? choiceCount = null,
-        ChatCompletionOptions options = null)
+        ChatCompletionOptions? options = default)
     {
-        PipelineMessage requestMessage = CreateCustomRequestMessage(messages, choiceCount, options);
+        PipelineMessage requestMessage = CreateCustomRequestMessage(messages, choiceCount, stream: true, options);
         requestMessage.BufferResponse = false;
         await Shim.Pipeline.SendAsync(requestMessage).ConfigureAwait(false);
-        PipelineResponse response = requestMessage.ExtractResponse();
+        PipelineResponse response = requestMessage.ExtractResponse()!;
 
         if (response.IsError)
         {
@@ -256,7 +254,7 @@ public partial class ChatClient
 
     private Internal.Models.CreateChatCompletionRequest CreateInternalRequest(
         IEnumerable<ChatRequestMessage> messages,
-        ChatCompletionOptions options = null,
+        ChatCompletionOptions? options = default,
         int? choiceCount = null,
         bool? stream = null)
     {
@@ -302,28 +300,10 @@ public partial class ChatClient
         );
     }
 
-    private PipelineMessage CreateCustomRequestMessage(IEnumerable<ChatRequestMessage> messages, int? choiceCount, ChatCompletionOptions options)
+    private PipelineMessage CreateCustomRequestMessage(IEnumerable<ChatRequestMessage> messages, int? choiceCount, bool stream, ChatCompletionOptions? options)
     {
         Internal.Models.CreateChatCompletionRequest internalRequest = CreateInternalRequest(messages, options, choiceCount, stream: true);
         BinaryContent content = BinaryContent.Create(internalRequest);
-
-        PipelineMessage message = Shim.Pipeline.CreateMessage();
-        message.ResponseClassifier = ResponseErrorClassifier200;
-        message.BufferResponse = false;
-        PipelineRequest request = message.Request;
-        request.Method = "POST";
-        UriBuilder uriBuilder = new(_clientConnector.Endpoint.AbsoluteUri);
-        StringBuilder path = new();
-        path.Append("/chat/completions");
-        uriBuilder.Path += path.ToString();
-        request.Uri = uriBuilder.Uri;
-        request.Headers.Set("Accept", "application/json");
-        request.Headers.Set("Content-Type", "application/json");
-        request.Content = content;
-
-        return message;
+        return CreateCustomRequestMessage(content, stream);
     }
-
-    private static PipelineMessageClassifier _responseErrorClassifier200;
-    private static PipelineMessageClassifier ResponseErrorClassifier200 => _responseErrorClassifier200 ??= PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
 }

--- a/.dotnet/src/Custom/Chat/ChatCompletion.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletion.cs
@@ -7,8 +7,8 @@ namespace OpenAI.Chat;
 /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponse"/>
 public class ChatCompletion
 {
-    private Internal.Models.CreateChatCompletionResponse _internalResponse;
-    private int _internalChoiceIndex;
+    private readonly Internal.Models.CreateChatCompletionResponse _internalResponse;
+    private readonly int _internalChoiceIndex;
 
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponse.Id"/>
     public string Id => _internalResponse.Id;
@@ -21,17 +21,17 @@ public class ChatCompletion
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponseChoice.FinishReason"/>
     public ChatFinishReason FinishReason { get; }
     /// <inheritdoc cref="Internal.Models.ChatCompletionResponseMessage.Content"/>
-    public ChatMessageContent Content { get; }
+    public ChatMessageContent? Content { get; }
     /// <inheritdoc cref="Internal.Models.ChatCompletionResponseMessage.ToolCalls"/>
-    public IReadOnlyList<ChatToolCall> ToolCalls { get; }
+    public IReadOnlyList<ChatToolCall>? ToolCalls { get; }
     /// <inheritdoc cref="Internal.Models.ChatCompletionResponseMessage.FunctionCall"/>
-    public ChatFunctionCall FunctionCall { get; }
+    public ChatFunctionCall? FunctionCall { get; }
     /// <inheritdoc cref="Internal.Models.ChatCompletionResponseMessage.Role"/>
     public ChatRole Role { get; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponseChoice.Logprobs"/>
-    public ChatLogProbabilityCollection LogProbabilities { get; }
+    public ChatLogProbabilityCollection? LogProbabilities { get; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponseChoice.Index"/>
-    public int Index => (int)_internalResponse.Choices[(int)_internalChoiceIndex].Index;
+    public int ChoiceIndex => (int)_internalResponse.Choices[(int)_internalChoiceIndex].Index;
 
     internal ChatCompletion(Internal.Models.CreateChatCompletionResponse internalResponse, int internalChoiceIndex)
     {

--- a/.dotnet/src/Custom/Chat/ChatCompletion.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletion.cs
@@ -1,4 +1,3 @@
-using OpenAI.ClientShared.Internal;
 using System;
 using System.Collections.Generic;
 

--- a/.dotnet/src/Custom/Chat/ChatCompletion.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletion.cs
@@ -22,13 +22,13 @@ public class ChatCompletion
     /// <inheritdoc cref="Internal.Models.ChatCompletionResponseMessage.Content"/>
     public ChatMessageContent? Content { get; }
     /// <inheritdoc cref="Internal.Models.ChatCompletionResponseMessage.ToolCalls"/>
-    public IReadOnlyList<ChatToolCall>? ToolCalls { get; }
+    public IReadOnlyList<ChatToolCall> ToolCalls { get; }
     /// <inheritdoc cref="Internal.Models.ChatCompletionResponseMessage.FunctionCall"/>
     public ChatFunctionCall? FunctionCall { get; }
     /// <inheritdoc cref="Internal.Models.ChatCompletionResponseMessage.Role"/>
     public ChatRole Role { get; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponseChoice.Logprobs"/>
-    public ChatLogProbabilityCollection? LogProbabilities { get; }
+    public ChatLogProbabilityCollection LogProbabilities { get; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionResponseChoice.Index"/>
     public int ChoiceIndex => (int)_internalResponse.Choices[(int)_internalChoiceIndex].Index;
 
@@ -73,9 +73,6 @@ public class ChatCompletion
         {
             FunctionCall = new(internalChoice.Message.FunctionCall.Name, internalChoice.Message.FunctionCall.Arguments);
         }
-        if (internalChoice.Logprobs != null)
-        {
-            LogProbabilities = ChatLogProbabilityCollection.FromInternalData(internalChoice.Logprobs);
-        }
+        LogProbabilities = ChatLogProbabilityCollection.FromInternalData(internalChoice.Logprobs);
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
@@ -39,13 +39,13 @@ public partial class ChatCompletionOptions
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.ToolChoice" />
     public ChatToolConstraint? ToolConstraint { get; set; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.User" />
-    public string User { get; set; }
+    public string? User { get; set; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Functions" />
     public IList<ChatFunctionDefinition> Functions { get; } = new ChangeTrackingList<ChatFunctionDefinition>();
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.FunctionCall" />
     public ChatFunctionConstraint? FunctionConstraint { get; set; }
 
-    internal BinaryData GetInternalStopSequences()
+    internal BinaryData? GetInternalStopSequences()
     {
         if (!Optional.IsCollectionDefined(StopSequences))
         {
@@ -73,7 +73,7 @@ public partial class ChatCompletionOptions
             {
                 Internal.Models.FunctionObject functionObject = new(
                     functionTool.Description,
-                    functionTool.Name,
+                    functionTool.FunctionName,
                     CreateInternalFunctionParameters(functionTool.Parameters),
                     serializedAdditionalRawData: null);
                 internalTools.Add(new(functionObject));
@@ -89,7 +89,7 @@ public partial class ChatCompletionOptions
         {
             Internal.Models.ChatCompletionFunctions internalFunction = new(
                 function.Description,
-                function.Name,
+                function.FunctionName,
                 CreateInternalFunctionParameters(function.Parameters),
                 serializedAdditionalRawData: null);
             internalFunctions.Add(internalFunction);

--- a/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
@@ -1,6 +1,4 @@
-using OpenAI.ClientShared.Internal;
 using System;
-using System.ClientModel.Internal;
 
 using System.Collections.Generic;
 using System.Text.Json;

--- a/.dotnet/src/Custom/Chat/ChatFunctionCall.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionCall.Serialization.cs
@@ -1,3 +1,4 @@
+using OpenAI.ClientShared.Internal;
 using System;
 using System.ClientModel.Primitives;
 using System.Text.Json;
@@ -6,20 +7,7 @@ namespace OpenAI.Chat;
 
 public partial class ChatFunctionCall :  IJsonModel<ChatFunctionCall>
 {
-    void IJsonModel<ChatFunctionCall>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
-    {
-        writer.WriteStartObject();
-        writer.WriteString("name"u8, FunctionName);
-        writer.WriteString("arguments"u8, Arguments);
-        writer.WriteEndObject();
-    }
-
     ChatFunctionCall IJsonModel<ChatFunctionCall>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-    {
-        throw new NotImplementedException();
-    }
-
-    BinaryData IPersistableModel<ChatFunctionCall>.Write(ModelReaderWriterOptions options)
     {
         throw new NotImplementedException();
     }
@@ -27,6 +15,21 @@ public partial class ChatFunctionCall :  IJsonModel<ChatFunctionCall>
     ChatFunctionCall IPersistableModel<ChatFunctionCall>.Create(BinaryData data, ModelReaderWriterOptions options)
     {
         throw new NotImplementedException();
+    }
+
+    BinaryData IPersistableModel<ChatFunctionCall>.Write(ModelReaderWriterOptions options)
+    {
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
+    }
+
+    void IJsonModel<ChatFunctionCall>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
+        writer.WriteStartObject();
+        writer.WriteString("name"u8, FunctionName);
+        writer.WriteString("arguments"u8, Arguments);
+        writer.WriteEndObject();
     }
 
     string IPersistableModel<ChatFunctionCall>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";

--- a/.dotnet/src/Custom/Chat/ChatFunctionCall.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionCall.Serialization.cs
@@ -1,9 +1,5 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace OpenAI.Chat;

--- a/.dotnet/src/Custom/Chat/ChatFunctionCall.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionCall.cs
@@ -24,11 +24,11 @@ public partial class ChatFunctionCall
     /// <summary>
     /// The name of the function being called by the model.
     /// </summary>
-    public required string FunctionName { get; set; }
+    public required string FunctionName { get; init; }
     /// <summary>
     /// The arguments to the function being called by the model.
     /// </summary>
-    public required string Arguments { get; set; }
+    public required string Arguments { get; init; }
     /// <summary>
     /// Creates a new instance of <see cref="ChatFunctionCall"/>.
     /// </summary>

--- a/.dotnet/src/Custom/Chat/ChatFunctionDefinition.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionDefinition.cs
@@ -11,12 +11,12 @@ public class ChatFunctionDefinition
     /// <summary>
     /// The name of the function.
     /// </summary>
-    public required string Name { get; set; }
+    public required string FunctionName { get; init; }
     /// <summary>
-    /// A friendly description of the function. This supplements <see cref="Name"/> in informing the model about when
+    /// A friendly description of the function. This supplements <see cref="FunctionName"/> in informing the model about when
     /// it should call the function.
     /// </summary>
-    public string Description { get; set; }
+    public string? Description { get; init; }
     /// <summary>
     /// The parameter information for the function, provided in JSON Schema format.
     /// </summary>
@@ -39,7 +39,7 @@ public class ChatFunctionDefinition
     /// })
     /// </code></para>
     /// </remarks>
-    public BinaryData Parameters { get; set; }
+    public BinaryData? Parameters { get; init; }
     /// <summary>
     /// Creates a new instance of <see cref="ChatFunctionDefinition"/>.
     /// </summary>
@@ -51,9 +51,9 @@ public class ChatFunctionDefinition
     /// <param name="description"> A description of the function's behavior or purpose. </param>
     /// <param name="parameters"> The parameter information for the function, in JSON Schema format. </param>
     [SetsRequiredMembers]
-    public ChatFunctionDefinition(string name, string description = null, BinaryData parameters = null)
+    public ChatFunctionDefinition(string name, string? description = null, BinaryData? parameters = null)
     {
-        Name = name;
+        FunctionName = name;
         Description = description;
         Parameters = parameters;
     }

--- a/.dotnet/src/Custom/Chat/ChatFunctionToolCall.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionToolCall.cs
@@ -1,5 +1,3 @@
-using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;

--- a/.dotnet/src/Custom/Chat/ChatFunctionToolCall.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionToolCall.cs
@@ -16,10 +16,10 @@ public class ChatFunctionToolCall : ChatToolCall
     /// <summary>
     /// Gets the <c>name</c> of the function.
     /// </summary>
-    public required string Name
+    public required string FunctionName
     {
         get => InternalToolCall.Name;
-        set => InternalToolCall.Name = value;
+        init => InternalToolCall.Name = value;
     }
 
     /// <summary>
@@ -28,7 +28,7 @@ public class ChatFunctionToolCall : ChatToolCall
     public required string Arguments
     {
         get => InternalToolCall.Arguments;
-        set => InternalToolCall.Arguments = value;
+        init => InternalToolCall.Arguments = value;
 
     }
     /// <summary>
@@ -53,7 +53,7 @@ public class ChatFunctionToolCall : ChatToolCall
         : this()
     {
         Id = toolCallId;
-        Name = functionName;
+        FunctionName = functionName;
         Arguments = arguments;
     }
 
@@ -62,7 +62,7 @@ public class ChatFunctionToolCall : ChatToolCall
         writer.WriteString("type"u8, "function"u8);
         writer.WritePropertyName("function"u8);
         writer.WriteStartObject();
-        writer.WriteString("name"u8, Name);
+        writer.WriteString("name"u8, FunctionName);
         writer.WriteString("arguments"u8, Arguments);
         writer.WriteEndObject();
     }

--- a/.dotnet/src/Custom/Chat/ChatFunctionToolDefinition.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionToolDefinition.cs
@@ -39,7 +39,7 @@ public class ChatFunctionToolDefinition : ChatToolDefinition
     /// })
     /// </code></para>
     /// </remarks>
-    public BinaryData Parameters { get; init; }
+    public BinaryData? Parameters { get; init; }
     /// <summary>
     /// Creates a new instance of <see cref="ChatFunctionToolDefinition"/>.
     /// </summary>

--- a/.dotnet/src/Custom/Chat/ChatFunctionToolDefinition.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionToolDefinition.cs
@@ -11,12 +11,12 @@ public class ChatFunctionToolDefinition : ChatToolDefinition
     /// <summary>
     /// The name of the function that the tool represents.
     /// </summary>
-    public required string Name { get; set; }
+    public required string FunctionName { get; init; }
     /// <summary>
-    /// A friendly description of the function. This supplements <see cref="Name"/> in informing the model about when
+    /// A friendly description of the function. This supplements <see cref="FunctionName"/> in informing the model about when
     /// it should call the function.
     /// </summary>
-    public string Description { get; set; }
+    public string? Description { get; init; }
     /// <summary>
     /// The parameter information for the function, provided in JSON Schema format.
     /// </summary>
@@ -39,7 +39,7 @@ public class ChatFunctionToolDefinition : ChatToolDefinition
     /// })
     /// </code></para>
     /// </remarks>
-    public BinaryData Parameters { get; set; }
+    public BinaryData Parameters { get; init; }
     /// <summary>
     /// Creates a new instance of <see cref="ChatFunctionToolDefinition"/>.
     /// </summary>
@@ -51,9 +51,9 @@ public class ChatFunctionToolDefinition : ChatToolDefinition
     /// <param name="description"> The <c>description</c> of the function. </param>
     /// <param name="parameters"> The <c>parameters</c> into the function, in JSON Schema format. </param>
     [SetsRequiredMembers]
-    public ChatFunctionToolDefinition(string name, string description = null, BinaryData parameters = null)
+    public ChatFunctionToolDefinition(string name, string? description = null, BinaryData? parameters = null)
     {
-        Name = name;
+        FunctionName = name;
         Description = description;
         Parameters = parameters;
     }

--- a/.dotnet/src/Custom/Chat/ChatLogProbabilityCollection.cs
+++ b/.dotnet/src/Custom/Chat/ChatLogProbabilityCollection.cs
@@ -14,15 +14,11 @@ public class ChatLogProbabilityCollection : ReadOnlyCollection<ChatLogProbabilit
     internal static ChatLogProbabilityCollection FromInternalData(
         Internal.Models.CreateChatCompletionResponseChoiceLogprobs internalLogprobs)
     {
-        if (internalLogprobs == null)
-        {
-            return null;
-        }
         List<ChatLogProbabilityResult> logProbabilities = [];
-        foreach (Internal.Models.ChatCompletionTokenLogprob internalLogprob in internalLogprobs.Content)
+        foreach (Internal.Models.ChatCompletionTokenLogprob internalLogprob in internalLogprobs?.Content ?? [])
         {
-            List<ChatLogProbabilityResultItem> alternateLogProbabilities = null;
-            if (internalLogprob.TopLogprobs != null)
+            List<ChatLogProbabilityResultItem> alternateLogProbabilities = [];
+            if (internalLogprob.TopLogprobs is not null)
             {
                 alternateLogProbabilities = [];
                 foreach (Internal.Models.ChatCompletionTokenLogprobTopLogprob internalTopLogprob in internalLogprob.TopLogprobs)

--- a/.dotnet/src/Custom/Chat/ChatLogProbabilityResult.cs
+++ b/.dotnet/src/Custom/Chat/ChatLogProbabilityResult.cs
@@ -22,7 +22,7 @@ public class ChatLogProbabilityResult
     /// characters are represented by multiple tokens and their byte representations must be combined to generate
     /// the correct text representation. Can be null if there is no bytes representation for the token.
     /// </summary>
-    public IReadOnlyList<int> Utf8ByteValues { get; }
+    public IReadOnlyList<int>? Utf8ByteValues { get; }
     /// <summary>
     /// List of the most likely tokens and their log probability at this token position. In rare cases,
     /// there may be fewer than the number of requested top_logprobs returned, as supplied via

--- a/.dotnet/src/Custom/Chat/ChatLogProbabilityResult.cs
+++ b/.dotnet/src/Custom/Chat/ChatLogProbabilityResult.cs
@@ -22,13 +22,14 @@ public class ChatLogProbabilityResult
     /// characters are represented by multiple tokens and their byte representations must be combined to generate
     /// the correct text representation. Can be null if there is no bytes representation for the token.
     /// </summary>
-    public IReadOnlyList<int>? Utf8ByteValues { get; }
+    public IReadOnlyList<int> Utf8ByteValues { get; }
     /// <summary>
     /// List of the most likely tokens and their log probability at this token position. In rare cases,
     /// there may be fewer than the number of requested top_logprobs returned, as supplied via
     /// <see cref="ChatCompletionOptions.LogProbabilityCount"/>.
     /// </summary>
     public IReadOnlyList<ChatLogProbabilityResultItem> AlternateLogProbabilities { get; }
+
     internal ChatLogProbabilityResult(
         string token,
         double logProbability,

--- a/.dotnet/src/Custom/Chat/ChatLogProbabilityResultItem.cs
+++ b/.dotnet/src/Custom/Chat/ChatLogProbabilityResultItem.cs
@@ -22,7 +22,7 @@ public class ChatLogProbabilityResultItem
     /// characters are represented by multiple tokens and their byte representations must be combined to generate
     /// the correct text representation. Can be null if there is no bytes representation for the token.
     /// </summary>
-    public IReadOnlyList<int>? Utf8ByteValues { get; }
+    public IReadOnlyList<int> Utf8ByteValues { get; }
     /// <summary>
     /// Creates a new instance of <see cref="ChatLogProbabilityResultItem"/>.
     /// </summary>

--- a/.dotnet/src/Custom/Chat/ChatLogProbabilityResultItem.cs
+++ b/.dotnet/src/Custom/Chat/ChatLogProbabilityResultItem.cs
@@ -22,11 +22,7 @@ public class ChatLogProbabilityResultItem
     /// characters are represented by multiple tokens and their byte representations must be combined to generate
     /// the correct text representation. Can be null if there is no bytes representation for the token.
     /// </summary>
-    public IReadOnlyList<int> Utf8ByteValues { get; }
-    /// <summary>
-    /// Creates a new instance of <see cref="ChatLogProbabilityResultItem"/>.
-    /// </summary>
-    protected ChatLogProbabilityResultItem() { }
+    public IReadOnlyList<int>? Utf8ByteValues { get; }
     /// <summary>
     /// Creates a new instance of <see cref="ChatLogProbabilityResultItem"/>.
     /// </summary>

--- a/.dotnet/src/Custom/Chat/ChatMessageContent.cs
+++ b/.dotnet/src/Custom/Chat/ChatMessageContent.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace OpenAI.Chat;

--- a/.dotnet/src/Custom/Chat/ChatRequestAssistantMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestAssistantMessage.cs
@@ -17,7 +17,7 @@ public class ChatRequestAssistantMessage : ChatRequestMessage
     /// An optional <c>name</c> associated with the assistant message. This is typically defined with a <c>system</c>
     /// message and is used to differentiate between multiple participants of the same role.
     /// </summary>
-    public string Name { get; set; }
+    public string ParticipantName { get; set; }
 
     /// <summary>
     /// The <c>tool_calls</c> furnished by the model that are needed to continue the logical conversation across chat
@@ -58,7 +58,7 @@ public class ChatRequestAssistantMessage : ChatRequestMessage
     /// </summary>
     /// <param name="toolCalls"> The <c>tool_calls</c> made by the model. </param>
     /// <param name="content"> Optional text content associated with the message. </param>
-    public ChatRequestAssistantMessage(IEnumerable<ChatToolCall> toolCalls, string content = null)
+    public ChatRequestAssistantMessage(IEnumerable<ChatToolCall> toolCalls, string? content = null)
         : base(ChatRole.Assistant, content)
     {
         ToolCalls = new List<ChatToolCall>(toolCalls);
@@ -69,9 +69,9 @@ public class ChatRequestAssistantMessage : ChatRequestMessage
     /// (deprecated in favor of <c>tool_calls</c>) that was made by the model.
     /// </summary>
     /// <param name="functionCall"> The <c>function_call</c> made by the model. </param>
-    /// <param name="content"> Optional text content associated with the message. </param>
-    public ChatRequestAssistantMessage(ChatFunctionCall functionCall, string content = null)
-        : base(ChatRole.Assistant, content)
+    /// <param name="text"> Optional text content associated with the message. </param>
+    public ChatRequestAssistantMessage(ChatFunctionCall functionCall, string? text = null)
+        : base(ChatRole.Assistant, text)
     {
         FunctionCall = functionCall;
     }
@@ -105,9 +105,9 @@ public class ChatRequestAssistantMessage : ChatRequestMessage
 
     internal override void WriteDerivedAdditions(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        if (Optional.IsDefined(Name))
+        if (Optional.IsDefined(ParticipantName))
         {
-            writer.WriteString("name"u8, Name);
+            writer.WriteString("name"u8, ParticipantName);
         }
         if (Optional.IsCollectionDefined(ToolCalls))
         {

--- a/.dotnet/src/Custom/Chat/ChatRequestAssistantMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestAssistantMessage.cs
@@ -1,4 +1,3 @@
-using OpenAI.ClientShared.Internal;
 using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;

--- a/.dotnet/src/Custom/Chat/ChatRequestFunctionMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestFunctionMessage.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Chat/ChatRequestMessage.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestMessage.Serialization.cs
@@ -1,11 +1,6 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.ComponentModel.Design;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Chat;
 

--- a/.dotnet/src/Custom/Chat/ChatRequestMessage.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestMessage.Serialization.cs
@@ -8,6 +8,7 @@ public abstract partial class ChatRequestMessage :  IJsonModel<ChatRequestMessag
 {
     void IJsonModel<ChatRequestMessage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
         writer.WriteStartObject();
         writer.WriteString("role"u8, Role switch
         {
@@ -75,7 +76,8 @@ public abstract partial class ChatRequestMessage :  IJsonModel<ChatRequestMessag
 
     BinaryData IPersistableModel<ChatRequestMessage>.Write(ModelReaderWriterOptions options)
     {
-        throw new NotImplementedException();
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
     }
 
     ChatRequestMessage IPersistableModel<ChatRequestMessage>.Create(BinaryData data, ModelReaderWriterOptions options)

--- a/.dotnet/src/Custom/Chat/ChatRequestMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestMessage.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel;
-using System.ClientModel.Primitives;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace OpenAI.Chat;

--- a/.dotnet/src/Custom/Chat/ChatRequestSystemMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestSystemMessage.cs
@@ -1,12 +1,5 @@
-using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Dynamic;
-using System.Runtime.InteropServices;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Chat;
 

--- a/.dotnet/src/Custom/Chat/ChatRequestSystemMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestSystemMessage.cs
@@ -21,7 +21,7 @@ public class ChatRequestSystemMessage : ChatRequestMessage
     /// <summary>
     /// An optional <c>name</c> for the participant.
     /// </summary>
-    public string Name { get; set; } // JSON "name"
+    public string ParticipantName { get; set; } // JSON "name"
 
     /// <summary>
     /// Creates a new instance of <see cref="ChatRequestSystemMessage"/>.
@@ -31,9 +31,9 @@ public class ChatRequestSystemMessage : ChatRequestMessage
 
     internal override void WriteDerivedAdditions(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        if (Optional.IsDefined(Name))
+        if (Optional.IsDefined(ParticipantName))
         {
-            writer.WriteString("name"u8, Name);
+            writer.WriteString("name"u8, ParticipantName);
         }
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatRequestToolMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestToolMessage.cs
@@ -1,10 +1,6 @@
-using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Text.Json;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 
 namespace OpenAI.Chat;
 

--- a/.dotnet/src/Custom/Chat/ChatRequestToolMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestToolMessage.cs
@@ -30,7 +30,7 @@ public class ChatRequestToolMessage : ChatRequestMessage
     /// <summary>
     /// The <c>id</c> correlating to the prior <see cref="ChatToolCall"/> made by the model.
     /// </summary>
-    public required string ToolCallId { get; set; }
+    public string ToolCallId { get; set; }
 
     /// <summary>
     /// Creates a new instance of <see cref="ChatRequestToolMessage"/>.

--- a/.dotnet/src/Custom/Chat/ChatRequestUserMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestUserMessage.cs
@@ -21,7 +21,7 @@ public class ChatRequestUserMessage : ChatRequestMessage
     /// <summary>
     /// An optional <c>name</c> for the participant.
     /// </summary>
-    public string Name { get; set; }
+    public string ParticipantName { get; set; }
 
     /// <summary>
     /// Creates a new instance of <see cref="ChatRequestUserMessage"/> with ordinary text <c>content</c>.
@@ -57,9 +57,9 @@ public class ChatRequestUserMessage : ChatRequestMessage
 
     internal override void WriteDerivedAdditions(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        if (Optional.IsDefined(Name))
+        if (Optional.IsDefined(ParticipantName))
         {
-            writer.WriteString("name"u8, Name);
+            writer.WriteString("name"u8, ParticipantName);
         }
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatRequestUserMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestUserMessage.cs
@@ -1,13 +1,7 @@
-using System.ClientModel.Internal;
-
-using System;
-using System.Collections.Generic;
-using System.Dynamic;
-using System.Text.Json;
-using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Linq;
-using OpenAI.ClientShared.Internal;
+using System.Text.Json;
 
 namespace OpenAI.Chat;
 

--- a/.dotnet/src/Custom/Chat/ChatResponseFormat.cs
+++ b/.dotnet/src/Custom/Chat/ChatResponseFormat.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenAI.Chat;
 
 /// <summary>

--- a/.dotnet/src/Custom/Chat/ChatToolCall.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatToolCall.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Chat/ChatToolCall.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatToolCall.Serialization.cs
@@ -20,6 +20,7 @@ public abstract partial class ChatToolCall :  IJsonModel<ChatToolCall>
 
     void IJsonModel<ChatToolCall>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
         writer.WriteStartObject();
         writer.WriteString("id"u8, Id);
         WriteDerivedAdditions(writer, options);
@@ -28,7 +29,8 @@ public abstract partial class ChatToolCall :  IJsonModel<ChatToolCall>
 
     BinaryData IPersistableModel<ChatToolCall>.Write(ModelReaderWriterOptions options)
     {
-        throw new NotImplementedException();
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
     }
 
     internal abstract void WriteDerivedAdditions(Utf8JsonWriter writer, ModelReaderWriterOptions options);

--- a/.dotnet/src/Custom/Chat/ChatToolCall.cs
+++ b/.dotnet/src/Custom/Chat/ChatToolCall.cs
@@ -11,5 +11,5 @@ public abstract partial class ChatToolCall
     /// A unique identifier associated with the tool call, used in a subsequent <see cref="ChatRequestToolMessage"/> to
     /// resolve the tool call and continue the logical conversation.
     /// </summary>
-    public required string Id { get; set; }
+    public required string Id { get; init; }
 }

--- a/.dotnet/src/Custom/Chat/ChatToolConstraint.cs
+++ b/.dotnet/src/Custom/Chat/ChatToolConstraint.cs
@@ -37,7 +37,7 @@ public readonly struct ChatToolConstraint : IEquatable<ChatToolConstraint>
                 type = "function",
                 function = new
                 {
-                    name = functionToolDefinition.Name,
+                    name = functionToolDefinition.FunctionName,
                 }
             });
         }

--- a/.dotnet/src/Custom/Chat/StreamingChatUpdate.cs
+++ b/.dotnet/src/Custom/Chat/StreamingChatUpdate.cs
@@ -60,7 +60,7 @@ public partial class StreamingChatUpdate
     /// response, all <see cref="ContentUpdate"/> values for the same <see cref="ChoiceIndex"/> should be
     /// combined.
     /// </remarks>
-    public string ContentUpdate { get; }
+    public string? ContentUpdate { get; }
 
     /// <summary>
     /// Gets the name of a function to be called.
@@ -68,7 +68,7 @@ public partial class StreamingChatUpdate
     /// <remarks>
     /// Corresponds to e.g. <c>$.choices[0].delta.function_call.name</c> in the underlying REST schema.
     /// </remarks>
-    public string FunctionName { get; }
+    public string? FunctionName { get; }
 
     /// <summary>
     /// Gets a function arguments fragment associated with this update.
@@ -90,7 +90,7 @@ public partial class StreamingChatUpdate
     /// function arguments before using them.
     /// </para>
     /// </remarks>
-    public string FunctionArgumentsUpdate { get; }
+    public string? FunctionArgumentsUpdate { get; }
 
     /// <summary>
     /// An incremental update payload for a tool call that is part of this response.
@@ -110,7 +110,7 @@ public partial class StreamingChatUpdate
     /// The available derived classes include: <see cref="StreamingFunctionToolCallUpdate"/>.
     /// </para>
     /// </remarks>
-    public StreamingToolCallUpdate ToolCallUpdate { get; }
+    public StreamingToolCallUpdate? ToolCallUpdate { get; }
 
     /// <summary>
     /// Gets the <see cref="ChatFinishReason"/> associated with this update.
@@ -148,26 +148,26 @@ public partial class StreamingChatUpdate
     public int? ChoiceIndex { get; }
 
     /// <inheritdoc cref="ChatCompletion.SystemFingerprint"/>
-    public string SystemFingerprint { get; }
+    public string? SystemFingerprint { get; }
 
     /// <summary>
     /// The log probability information for choices in the chat completion response, as requested via
     /// <see cref="ChatCompletionOptions.IncludeLogProbabilities"/>.
     /// </summary>
-    public ChatLogProbabilityCollection LogProbabilities { get; }
+    public ChatLogProbabilityCollection? LogProbabilities { get; }
 
     internal StreamingChatUpdate(
         string id,
         DateTimeOffset created,
-        string systemFingerprint = null,
+        string? systemFingerprint = null,
         int? choiceIndex = null,
         ChatRole? role = null,
-        string contentUpdate = null,
+        string? contentUpdate = null,
         ChatFinishReason? finishReason = null,
-        string functionName = null,
-        string functionArgumentsUpdate = null,
-        StreamingToolCallUpdate toolCallUpdate = null,
-        ChatLogProbabilityCollection logProbabilities = null)
+        string? functionName = null,
+        string? functionArgumentsUpdate = null,
+        StreamingToolCallUpdate? toolCallUpdate = null,
+        ChatLogProbabilityCollection? logProbabilities = null)
     {
         Id = id;
         Created = created;

--- a/.dotnet/src/Custom/Chat/StreamingChatUpdate.cs
+++ b/.dotnet/src/Custom/Chat/StreamingChatUpdate.cs
@@ -1,8 +1,8 @@
-namespace OpenAI.Chat;
-
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+
+namespace OpenAI.Chat;
 
 /// <summary>
 /// Represents an incremental item of new data in a streaming response to a chat completion request.

--- a/.dotnet/src/Custom/Chat/StreamingFunctionToolCallUpdate.cs
+++ b/.dotnet/src/Custom/Chat/StreamingFunctionToolCallUpdate.cs
@@ -1,5 +1,6 @@
-namespace OpenAI.Chat;
 using System.Text.Json;
+
+namespace OpenAI.Chat;
 
 /// <summary>
 /// Represents an incremental update to a streaming function tool call that is part of a streaming chat completions

--- a/.dotnet/src/Custom/Chat/StreamingFunctionToolCallUpdate.cs
+++ b/.dotnet/src/Custom/Chat/StreamingFunctionToolCallUpdate.cs
@@ -20,7 +20,7 @@ public partial class StreamingFunctionToolCallUpdate : StreamingToolCallUpdate
     /// parallel tool calls when streaming.
     /// </para>
     /// </remarks>
-    public string Name { get; }
+    public string? FunctionName { get; }
 
     /// <summary>
     /// The next new segment of the function arguments for the function tool called by a streaming tool call.
@@ -34,7 +34,7 @@ public partial class StreamingFunctionToolCallUpdate : StreamingToolCallUpdate
     /// not defined by your function schema. Validate the arguments in your code before calling
     /// your function.
     /// </remarks>
-    public string ArgumentsUpdate { get; }
+    public string? ArgumentsUpdate { get; }
 
     internal StreamingFunctionToolCallUpdate(
         string id,
@@ -43,7 +43,7 @@ public partial class StreamingFunctionToolCallUpdate : StreamingToolCallUpdate
         string functionArgumentsUpdate)
         : base("function", id, toolCallIndex)
     {
-        Name = functionName;
+        FunctionName = functionName;
         ArgumentsUpdate = functionArgumentsUpdate;
     }
 

--- a/.dotnet/src/Custom/Chat/StreamingToolCallUpdate.cs
+++ b/.dotnet/src/Custom/Chat/StreamingToolCallUpdate.cs
@@ -1,5 +1,6 @@
-namespace OpenAI.Chat;
 using System.Text.Json;
+
+namespace OpenAI.Chat;
 
 /// <summary>
 /// A base representation of an incremental update to a streaming tool call that is part of a streaming chat completion

--- a/.dotnet/src/Custom/Embeddings/EmbeddingClient.Protocol.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingClient.Protocol.cs
@@ -9,11 +9,11 @@ public partial class EmbeddingClient
 {
     /// <inheritdoc cref="Internal.Embeddings.CreateEmbedding(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GenerateEmbeddings(BinaryContent content, RequestOptions options = null)
+    public virtual ClientResult GenerateEmbeddings(BinaryContent content, RequestOptions? options = default)
         => Shim.CreateEmbedding(content, options);
 
     /// <inheritdoc cref="Internal.Embeddings.CreateEmbeddingAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> GenerateEmbeddingsAsync(BinaryContent content, RequestOptions options = null)
+    public virtual async Task<ClientResult> GenerateEmbeddingsAsync(BinaryContent content, RequestOptions? options = default)
         => await Shim.CreateEmbeddingAsync(content, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/Embeddings/EmbeddingClient.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingClient.cs
@@ -11,12 +11,12 @@ public partial class EmbeddingClient
     private readonly OpenAIClientConnector _clientConnector;
     private Internal.Embeddings Shim => _clientConnector.InternalClient.GetEmbeddingsClient();
 
-    public EmbeddingClient(string model, ApiKeyCredential credential = default, OpenAIClientOptions options = default)
+    public EmbeddingClient(string model, ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         _clientConnector = new(model, credential, options);
     }
 
-    public virtual ClientResult<Embedding> GenerateEmbedding(string input, EmbeddingOptions options = null)
+    public virtual ClientResult<Embedding> GenerateEmbedding(string input, EmbeddingOptions? options = default)
     {
         Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(input, options);
         ClientResult<Internal.Models.CreateEmbeddingResponse> response = Shim.CreateEmbedding(request);
@@ -24,23 +24,7 @@ public partial class EmbeddingClient
         return ClientResult.FromValue(embeddingResult, response.GetRawResponse());
     }
 
-    public virtual async Task<ClientResult<Embedding>> GenerateEmbeddingAsync(string input, EmbeddingOptions options = null)
-    {
-        Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(input, options);
-        ClientResult<Internal.Models.CreateEmbeddingResponse> response = await Shim.CreateEmbeddingAsync(request);
-        Embedding embeddingResult = new(response.Value, internalDataIndex: 0);
-        return ClientResult.FromValue(embeddingResult, response.GetRawResponse());
-    }
-
-    public virtual ClientResult<Embedding> GenerateEmbedding(IEnumerable<int> input, EmbeddingOptions options = null)
-    {
-        Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(input, options);
-        ClientResult<Internal.Models.CreateEmbeddingResponse> response = Shim.CreateEmbedding(request);
-        Embedding embeddingResult = new(response.Value, internalDataIndex: 0);
-        return ClientResult.FromValue(embeddingResult, response.GetRawResponse());
-    }
-
-    public virtual async Task<ClientResult<Embedding>> GenerateEmbeddingAsync(IEnumerable<int> input, EmbeddingOptions options = null)
+    public virtual async Task<ClientResult<Embedding>> GenerateEmbeddingAsync(string input, EmbeddingOptions? options = default)
     {
         Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(input, options);
         ClientResult<Internal.Models.CreateEmbeddingResponse> response = await Shim.CreateEmbeddingAsync(request);
@@ -48,7 +32,23 @@ public partial class EmbeddingClient
         return ClientResult.FromValue(embeddingResult, response.GetRawResponse());
     }
 
-    public virtual ClientResult<EmbeddingCollection> GenerateEmbeddings(IEnumerable<string> inputs, EmbeddingOptions options = null)
+    public virtual ClientResult<Embedding> GenerateEmbedding(IEnumerable<int> input, EmbeddingOptions? options = default)
+    {
+        Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(input, options);
+        ClientResult<Internal.Models.CreateEmbeddingResponse> response = Shim.CreateEmbedding(request);
+        Embedding embeddingResult = new(response.Value, internalDataIndex: 0);
+        return ClientResult.FromValue(embeddingResult, response.GetRawResponse());
+    }
+
+    public virtual async Task<ClientResult<Embedding>> GenerateEmbeddingAsync(IEnumerable<int> input, EmbeddingOptions? options = default)
+    {
+        Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(input, options);
+        ClientResult<Internal.Models.CreateEmbeddingResponse> response = await Shim.CreateEmbeddingAsync(request);
+        Embedding embeddingResult = new(response.Value, internalDataIndex: 0);
+        return ClientResult.FromValue(embeddingResult, response.GetRawResponse());
+    }
+
+    public virtual ClientResult<EmbeddingCollection> GenerateEmbeddings(IEnumerable<string> inputs, EmbeddingOptions? options = default)
     {
         Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(inputs, options);
         ClientResult<Internal.Models.CreateEmbeddingResponse> response = Shim.CreateEmbedding(request);
@@ -56,7 +56,7 @@ public partial class EmbeddingClient
         return ClientResult.FromValue(resultCollection, response.GetRawResponse());
     }
 
-    public virtual async Task<ClientResult<EmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<string> inputs, EmbeddingOptions options = null)
+    public virtual async Task<ClientResult<EmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<string> inputs, EmbeddingOptions? options = default)
     {
         Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(inputs, options);
         ClientResult<Internal.Models.CreateEmbeddingResponse> response = await Shim.CreateEmbeddingAsync(request);
@@ -64,7 +64,7 @@ public partial class EmbeddingClient
         return ClientResult.FromValue(resultCollection, response.GetRawResponse());
     }
 
-    public virtual ClientResult<EmbeddingCollection> GenerateEmbeddings(IEnumerable<IEnumerable<int>> inputs, EmbeddingOptions options = null)
+    public virtual ClientResult<EmbeddingCollection> GenerateEmbeddings(IEnumerable<IEnumerable<int>> inputs, EmbeddingOptions? options = default)
     {
         Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(inputs, options);
         ClientResult<Internal.Models.CreateEmbeddingResponse> response = Shim.CreateEmbedding(request);
@@ -72,7 +72,7 @@ public partial class EmbeddingClient
         return ClientResult.FromValue(resultCollection, response.GetRawResponse());
     }
 
-    public virtual async Task<ClientResult<EmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<IEnumerable<int>> inputs, EmbeddingOptions options = null)
+    public virtual async Task<ClientResult<EmbeddingCollection>> GenerateEmbeddingsAsync(IEnumerable<IEnumerable<int>> inputs, EmbeddingOptions? options = default)
     {
         Internal.Models.CreateEmbeddingRequest request = CreateInternalRequest(inputs, options);
         ClientResult<Internal.Models.CreateEmbeddingResponse> response = await Shim.CreateEmbeddingAsync(request);

--- a/.dotnet/src/Custom/Files/FileClient.Protocol.cs
+++ b/.dotnet/src/Custom/Files/FileClient.Protocol.cs
@@ -39,7 +39,7 @@ public partial class FileClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult UploadFile(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual ClientResult UploadFile(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));
@@ -89,7 +89,7 @@ public partial class FileClient
     /// <exception cref="ArgumentException"> <paramref name="contentType"/> is an empty string, and was expected to be non-empty. </exception>
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> UploadFileAsync(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual async Task<ClientResult> UploadFileAsync(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -32,7 +32,7 @@ public partial class FileClient
     /// </remarks>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public FileClient(ApiKeyCredential credential = default, OpenAIClientOptions options = null)
+    public FileClient(ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         _clientConnector = new(model: null, credential, options);
     }
@@ -162,7 +162,7 @@ public partial class FileClient
     public virtual ClientResult<BinaryData> DownloadFile(string fileId)
     {
         PipelineMessage message = Shim.Pipeline.CreateMessage();
-        message.ResponseClassifier = ResponseErrorClassifier200;
+        message.ResponseClassifier = PipelineMessageClassifiers.ResponseErrorClassifier200;
         PipelineRequest request = message.Request;
         request.Method = "GET";
         UriBuilder uriBuilder = new(_clientConnector.Endpoint.AbsoluteUri);
@@ -184,7 +184,7 @@ public partial class FileClient
     public virtual async Task<ClientResult<BinaryData>> DownloadFileAsync(string fileId)
     {
         PipelineMessage message = Shim.Pipeline.CreateMessage();
-        message.ResponseClassifier = ResponseErrorClassifier200;
+        message.ResponseClassifier = PipelineMessageClassifiers.ResponseErrorClassifier200;
         PipelineRequest request = message.Request;
         request.Method = "GET";
         UriBuilder uriBuilder = new(_clientConnector.Endpoint.AbsoluteUri);
@@ -217,7 +217,7 @@ public partial class FileClient
     private PipelineMessage CreateUploadFileRequest(BinaryContent content, string contentType, RequestOptions options)
     {
         PipelineMessage message = Shim.Pipeline.CreateMessage();
-        message.ResponseClassifier = ResponseErrorClassifier200;
+        message.ResponseClassifier = PipelineMessageClassifiers.ResponseErrorClassifier200;
 
         PipelineRequest request = message.Request;
         request.Method = "POST";
@@ -255,7 +255,4 @@ public partial class FileClient
             _ => throw new ArgumentException($"Unsupported file purpose: {purpose}"),
         };
     }
-
-    private static PipelineMessageClassifier _responseErrorClassifier200;
-    private static PipelineMessageClassifier ResponseErrorClassifier200 => _responseErrorClassifier200 ??= PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
 }

--- a/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.Protocol.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.Protocol.cs
@@ -9,13 +9,13 @@ public partial class FineTuningManagementClient
     /// <inheritdoc cref="Internal.FineTuning.CreateFineTuningJob(BinaryContent, RequestOptions)"/>
     public virtual ClientResult CreateFineTuningJob(
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => FineTuningShim.CreateFineTuningJob(content, options);
 
     /// <inheritdoc cref="Internal.FineTuning.CreateFineTuningJobAsync(BinaryContent, RequestOptions)"/>
     public virtual async Task<ClientResult> CreateFineTuningJobAsync(
         BinaryContent content,
-        RequestOptions options = null)
+        RequestOptions? options = default)
         => await FineTuningShim.CreateFineTuningJobAsync(content, options).ConfigureAwait(false);
 
     /// <inheritdoc cref="Internal.FineTuning.RetrieveFineTuningJob(string, RequestOptions)"/>

--- a/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
@@ -26,7 +26,7 @@ public partial class FineTuningManagementClient
     /// </remarks>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public FineTuningManagementClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
+    public FineTuningManagementClient(ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         _clientConnector = new(model: null, credential, options);
     }

--- a/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ClientModel;
+﻿using System.ClientModel;
 
 namespace OpenAI.FineTuningManagement;
 

--- a/.dotnet/src/Custom/Images/GeneratedImage.Serialization.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImage.Serialization.cs
@@ -8,43 +8,16 @@ namespace OpenAI.Images;
 public partial class GeneratedImage : IJsonModel<GeneratedImage>
 {
     GeneratedImage IJsonModel<GeneratedImage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImage>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(GeneratedImage)} does not support '{format}' format.");
-        }
-
-        using JsonDocument document = JsonDocument.ParseValue(ref reader);
-        return DeserializeGeneratedImage(document.RootElement, options)!;
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeGeneratedImage, ref reader, options);
 
     GeneratedImage IPersistableModel<GeneratedImage>.Create(BinaryData data, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImage>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                {
-                    using JsonDocument document = JsonDocument.Parse(data);
-                    return DeserializeGeneratedImage(document.RootElement, options)!;
-                }
-            default:
-                throw new FormatException($"The model {nameof(GeneratedImage)} does not support '{options.Format}' format.");
-        }
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeGeneratedImage, data, options);
 
     string IPersistableModel<GeneratedImage>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
     void IJsonModel<GeneratedImage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImage>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(GeneratedImage)} does not support '{format}' format.");
-        }
-
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
         writer.WriteStartObject();
         if (Optional.IsDefined(ImageBytes))
         {
@@ -64,22 +37,15 @@ public partial class GeneratedImage : IJsonModel<GeneratedImage>
 
     BinaryData IPersistableModel<GeneratedImage>.Write(ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImage>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                return ModelReaderWriter.Write(this, options);
-            default:
-                throw new FormatException($"The model {nameof(GeneratedImage)} does not support '{options.Format}' format.");
-        }
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
     }
 
-    internal static GeneratedImage? DeserializeGeneratedImage(JsonElement element, ModelReaderWriterOptions? options = default)
+    internal static GeneratedImage DeserializeGeneratedImage(JsonElement element, ModelReaderWriterOptions? options = default)
     {
         if (element.ValueKind != JsonValueKind.Object)
         {
-            return null;
+            throw new ArgumentException(nameof(element));
         }
 
         BinaryData? b64Json = null;

--- a/.dotnet/src/Custom/Images/GeneratedImage.Serialization.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImage.Serialization.cs
@@ -1,0 +1,118 @@
+using OpenAI.ClientShared.Internal;
+using System;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+
+namespace OpenAI.Images;
+
+public partial class GeneratedImage : IJsonModel<GeneratedImage>
+{
+    GeneratedImage IJsonModel<GeneratedImage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImage>)this).GetFormatFromOptions(options) : options.Format;
+        if (format != "J")
+        {
+            throw new FormatException($"The model {nameof(GeneratedImage)} does not support '{format}' format.");
+        }
+
+        using JsonDocument document = JsonDocument.ParseValue(ref reader);
+        return DeserializeGeneratedImage(document.RootElement, options)!;
+    }
+
+    GeneratedImage IPersistableModel<GeneratedImage>.Create(BinaryData data, ModelReaderWriterOptions options)
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImage>)this).GetFormatFromOptions(options) : options.Format;
+
+        switch (format)
+        {
+            case "J":
+                {
+                    using JsonDocument document = JsonDocument.Parse(data);
+                    return DeserializeGeneratedImage(document.RootElement, options)!;
+                }
+            default:
+                throw new FormatException($"The model {nameof(GeneratedImage)} does not support '{options.Format}' format.");
+        }
+    }
+
+    string IPersistableModel<GeneratedImage>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
+
+    void IJsonModel<GeneratedImage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImage>)this).GetFormatFromOptions(options) : options.Format;
+        if (format != "J")
+        {
+            throw new FormatException($"The model {nameof(GeneratedImage)} does not support '{format}' format.");
+        }
+
+        writer.WriteStartObject();
+        if (Optional.IsDefined(ImageBytes))
+        {
+            string base64Image = Convert.ToBase64String(ImageBytes!.ToArray());
+            writer.WriteString("b64_json"u8, base64Image);
+        }
+        if (Optional.IsDefined(ImageUri))
+        {
+            writer.WriteString("url"u8, ImageUri!.AbsoluteUri);
+        }
+        if (Optional.IsDefined(RevisedPrompt))
+        {
+            writer.WriteString("revised_prompt"u8, RevisedPrompt!);
+        }
+        writer.WriteEndObject();
+    }
+
+    BinaryData IPersistableModel<GeneratedImage>.Write(ModelReaderWriterOptions options)
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImage>)this).GetFormatFromOptions(options) : options.Format;
+
+        switch (format)
+        {
+            case "J":
+                return ModelReaderWriter.Write(this, options);
+            default:
+                throw new FormatException($"The model {nameof(GeneratedImage)} does not support '{options.Format}' format.");
+        }
+    }
+
+    internal static GeneratedImage? DeserializeGeneratedImage(JsonElement element, ModelReaderWriterOptions? options = default)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        BinaryData? b64Json = null;
+        Uri? uri = null;
+        string? revisedPrompt = null;
+
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (property.NameEquals("b64_json"u8))
+            {
+                if (property.Value.ValueKind == JsonValueKind.Null)
+                {
+                    continue;
+                }
+                b64Json = BinaryData.FromBytes(property.Value.GetBytesFromBase64("D")!);
+                continue;
+            }
+            if (property.NameEquals("url"u8))
+            {
+                if (property.Value.ValueKind == JsonValueKind.Null)
+                {
+                    continue;
+                }
+                uri = new Uri(property.Value.GetString());
+                continue;
+            }
+            if (property.NameEquals("revised_prompt"u8))
+            {
+                revisedPrompt = property.Value.GetString();
+                continue;
+            }
+        }
+
+        return new GeneratedImage(createdAt: default, uri, b64Json, revisedPrompt);
+    }
+}

--- a/.dotnet/src/Custom/Images/GeneratedImage.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImage.cs
@@ -5,7 +5,7 @@ namespace OpenAI.Images;
 /// <summary>
 /// Represents the result data for an image generation request.
 /// </summary>
-public class GeneratedImage
+public partial class GeneratedImage
 {
     /// <summary>
     /// The binary image data received from the response, provided when
@@ -15,7 +15,7 @@ public class GeneratedImage
     /// This property is mutually exclusive with <see cref="ImageUri"/> and will be <c>null</c> when the other
     /// is present.
     /// </remarks>
-    public BinaryData ImageBytes { get; }
+    public BinaryData? ImageBytes { get; }
     /// <summary>
     /// A temporary internet location for an image, provided by default or when
     /// <see cref="ImageGenerationOptions.ResponseFormat"/> is set to <see cref="ImageResponseFormat.Uri"/>.
@@ -24,7 +24,7 @@ public class GeneratedImage
     /// This property is mutually exclusive with <see cref="ImageBytes"/> and will be <c>null</c> when the other
     /// is present.
     /// </remarks>
-    public Uri ImageUri { get; }
+    public Uri? ImageUri { get; }
     /// <summary>
     /// The final, revised prompt that was used to generate the result image, populated if the model performed any
     /// such revisions to the prompt.
@@ -32,11 +32,19 @@ public class GeneratedImage
     /// <remarks>
     /// Revisions are automatically performed to enrich image prompts and improve output quality and consistency.
     /// </remarks>
-    public string RevisedPrompt { get; }
+    public string? RevisedPrompt { get; }
     /// <summary>
     /// The timestamp at which the result image was generated.
     /// </summary>
-    public DateTimeOffset CreatedAt { get; }
+    public DateTimeOffset CreatedAt { get; internal set; }
+
+    internal GeneratedImage(DateTimeOffset createdAt, Uri? imageUri, BinaryData? imageBytes, string? revisedPrompt)
+    {
+        CreatedAt = createdAt;
+        ImageBytes = imageBytes;
+        ImageUri = imageUri;
+        RevisedPrompt = revisedPrompt;
+    }
 
     internal GeneratedImage(Internal.Models.ImagesResponse internalResponse, int internalDataIndex)
     {

--- a/.dotnet/src/Custom/Images/GeneratedImageCollection.Serialization.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageCollection.Serialization.cs
@@ -1,5 +1,4 @@
 using OpenAI.ClientShared.Internal;
-using OpenAI.Internal.Models;
 using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;

--- a/.dotnet/src/Custom/Images/GeneratedImageCollection.Serialization.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageCollection.Serialization.cs
@@ -1,0 +1,114 @@
+using OpenAI.ClientShared.Internal;
+using OpenAI.Internal.Models;
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace OpenAI.Images;
+
+public partial class GeneratedImageCollection : IJsonModel<GeneratedImageCollection>
+{
+    GeneratedImageCollection IJsonModel<GeneratedImageCollection>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageCollection>)this).GetFormatFromOptions(options) : options.Format;
+        if (format != "J")
+        {
+            throw new FormatException($"The model {nameof(GeneratedImageCollection)} does not support '{format}' format.");
+        }
+
+        using JsonDocument document = JsonDocument.ParseValue(ref reader);
+        return DeserializeGeneratedImageCollection(document.RootElement, options)!;
+    }
+
+    GeneratedImageCollection IPersistableModel<GeneratedImageCollection>.Create(BinaryData data, ModelReaderWriterOptions options)
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageCollection>)this).GetFormatFromOptions(options) : options.Format;
+
+        switch (format)
+        {
+            case "J":
+                {
+                    using JsonDocument document = JsonDocument.Parse(data);
+                    return DeserializeGeneratedImageCollection(document.RootElement, options)!;
+                }
+            default:
+                throw new FormatException($"The model {nameof(GeneratedImageCollection)} does not support '{options.Format}' format.");
+        }
+    }
+
+    string IPersistableModel<GeneratedImageCollection>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
+
+    void IJsonModel<GeneratedImageCollection>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageCollection>)this).GetFormatFromOptions(options) : options.Format;
+        if (format != "J")
+        {
+            throw new FormatException($"The model {nameof(GeneratedImageCollection)} does not support '{format}' format.");
+        }
+        writer.WriteStartObject();
+        writer.WriteNumber("created"u8, CreatedAt.ToUnixTimeSeconds());
+        writer.WriteStartArray();
+        foreach (GeneratedImage generatedImage in this)
+        {
+            writer.WriteObjectValue(generatedImage);
+        }
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+
+    BinaryData IPersistableModel<GeneratedImageCollection>.Write(ModelReaderWriterOptions options)
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageCollection>)this).GetFormatFromOptions(options) : options.Format;
+
+        switch (format)
+        {
+            case "J":
+                return ModelReaderWriter.Write(this, options);
+            default:
+                throw new FormatException($"The model {nameof(GeneratedImageCollection)} does not support '{options.Format}' format.");
+        }
+    }
+
+    internal static GeneratedImageCollection? DeserializeGeneratedImageCollection(JsonElement element, ModelReaderWriterOptions? options = default)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        DateTimeOffset? createdAt = null;
+        List<GeneratedImage> images = [];
+
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (property.NameEquals("created"u8))
+            {
+                createdAt = DateTimeOffset.FromUnixTimeSeconds(property.Value.GetInt64());
+                continue;
+            }
+            if (property.NameEquals("data"u8))
+            {
+                foreach (JsonElement item in property.Value.EnumerateArray())
+                {
+                    GeneratedImage image = GeneratedImage.DeserializeGeneratedImage(item, options)!;
+                    images.Add(image);
+                }
+                continue;
+            }
+        }
+
+        foreach (GeneratedImage image in images)
+        {
+            image.CreatedAt = createdAt!.Value;
+        }
+
+        return new GeneratedImageCollection(images, createdAt!.Value);
+    }
+
+    internal static GeneratedImageCollection? FromResponse(PipelineResponse response)
+    {
+        using var document = JsonDocument.Parse(response.Content);
+        return DeserializeGeneratedImageCollection(document.RootElement);
+    }
+}

--- a/.dotnet/src/Custom/Images/GeneratedImageCollection.Serialization.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageCollection.Serialization.cs
@@ -9,42 +9,16 @@ namespace OpenAI.Images;
 public partial class GeneratedImageCollection : IJsonModel<GeneratedImageCollection>
 {
     GeneratedImageCollection IJsonModel<GeneratedImageCollection>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageCollection>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(GeneratedImageCollection)} does not support '{format}' format.");
-        }
-
-        using JsonDocument document = JsonDocument.ParseValue(ref reader);
-        return DeserializeGeneratedImageCollection(document.RootElement, options)!;
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeGeneratedImageCollection, ref reader, options)!;
 
     GeneratedImageCollection IPersistableModel<GeneratedImageCollection>.Create(BinaryData data, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageCollection>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                {
-                    using JsonDocument document = JsonDocument.Parse(data);
-                    return DeserializeGeneratedImageCollection(document.RootElement, options)!;
-                }
-            default:
-                throw new FormatException($"The model {nameof(GeneratedImageCollection)} does not support '{options.Format}' format.");
-        }
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeGeneratedImageCollection, data, options);
 
     string IPersistableModel<GeneratedImageCollection>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
     void IJsonModel<GeneratedImageCollection>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageCollection>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(GeneratedImageCollection)} does not support '{format}' format.");
-        }
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
         writer.WriteStartObject();
         writer.WriteNumber("created"u8, CreatedAt.ToUnixTimeSeconds());
         writer.WriteStartArray();
@@ -58,22 +32,15 @@ public partial class GeneratedImageCollection : IJsonModel<GeneratedImageCollect
 
     BinaryData IPersistableModel<GeneratedImageCollection>.Write(ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageCollection>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                return ModelReaderWriter.Write(this, options);
-            default:
-                throw new FormatException($"The model {nameof(GeneratedImageCollection)} does not support '{options.Format}' format.");
-        }
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
     }
 
-    internal static GeneratedImageCollection? DeserializeGeneratedImageCollection(JsonElement element, ModelReaderWriterOptions? options = default)
+    internal static GeneratedImageCollection DeserializeGeneratedImageCollection(JsonElement element, ModelReaderWriterOptions? options = default)
     {
         if (element.ValueKind != JsonValueKind.Object)
         {
-            return null;
+            throw new ArgumentException(nameof(element));
         }
 
         DateTimeOffset? createdAt = null;

--- a/.dotnet/src/Custom/Images/GeneratedImageCollection.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageCollection.cs
@@ -1,33 +1,22 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Text.Json;
 
 namespace OpenAI.Images;
 
 /// <summary>
 /// Represents an image generation response payload that contains information for multiple generated images.
 /// </summary>
-public class GeneratedImageCollection : ReadOnlyCollection<GeneratedImage>
+public partial class GeneratedImageCollection : ReadOnlyCollection<GeneratedImage>
 {
-    internal GeneratedImageCollection(IList<GeneratedImage> list) : base(list) { }
+    /// <summary>
+    /// The timestamp at which the result images were generated.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; }
 
-    internal static GeneratedImageCollection Deserialize(BinaryData content)
+    internal GeneratedImageCollection(IList<GeneratedImage> list, DateTimeOffset createdAt)
+        : base(list)
     {
-        using JsonDocument responseDocument = JsonDocument.Parse(content);
-        return Deserialize(responseDocument.RootElement);
-    }
-
-    internal static GeneratedImageCollection Deserialize(JsonElement element)
-    {
-        Internal.Models.ImagesResponse response = Internal.Models.ImagesResponse.DeserializeImagesResponse(element);
-
-        List<GeneratedImage> images = [];
-        for (int i = 0; i < response.Data.Count; i++)
-        {
-            images.Add(new GeneratedImage(response, i));
-        }
-
-        return new GeneratedImageCollection(images);
+        CreatedAt = createdAt;
     }
 }

--- a/.dotnet/src/Custom/Images/GeneratedImageQuality.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageQuality.cs
@@ -11,7 +11,7 @@ namespace OpenAI.Images;
 /// <item><see cref="High"/> - <c>hd</c> - Better consistency and finer details, but may be slower. </item>
 /// </list>
 /// </remarks>
-public enum ImageQuality
+public enum GeneratedImageQuality
 {
     /// <summary>
     /// The <c>hd</c> image quality that provides finer details and greater consistency but may be slower.

--- a/.dotnet/src/Custom/Images/GeneratedImageSize.Serialization.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageSize.Serialization.cs
@@ -1,7 +1,6 @@
 using OpenAI.Internal.Models;
 using System;
 using System.ClientModel.Primitives;
-using System.Linq;
 using System.Text.Json;
 
 namespace OpenAI.Images;
@@ -25,7 +24,7 @@ public partial class GeneratedImageSize : IJsonModel<GeneratedImageSize>
 
     GeneratedImageSize IPersistableModel<GeneratedImageSize>.Create(BinaryData data, ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<ChatCompletionFunctionCallOption>)this).GetFormatFromOptions(options) : options.Format;
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageSize>)this).GetFormatFromOptions(options) : options.Format;
 
         switch (format)
         {
@@ -43,10 +42,10 @@ public partial class GeneratedImageSize : IJsonModel<GeneratedImageSize>
 
     void IJsonModel<GeneratedImageSize>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<ChatCompletionFunctionCallOption>)this).GetFormatFromOptions(options) : options.Format;
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageSize>)this).GetFormatFromOptions(options) : options.Format;
         if (format != "J")
         {
-            throw new FormatException($"The model {nameof(ChatCompletionFunctionCallOption)} does not support '{format}' format.");
+            throw new FormatException($"The model {nameof(GeneratedImageSize)} does not support '{format}' format.");
         }
         writer.WriteStringValue($"{Width}x{Height}");
     }
@@ -64,7 +63,7 @@ public partial class GeneratedImageSize : IJsonModel<GeneratedImageSize>
         }
     }
 
-    internal static GeneratedImageSize DeserializeGeneratedImageSize(JsonElement element, ModelReaderWriterOptions options = null)
+    internal static GeneratedImageSize DeserializeGeneratedImageSize(JsonElement element, ModelReaderWriterOptions? options = default)
     {
         if (element.ValueKind != JsonValueKind.String)
         {

--- a/.dotnet/src/Custom/Images/GeneratedImageSize.Serialization.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageSize.Serialization.cs
@@ -1,4 +1,3 @@
-using OpenAI.Internal.Models;
 using System;
 using System.ClientModel.Primitives;
 using System.Text.Json;
@@ -11,68 +10,36 @@ namespace OpenAI.Images;
 public partial class GeneratedImageSize : IJsonModel<GeneratedImageSize>
 {
     GeneratedImageSize IJsonModel<GeneratedImageSize>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<ChatCompletionFunctionCallOption>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(GeneratedImageSize)} does not support '{format}' format.");
-        }
-
-        using JsonDocument document = JsonDocument.ParseValue(ref reader);
-        return DeserializeGeneratedImageSize(document.RootElement, options);
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeGeneratedImageSize, ref reader, options);
 
     GeneratedImageSize IPersistableModel<GeneratedImageSize>.Create(BinaryData data, ModelReaderWriterOptions options)
-    {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageSize>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                {
-                    using JsonDocument document = JsonDocument.Parse(data);
-                    return DeserializeGeneratedImageSize(document.RootElement, options);
-                }
-            default:
-                throw new FormatException($"The model {nameof(GeneratedImageSize)} does not support '{options.Format}' format.");
-        }
-    }
+        => ModelSerializationHelpers.DeserializeNewInstance(this, DeserializeGeneratedImageSize, data, options);
 
     string IPersistableModel<GeneratedImageSize>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
 
     void IJsonModel<GeneratedImageSize>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageSize>)this).GetFormatFromOptions(options) : options.Format;
-        if (format != "J")
-        {
-            throw new FormatException($"The model {nameof(GeneratedImageSize)} does not support '{format}' format.");
-        }
+        ModelSerializationHelpers.AssertSupportedJsonWriteFormat(this, options);
         writer.WriteStringValue($"{Width}x{Height}");
     }
 
     BinaryData IPersistableModel<GeneratedImageSize>.Write(ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageSize>)this).GetFormatFromOptions(options) : options.Format;
-
-        switch (format)
-        {
-            case "J":
-                return ModelReaderWriter.Write(this, options);
-            default:
-                throw new FormatException($"The model {nameof(GeneratedImageSize)} does not support '{options.Format}' format.");
-        }
+        ModelSerializationHelpers.AssertSupportedPersistableWriteFormat(this, options);
+        return ModelReaderWriter.Write(this, options);
     }
 
     internal static GeneratedImageSize DeserializeGeneratedImageSize(JsonElement element, ModelReaderWriterOptions? options = default)
     {
         if (element.ValueKind != JsonValueKind.String)
         {
-            return null;
+            throw new ArgumentException(nameof(element));
         }
-        string[] parts = element.GetString().Split('x');
+
+        string[] parts = element.GetString()!.Split('x');
         if (parts.Length != 2 || !int.TryParse(parts[0], out int width) || !int.TryParse(parts[1], out int height))
         {
-            return null;
+            throw new ArgumentException(nameof(element));
         }
         return new GeneratedImageSize(width, height);
     }

--- a/.dotnet/src/Custom/Images/GeneratedImageStyle.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageStyle.cs
@@ -5,7 +5,7 @@ namespace OpenAI.Images;
 /// generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real
 /// looking images. This param is only supported for <c>dall-e-3</c>.
 /// </summary>
-public enum ImageStyle
+public enum GeneratedImageStyle
 {
     /// <summary>
     /// The <c>vivid</c> style, with which the model will tend towards hyper-realistic, dramatic imagery.

--- a/.dotnet/src/Custom/Images/ImageClient.Protocol.cs
+++ b/.dotnet/src/Custom/Images/ImageClient.Protocol.cs
@@ -11,12 +11,12 @@ public partial class ImageClient
 {
     /// <inheritdoc cref="Internal.Images.CreateImage(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GenerateImage(BinaryContent content, RequestOptions options = null)
+    public virtual ClientResult GenerateImages(BinaryContent content, RequestOptions? options = default)
         => Shim.CreateImage(content, options);
 
     /// <inheritdoc cref="Internal.Images.CreateImageAsync(BinaryContent, RequestOptions)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> GenerateImageAsync(BinaryContent content, RequestOptions options = null)
+    public virtual async Task<ClientResult> GenerateImagesAsync(BinaryContent content, RequestOptions? options = default)
         => await Shim.CreateImageAsync(content, options).ConfigureAwait(false);
 
     /// <summary>
@@ -42,7 +42,7 @@ public partial class ImageClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GenerateImageEdits(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual ClientResult GenerateImageEdits(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));
@@ -86,7 +86,7 @@ public partial class ImageClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> GenerateImageEditsAsync(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual async Task<ClientResult> GenerateImageEditsAsync(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));
@@ -130,7 +130,7 @@ public partial class ImageClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GenerateImageVariations(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual ClientResult GenerateImageVariations(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));
@@ -174,7 +174,7 @@ public partial class ImageClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> GenerateImageVariationsAsync(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual async Task<ClientResult> GenerateImageVariationsAsync(BinaryContent content, string contentType, RequestOptions? options = default)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));

--- a/.dotnet/src/Custom/Images/ImageClient.cs
+++ b/.dotnet/src/Custom/Images/ImageClient.cs
@@ -2,9 +2,7 @@ using OpenAI.Internal;
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/.dotnet/src/Custom/Images/ImageGenerationOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageGenerationOptions.cs
@@ -10,15 +10,15 @@ public partial class ImageGenerationOptions
     /// the <c>dall-e-3</c> model.
     /// <list type="bullet">
     /// <item>
-    ///     <c>hd</c> - <see cref="ImageQuality.High"/> - Finer details, greater consistency, slower, more intensive.
+    ///     <c>hd</c> - <see cref="GeneratedImageQuality.High"/> - Finer details, greater consistency, slower, more intensive.
     /// </item>
     /// <item>
-    ///     <c>standard</c> - <see cref="ImageQuality.Standard"/> - The default quality level that's faster and less
+    ///     <c>standard</c> - <see cref="GeneratedImageQuality.Standard"/> - The default quality level that's faster and less
     ///     intensive but may also be less detailed and consistent than <c>hd</c>.
     /// </item>
     /// </list>
     /// </summary>
-    public ImageQuality? Quality { get; set; }
+    public GeneratedImageQuality? Quality { get; set; }
     /// <summary>
     /// Specifies the desired output representation of the generated image.
     /// <list type="bullet">
@@ -53,23 +53,23 @@ public partial class ImageGenerationOptions
     /// </list>
     /// </para>
     /// </summary>
-    public GeneratedImageSize Size { get; set; }
+    public GeneratedImageSize? Size { get; set; }
     /// <summary>
     /// The style kind to guide the generation of the image.
     /// <list type="bullet">
     /// <item>
-    ///     <c>vivid</c> - <see cref="ImageStyle.Vivid"/> - default, a style that tends towards more realistic,
+    ///     <c>vivid</c> - <see cref="GeneratedImageStyle.Vivid"/> - default, a style that tends towards more realistic,
     ///     dramatic images.
     /// </item>
     /// <item>
-    ///     <c>natural</c> - <see cref="ImageStyle.Natural"/> - a more subdued style with less tendency towards
+    ///     <c>natural</c> - <see cref="GeneratedImageStyle.Natural"/> - a more subdued style with less tendency towards
     ///     realism and striking imagery.
     /// </item>
     /// </list>
     /// </summary>
-    public ImageStyle? Style { get; set; }
+    public GeneratedImageStyle? Style { get; set; }
     /// <summary>
     /// An optional identifier for the end user that can help OpenAI monitor for and detect abuse.
     /// </summary>
-    public string User { get; set; }
+    public string? User { get; set; }
 }

--- a/.dotnet/src/Custom/Images/ImageResponseFormat.cs
+++ b/.dotnet/src/Custom/Images/ImageResponseFormat.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenAI.Images;
 
 /// <summary>

--- a/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.Protocol.cs
+++ b/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.Protocol.cs
@@ -7,10 +7,10 @@ namespace OpenAI.LegacyCompletions;
 public partial class LegacyCompletionClient
 {
     /// <inheritdoc cref="Internal.Completions.CreateCompletion(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult GenerateLegacyCompletions(BinaryContent content, RequestOptions options = null)
+    public virtual ClientResult GenerateLegacyCompletions(BinaryContent content, RequestOptions? options = default)
         => Shim.CreateCompletion(content, options);
 
     /// <inheritdoc cref="Internal.Completions.CreateCompletionAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> GenerateLegacyCompletionsAsync(BinaryContent content, RequestOptions options = null)
+    public virtual async Task<ClientResult> GenerateLegacyCompletionsAsync(BinaryContent content, RequestOptions? options = default)
         => await Shim.CreateCompletionAsync(content, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
+++ b/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
@@ -30,7 +30,7 @@ public partial class LegacyCompletionClient
     /// </remarks>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public LegacyCompletionClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
+    public LegacyCompletionClient(ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         _clientConnector = new(model: null, credential, options);
     }

--- a/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
+++ b/.dotnet/src/Custom/LegacyCompletions/LegacyCompletionClient.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ClientModel;
 
 namespace OpenAI.LegacyCompletions;

--- a/.dotnet/src/Custom/Models/ModelManagementClient.cs
+++ b/.dotnet/src/Custom/Models/ModelManagementClient.cs
@@ -28,7 +28,7 @@ public partial class ModelManagementClient
     /// </remarks>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public ModelManagementClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
+    public ModelManagementClient(ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         _clientConnector = new(model: "none", credential, options);
     }

--- a/.dotnet/src/Custom/Models/ModelManagementClient.cs
+++ b/.dotnet/src/Custom/Models/ModelManagementClient.cs
@@ -1,5 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System;
 using System.ClientModel;
 using System.Threading.Tasks;
 

--- a/.dotnet/src/Custom/Moderations/ModerationClient.Protocol.cs
+++ b/.dotnet/src/Custom/Moderations/ModerationClient.Protocol.cs
@@ -7,10 +7,10 @@ namespace OpenAI.Moderations;
 public partial class ModerationClient
 {
     /// <inheritdoc cref="Internal.Moderations.CreateModeration(BinaryContent, RequestOptions)"/>
-    public virtual ClientResult ClassifyText(BinaryContent content, RequestOptions options = null)
+    public virtual ClientResult ClassifyText(BinaryContent content, RequestOptions? options = default)
         => Shim.CreateModeration(content, options);
 
     /// <inheritdoc cref="Internal.Moderations.CreateModerationAsync(BinaryContent, RequestOptions)"/>
-    public virtual async Task<ClientResult> ClassifyTextAsync(BinaryContent content, RequestOptions options = null)
+    public virtual async Task<ClientResult> ClassifyTextAsync(BinaryContent content, RequestOptions? options = default)
         => await Shim.CreateModerationAsync(content, options).ConfigureAwait(false);
 }

--- a/.dotnet/src/Custom/Moderations/ModerationClient.cs
+++ b/.dotnet/src/Custom/Moderations/ModerationClient.cs
@@ -25,7 +25,7 @@ public partial class ModerationClient
     /// </remarks>
     /// <param name="credential">The API key used to authenticate with the service endpoint.</param>
     /// <param name="options">Additional options to customize the client.</param>
-    public ModerationClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
+    public ModerationClient(ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         _clientConnector = new(model: null, credential, options);
     }

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -5,11 +5,9 @@ using OpenAI.Embeddings;
 using OpenAI.Files;
 using OpenAI.FineTuningManagement;
 using OpenAI.Images;
-using OpenAI.Internal.Models;
 using OpenAI.LegacyCompletions;
 using OpenAI.ModelManagement;
 using OpenAI.Moderations;
-using System;
 using System.ClientModel;
 using System.Diagnostics.CodeAnalysis;
 

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -21,8 +21,8 @@ namespace OpenAI;
 /// </summary>
 public partial class OpenAIClient
 {
-    private readonly ApiKeyCredential _cachedCredential = null;
-    private readonly OpenAIClientOptions _cachedOptions = null;
+    private readonly ApiKeyCredential? _cachedCredential = default;
+    private readonly OpenAIClientOptions? _cachedOptions = default;
 
     /// <summary>
     /// Creates a new instance of <see cref="OpenAIClient"/> will store common client configuration details to permit
@@ -34,7 +34,7 @@ public partial class OpenAIClient
     /// </remarks>
     /// <param name="credential"> An explicitly defined credential that all clients created by this <see cref="OpenAIClient"/> should use. </param>
     /// <param name="options"> A common client options definition that all clients created by this <see cref="OpenAIClient"/> should use. </param>
-    public OpenAIClient(ApiKeyCredential credential = default, OpenAIClientOptions options = default)
+    public OpenAIClient(ApiKeyCredential? credential = default, OpenAIClientOptions? options = default)
     {
         _cachedCredential = credential;
         _cachedOptions = options;

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -117,17 +117,6 @@ public partial class OpenAIClient
     public ImageClient GetImageClient(string model) => new(model, _cachedCredential, _cachedOptions);
 
     /// <summary>
-    /// Gets a new instance of <see cref="LegacyCompletionClient"/> that reuses the client configuration details provided to
-    /// the <see cref="OpenAIClient"/> instance.
-    /// </summary>
-    /// <remarks>
-    /// This method is functionally equivalent to using the <see cref="LegacyCompletionClient"/> constructor directly with
-    /// the same configuration details.
-    /// </remarks>
-    /// <returns> A new <see cref="LegacyCompletionClient"/>. </returns>
-    public LegacyCompletionClient GetLegacyCompletionClient() => new(_cachedCredential, _cachedOptions);
-
-    /// <summary>
     /// Gets a new instance of <see cref="ModelManagementClient"/> that reuses the client configuration details provided to
     /// the <see cref="OpenAIClient"/> instance.
     /// </summary>

--- a/.dotnet/src/Custom/OpenAIClientConnector.cs
+++ b/.dotnet/src/Custom/OpenAIClientConnector.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ClientModel;
-using System.ClientModel.Internal;
 
 
 namespace OpenAI;

--- a/.dotnet/src/Custom/OpenAIClientConnector.cs
+++ b/.dotnet/src/Custom/OpenAIClientConnector.cs
@@ -14,15 +14,14 @@ internal partial class OpenAIClientConnector
     private static readonly string s_defaultOpenAIV1Endpoint = "https://api.openai.com/v1";
 
     internal Internal.OpenAIClient InternalClient { get; }
-    internal string Model { get; }
+    internal string? Model { get; }
     internal Uri Endpoint { get; }
 
     internal OpenAIClientConnector(
-        string model,
-        ApiKeyCredential credential = null,
-        OpenAIClientOptions options = null)
+        string? model,
+        ApiKeyCredential? credential = default,
+        OpenAIClientOptions? options = default)
     {
-        if (model is null) throw new ArgumentNullException(nameof(model));
         Model = model;
         Endpoint ??= options?.Endpoint ?? new(Environment.GetEnvironmentVariable(s_OpenAIEndpointEnvironmentVariable) ?? s_defaultOpenAIV1Endpoint);
         credential ??= new(Environment.GetEnvironmentVariable(s_OpenAIApiKeyEnvironmentVariable) ?? string.Empty);

--- a/.dotnet/src/Custom/OpenAIClientOptions.cs
+++ b/.dotnet/src/Custom/OpenAIClientOptions.cs
@@ -1,8 +1,5 @@
 using System;
-using System.ClientModel;
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Threading;
 
 namespace OpenAI;
 

--- a/.dotnet/src/Custom/OpenAIClientOptions.cs
+++ b/.dotnet/src/Custom/OpenAIClientOptions.cs
@@ -9,7 +9,7 @@ namespace OpenAI;
 /// <summary>
 /// Client-level options for the OpenAI service.
 /// </summary>
-public partial class OpenAIClientOptions : RequestOptions
+public partial class OpenAIClientOptions : ClientPipelineOptions
 {
     /// <summary>
     /// Gets or sets a non-default base endpoint that clients should use when connecting.
@@ -30,7 +30,7 @@ public partial class OpenAIClientOptions : RequestOptions
         : this(internalOptions: null)
     { }
 
-    internal OpenAIClientOptions(Internal.OpenAIClientOptions internalOptions = null)
+    internal OpenAIClientOptions(Internal.OpenAIClientOptions? internalOptions = default)
     {
         internalOptions ??= new();
         InternalOptions = internalOptions;

--- a/.dotnet/src/OpenAI.csproj
+++ b/.dotnet/src/OpenAI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the OpenAI client library for developing .NET applications with rich experience.</Description>
     <AssemblyTitle>SDK Code Generation OpenAI</AssemblyTitle>
@@ -6,6 +6,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.dotnet/src/Utility/GenericActionPipelinePolicy.cs
+++ b/.dotnet/src/Utility/GenericActionPipelinePolicy.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/.dotnet/src/Utility/ModelSerializationHelpers.cs
+++ b/.dotnet/src/Utility/ModelSerializationHelpers.cs
@@ -1,0 +1,74 @@
+using System;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+
+namespace OpenAI;
+
+internal static partial class ModelSerializationHelpers
+{
+    internal static TOutput DeserializeNewInstance<TOutput,UInstanceInput>(
+        UInstanceInput existingInstance,
+        Func<JsonElement, ModelReaderWriterOptions?, TOutput> deserializationFunc,
+        ref Utf8JsonReader reader,
+        ModelReaderWriterOptions options)
+            where UInstanceInput : IJsonModel<TOutput>
+    {
+        var format = options.Format == "W" ? ((IJsonModel<TOutput>)existingInstance).GetFormatFromOptions(options) : options.Format;
+        if (format != "J")
+        {
+            throw new FormatException($"The model {nameof(UInstanceInput)} does not support '{format}' format.");
+        }
+
+        using JsonDocument document = JsonDocument.ParseValue(ref reader);
+        return deserializationFunc.Invoke(document.RootElement, options);
+    }
+
+    internal static TOutput DeserializeNewInstance<TOutput,UInstanceInput>(
+        UInstanceInput existingInstance,
+        Func<JsonElement, ModelReaderWriterOptions?, TOutput> deserializationFunc,
+        BinaryData data,
+        ModelReaderWriterOptions options)
+            where UInstanceInput : IPersistableModel<TOutput>
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<TOutput>)existingInstance).GetFormatFromOptions(options) : options.Format;
+
+        switch (format)
+        {
+            case "J":
+                {
+                    using JsonDocument document = JsonDocument.Parse(data);
+                    return deserializationFunc.Invoke(document.RootElement, options)!;
+                }
+            default:
+                throw new FormatException($"The model {nameof(UInstanceInput)} does not support '{format}' format.");
+        }
+    }
+
+    internal static void AssertSupportedJsonWriteFormat<T>(T instance, ModelReaderWriterOptions options)
+        where T : IJsonModel<T>
+            => AssertSupportedJsonWriteFormat<T, T>(instance, options);
+
+    internal static void AssertSupportedJsonWriteFormat<TOutput,UInstanceInput>(UInstanceInput instance, ModelReaderWriterOptions options)
+        where UInstanceInput : IJsonModel<TOutput>
+    {
+        var format = options.Format == "W" ? ((IJsonModel<TOutput>)instance).GetFormatFromOptions(options) : options.Format;
+        if (format != "J")
+        {
+            throw new FormatException($"The model {nameof(UInstanceInput)} does not support '{format}' format.");
+        }
+    }
+
+    internal static void AssertSupportedPersistableWriteFormat<T>(T instance, ModelReaderWriterOptions options)
+        where T : IPersistableModel<T>
+            => AssertSupportedPersistableWriteFormat<T, T>(instance, options);
+
+    internal static void AssertSupportedPersistableWriteFormat<TOutput,UInstanceInput>(UInstanceInput instance, ModelReaderWriterOptions options)
+        where UInstanceInput : IPersistableModel<TOutput>
+    {
+        var format = options.Format == "W" ? ((IPersistableModel<TOutput>)instance).GetFormatFromOptions(options) : options.Format;
+        if (format != "J")
+        {
+            throw new FormatException($"The model {nameof(UInstanceInput)} does not support '{format}' format.");
+        }
+    }
+}

--- a/.dotnet/src/Utility/PipelineMessageClassifiers.cs
+++ b/.dotnet/src/Utility/PipelineMessageClassifiers.cs
@@ -1,0 +1,14 @@
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace OpenAI;
+
+internal static partial class PipelineMessageClassifiers
+{
+    private static PipelineMessageClassifier? _responseErrorClassifier200;
+    internal static PipelineMessageClassifier ResponseErrorClassifier200
+        => _responseErrorClassifier200 ??= PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
+}

--- a/.dotnet/src/Utility/PipelineMessageClassifiers.cs
+++ b/.dotnet/src/Utility/PipelineMessageClassifiers.cs
@@ -1,8 +1,4 @@
-using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace OpenAI;
 

--- a/.dotnet/src/Utility/SseReader.cs
+++ b/.dotnet/src/Utility/SseReader.cs
@@ -1,6 +1,4 @@
 using System;
-using System.ClientModel;
-using System.ClientModel.Internal;
 using System.IO;
 using System.Threading.Tasks;
 

--- a/.dotnet/src/Utility/StreamingClientResult.cs
+++ b/.dotnet/src/Utility/StreamingClientResult.cs
@@ -56,19 +56,6 @@ public class StreamingClientResult<T>
     /// <returns> The <see cref="PipelineResponse"/> instance attached to this <see cref="StreamingClientResult{T}"/>. </returns>
     public PipelineResponse GetRawResponse() => _rawResult.GetRawResponse();
 
-    /// <summary>
-    /// Gets the asynchronously enumerable collection of distinct, streamable items in the response.
-    /// </summary>
-    /// <remarks>
-    /// <para> The return value of this method may be used with the "await foreach" statement. </para>
-    /// <para>
-    /// As <see cref="StreamingClientResult{T}"/> explicitly implements <see cref="IAsyncEnumerable{T}"/>, callers may
-    /// enumerate a <see cref="StreamingClientResult{T}"/> instance directly instead of calling this method.
-    /// </para>
-    /// </remarks>
-    /// <returns></returns>
-    public IAsyncEnumerable<T> EnumerateValues() => this;
-
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/.dotnet/src/Utility/StreamingResult.cs
+++ b/.dotnet/src/Utility/StreamingResult.cs
@@ -1,9 +1,8 @@
-using System.ClientModel;
+using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Threading;
 using System.Collections.Generic;
-using System;
+using System.Threading;
 
 namespace OpenAI;
 

--- a/.dotnet/tests/Samples/Assistants/Sample01_RetrievalAugmentedGeneration.cs
+++ b/.dotnet/tests/Samples/Assistants/Sample01_RetrievalAugmentedGeneration.cs
@@ -55,7 +55,7 @@ namespace OpenAI.Samples
             AssistantCreationOptions assistantOptions = new()
             {
                 Name = "Example: Contoso sales RAG",
-                Instructions =
+                DefaultInstructions =
                     "You are an assistant that looks up sales data and helps visualize the information based"
                     + " on user queries. When asked to generate a graph, chart, or other visualization, use"
                     + " the code interpreter tool to do so.",

--- a/.dotnet/tests/Samples/Assistants/Sample01_RetrievalAugmentedGenerationAsync.cs
+++ b/.dotnet/tests/Samples/Assistants/Sample01_RetrievalAugmentedGenerationAsync.cs
@@ -55,7 +55,7 @@ namespace OpenAI.Samples
             AssistantCreationOptions assistantOptions = new()
             {
                 Name = "Example: Contoso sales RAG",
-                Instructions =
+                DefaultInstructions =
                     "You are an assistant that looks up sales data and helps visualize the information based"
                     + " on user queries. When asked to generate a graph, chart, or other visualization, use"
                     + " the code interpreter tool to do so.",

--- a/.dotnet/tests/Samples/Assistants/Sample03_FunctionCalling.cs
+++ b/.dotnet/tests/Samples/Assistants/Sample03_FunctionCalling.cs
@@ -28,13 +28,13 @@ namespace OpenAI.Samples
 
         private static readonly FunctionToolDefinition getCurrentLocationFunction = new()
         {
-            Name = GetCurrentLocationFunctionName,
+            FunctionName = GetCurrentLocationFunctionName,
             Description = "Get the user's current location"
         };
 
         private static readonly FunctionToolDefinition getCurrentWeatherFunction = new()
         {
-            Name = GetCurrentWeatherFunctionName,
+            FunctionName = GetCurrentWeatherFunctionName,
             Description = "Get the current weather in a given location",
             Parameters = BinaryData.FromString("""
                 {
@@ -69,7 +69,7 @@ namespace OpenAI.Samples
             AssistantCreationOptions assistantOptions = new()
             {
                 Name = "Sample: Function Calling",
-                Instructions =
+                DefaultInstructions =
                     "Don't make assumptions about what values to plug into functions."
                     + " Ask for clarification if a user request is ambiguous.",
                 Tools = { getCurrentLocationFunction, getCurrentWeatherFunction },
@@ -105,7 +105,7 @@ namespace OpenAI.Samples
                     {
                         RequiredFunctionToolCall requiredFunctionToolCall = action as RequiredFunctionToolCall;
 
-                        switch (requiredFunctionToolCall?.Name)
+                        switch (requiredFunctionToolCall?.FunctionName)
                         {
                             case GetCurrentLocationFunctionName:
                                 {

--- a/.dotnet/tests/Samples/Assistants/Sample03_FunctionCallingAsync.cs
+++ b/.dotnet/tests/Samples/Assistants/Sample03_FunctionCallingAsync.cs
@@ -23,7 +23,7 @@ namespace OpenAI.Samples
             AssistantCreationOptions assistantOptions = new()
             {
                 Name = "Sample: Function Calling",
-                Instructions =
+                DefaultInstructions =
                     "Don't make assumptions about what values to plug into functions."
                     + " Ask for clarification if a user request is ambiguous.",
                 Tools = { getCurrentLocationFunction, getCurrentWeatherFunction },
@@ -59,7 +59,7 @@ namespace OpenAI.Samples
                     {
                         RequiredFunctionToolCall requiredFunctionToolCall = action as RequiredFunctionToolCall;
 
-                        switch (requiredFunctionToolCall?.Name)
+                        switch (requiredFunctionToolCall?.FunctionName)
                         {
                             case GetCurrentLocationFunctionName:
                                 {

--- a/.dotnet/tests/Samples/Chat/Sample03_FunctionCalling.cs
+++ b/.dotnet/tests/Samples/Chat/Sample03_FunctionCalling.cs
@@ -29,13 +29,13 @@ namespace OpenAI.Samples
 
         private static readonly ChatFunctionToolDefinition getCurrentLocationFunction = new()
         {
-            Name = GetCurrentLocationFunctionName,
+            FunctionName = GetCurrentLocationFunctionName,
             Description = "Get the user's current location"
         };
 
         private static readonly ChatFunctionToolDefinition getCurrentWeatherFunction = new()
         {
-            Name = GetCurrentWeatherFunctionName,
+            FunctionName = GetCurrentWeatherFunctionName,
             Description = "Get the current weather in a given location",
             Parameters = BinaryData.FromString("""
                 {
@@ -104,7 +104,7 @@ namespace OpenAI.Samples
                             {
                                 ChatFunctionToolCall functionToolCall = toolCall as ChatFunctionToolCall;
 
-                                switch (functionToolCall?.Name)
+                                switch (functionToolCall?.FunctionName)
                                 {
                                     case GetCurrentLocationFunctionName:
                                         {

--- a/.dotnet/tests/Samples/Chat/Sample03_FunctionCallingAsync.cs
+++ b/.dotnet/tests/Samples/Chat/Sample03_FunctionCallingAsync.cs
@@ -56,7 +56,7 @@ namespace OpenAI.Samples
                             {
                                 ChatFunctionToolCall functionToolCall = toolCall as ChatFunctionToolCall;
 
-                                switch (functionToolCall?.Name)
+                                switch (functionToolCall?.FunctionName)
                                 {
                                     case GetCurrentLocationFunctionName:
                                         {

--- a/.dotnet/tests/Samples/CombinationSamples.cs
+++ b/.dotnet/tests/Samples/CombinationSamples.cs
@@ -21,8 +21,8 @@ namespace OpenAI.Samples.Miscellaneous
                 "a majestic alpaca on a mountain ridge, backed by an expansive blue sky accented with sparse clouds",
                 new()
                 {
-                    Style = ImageStyle.Vivid,
-                    Quality = ImageQuality.High,
+                    Style = GeneratedImageStyle.Vivid,
+                    Quality = GeneratedImageQuality.High,
                     Size = GeneratedImageSize.W1792xH1024,
                 });
             GeneratedImage imageGeneration = imageResult.Value;
@@ -42,7 +42,7 @@ namespace OpenAI.Samples.Miscellaneous
                 {
                     MaxTokens = 2048,
                 });
-            string chatResponseText = chatResult.Value.Content;
+            string chatResponseText = chatResult.Value.Content.ToText();
             Console.WriteLine($"Art critique of majestic alpaca:\n{chatResponseText}");
 
             // Finally, we'll get some text-to-speech for that critical evaluation using tts-1-hd:
@@ -79,7 +79,7 @@ namespace OpenAI.Samples.Miscellaneous
                 {
                     MaxTokens = 2048,
                 });
-            string description = creativeWriterResult.Value.Content;
+            string description = (string)creativeWriterResult.Value.Content;
             Console.WriteLine($"Creative helper's creature description:\n{description}");
 
             // Asynchronously, in parallel to the next steps, we'll get the creative description in the voice of Onyx
@@ -109,7 +109,7 @@ namespace OpenAI.Samples.Miscellaneous
                 new ImageGenerationOptions()
                 {
                     Size = GeneratedImageSize.W1792xH1024,
-                    Quality = ImageQuality.High,
+                    Quality = GeneratedImageQuality.High,
                 });
             Uri imageLocation = imageGenerationResult.Value.ImageUri;
             Console.WriteLine($"Creature image available at:\n{imageLocation.AbsoluteUri}");
@@ -127,7 +127,7 @@ namespace OpenAI.Samples.Miscellaneous
                 {
                     MaxTokens = 2048,
                 });
-            string appraisal = criticalAppraisalResult.Value.Content;
+            string appraisal = (string)criticalAppraisalResult.Value.Content;
             Console.WriteLine($"Critic's appraisal:\n{appraisal}");
 
             // Finally, we'll get that art expert's laudations in the voice of Fable

--- a/.dotnet/tests/Samples/Images/Sample01_SimpleImage.cs
+++ b/.dotnet/tests/Samples/Images/Sample01_SimpleImage.cs
@@ -23,9 +23,9 @@ namespace OpenAI.Samples
 
             ImageGenerationOptions options = new()
             {
-                Quality = ImageQuality.High,
+                Quality = GeneratedImageQuality.High,
                 Size = GeneratedImageSize.W1792xH1024,
-                Style = ImageStyle.Vivid,
+                Style = GeneratedImageStyle.Vivid,
                 ResponseFormat = ImageResponseFormat.Bytes
             };
 

--- a/.dotnet/tests/Samples/Images/Sample01_SimpleImageAsync.cs
+++ b/.dotnet/tests/Samples/Images/Sample01_SimpleImageAsync.cs
@@ -24,9 +24,9 @@ namespace OpenAI.Samples
 
             ImageGenerationOptions options = new()
             {
-                Quality = ImageQuality.High,
+                Quality = GeneratedImageQuality.High,
                 Size = GeneratedImageSize.W1792xH1024,
-                Style = ImageStyle.Vivid,
+                Style = GeneratedImageStyle.Vivid,
                 ResponseFormat = ImageResponseFormat.Bytes
             };
 

--- a/.dotnet/tests/TestScenarios/AssistantTests.cs
+++ b/.dotnet/tests/TestScenarios/AssistantTests.cs
@@ -70,7 +70,7 @@ public partial class AssistantTests
                 {
                     new FunctionToolDefinition()
                     {
-                        Name = "get_favorite_food_for_day_of_week",
+                        FunctionName = "get_favorite_food_for_day_of_week",
                         Description = "gets the user's favorite food for a given day of the week, like Tuesday",
                         Parameters = BinaryData.FromObjectAsJson(new
                         {

--- a/.dotnet/tests/TestScenarios/ChatToolConstraints.cs
+++ b/.dotnet/tests/TestScenarios/ChatToolConstraints.cs
@@ -16,12 +16,12 @@ public partial class ChatToolConstraintTests
 
         ChatFunctionToolDefinition functionTool = new()
         {
-            Name = "test_function_tool",
+            FunctionName = "test_function_tool",
             Description = "description isn't applicable",
         };
 
         ChatToolConstraint constraintFromDefinition = new(functionTool);
-        Assert.That(constraintFromDefinition.ToString(), Is.EqualTo(@$"{{""type"":""function"",""function"":{{""name"":""{functionTool.Name}""}}}}"));
+        Assert.That(constraintFromDefinition.ToString(), Is.EqualTo(@$"{{""type"":""function"",""function"":{{""name"":""{functionTool.FunctionName}""}}}}"));
 
         ChatToolConstraint otherConstraint = new(new ChatFunctionToolDefinition("test_function_tool"));
         Assert.That(constraintFromDefinition, Is.EqualTo(otherConstraint));
@@ -53,7 +53,7 @@ public partial class ChatToolConstraintTests
 
     private static ChatFunctionToolDefinition s_numberForWordTool = new()
     {
-        Name = "get_number_for_word",
+        FunctionName = "get_number_for_word",
         Description = "gets an arbitrary number assigned to a given word",
         Parameters = BinaryData.FromObjectAsJson(new
         {

--- a/.dotnet/tests/TestScenarios/ChatToolTests.cs
+++ b/.dotnet/tests/TestScenarios/ChatToolTests.cs
@@ -17,7 +17,7 @@ public partial class ChatToolTests
         ChatClient client = new("gpt-3.5-turbo");
         ChatFunctionToolDefinition getFavoriteColorTool = new()
         {
-            Name = "get_favorite_color",
+            FunctionName = "get_favorite_color",
             Description = "gets the favorite color of the caller",
         };
         ChatCompletionOptions options = new()
@@ -30,7 +30,7 @@ public partial class ChatToolTests
         var functionToolCall = result.Value.ToolCalls[0] as ChatFunctionToolCall;
         var toolCallArguments = BinaryData.FromString(functionToolCall.Arguments).ToObjectFromJson<Dictionary<string, object>>();
         Assert.That(functionToolCall, Is.Not.Null);
-        Assert.That(functionToolCall.Name, Is.EqualTo(getFavoriteColorTool.Name));
+        Assert.That(functionToolCall.FunctionName, Is.EqualTo(getFavoriteColorTool.FunctionName));
         Assert.That(functionToolCall.Id, Is.Not.Null.Or.Empty);
         Assert.That(toolCallArguments.Count, Is.EqualTo(0));
 
@@ -50,7 +50,7 @@ public partial class ChatToolTests
         ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
         ChatFunctionToolDefinition favoriteColorForMonthTool = new()
         {
-            Name = "get_favorite_color_for_month",
+            FunctionName = "get_favorite_color_for_month",
             Description = "gets the caller's favorite color for a given month",
             Parameters = BinaryData.FromString("""
                 {
@@ -77,7 +77,7 @@ public partial class ChatToolTests
         Assert.That(result.Value.FinishReason, Is.EqualTo(ChatFinishReason.ToolCalls));
         Assert.That(result.Value.ToolCalls?.Count, Is.EqualTo(1));
         var functionToolCall = result.Value.ToolCalls[0] as ChatFunctionToolCall;
-        Assert.That(functionToolCall.Name, Is.EqualTo(favoriteColorForMonthTool.Name));
+        Assert.That(functionToolCall.FunctionName, Is.EqualTo(favoriteColorForMonthTool.FunctionName));
         JsonObject argumentsJson = JsonSerializer.Deserialize<JsonObject>(functionToolCall.Arguments);
         Assert.That(argumentsJson.Count, Is.EqualTo(1));
         Assert.That(argumentsJson.ContainsKey("month_name"));

--- a/.dotnet/tests/TestScenarios/ImageGenerationTests.cs
+++ b/.dotnet/tests/TestScenarios/ImageGenerationTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using OpenAI.Images;
+using OpenAI.Tests.Chat;
 using System;
 using System.ClientModel;
 using static OpenAI.Tests.TestHelpers;
@@ -21,13 +22,24 @@ public partial class ImageGenerationTests
     }
 
     [Test]
+    public void DataResponseFormatWorks()
+    {
+        ImageClient client = GetTestClient();
+        ClientResult<GeneratedImage> result = client.GenerateImage("an isolated stop sign", new ImageGenerationOptions()
+        {
+            ResponseFormat = ImageResponseFormat.Bytes,
+        });
+        Assert.That(result?.Value?.ImageBytes, Is.Not.Null);
+    }
+
+    [Test]
     public void GenerationWithOptionsWorks()
     {
         ImageClient client = GetTestClient();
         ClientResult<GeneratedImage> result = client.GenerateImage("an isolated stop sign", new ImageGenerationOptions()
         {
-            Quality = ImageQuality.Standard,
-            Style = ImageStyle.Natural,
+            Quality = GeneratedImageQuality.Standard,
+            Style = GeneratedImageStyle.Natural,
         });
         Assert.That(result.Value.ImageUri, Is.Not.Null);
     }

--- a/.dotnet/tests/Utility/TestHelpers.cs
+++ b/.dotnet/tests/Utility/TestHelpers.cs
@@ -33,7 +33,6 @@ internal static class TestHelpers
     {
         OpenAIClientOptions options = new();
         options.AddPolicy(GetDumpPolicy(), PipelinePosition.PerTry);
-        options.ErrorOptions = throwOnError ? ClientErrorBehaviors.Default : ClientErrorBehaviors.NoThrow;
         object clientObject = scenario switch
         {
             TestScenario.Chat => new ChatClient(overrideModel ?? "gpt-3.5-turbo", credential: null, options),


### PR DESCRIPTION
This PR touches many files, but the volume comes primarily from bulk pattern application.

Changes include:
- Per SCM guidance, nullable reference type support is added to the project and a first pass has been made across the public surface; this isn't 100% complete, particularly in the internal details, but it's the majority and allows a clear look at the pattern changes.
- `Name` properties have been been updated to use a more specific name -- either `FunctionName` or `ParticipantName` -- in cases where the question of "what is this the name of" isn't trivially inferable from the type.
- Public setters on request types have been removed, replaced with `init` for types where `required`/`init` are an intended initialization pattern.
- `ChatMessageContent`'s type conversions to `string` and (new) `Uri` are now explicit.
- `ChatRequestAssistantMessage` now uses "text" for its content constructor parameter name.
- `CreatedAt` is now present on `GeneratedImageCollection` (in addition to its emplacement on `GeneratedImage`).
- `ImageQuality` and `ImageStyle` are renamed with the consistent `Generated*` prefix.
- `OpenAIClientOptions`  now derives from the appropriate `PipelineClientOptions` type.
- `GetLegacyCompletionClient` is removed from `OpenAIClient`.
- 
