### PR TITLE
ApiView: port smaller set of feedback changes

### DIFF
--- a/.dotnet/src/Custom/Assistants/Assistant.cs
+++ b/.dotnet/src/Custom/Assistants/Assistant.cs
@@ -33,16 +33,22 @@ public partial class Assistant
         Description = internalAssistant.Description;
         DefaultModel = internalAssistant.Model;
         DefaultInstructions = internalAssistant.Instructions;
-        Metadata = internalAssistant.Metadata;
+        DefaultTools = GetToolsFromInternalTools(internalAssistant.Tools);
+        Metadata = internalAssistant.Metadata ?? new Dictionary<string, string>();
+    }
 
-        if (internalAssistant.Tools != null)
+    private static IReadOnlyList<ToolDefinition> GetToolsFromInternalTools(IReadOnlyList<BinaryData>? internalTools)
+    {
+        if (internalTools is not null)
         {
             List<ToolDefinition> tools = [];
-            foreach (BinaryData unionToolDefinitionData in internalAssistant.Tools)
+            foreach (BinaryData unionToolDefinitionData in internalTools)
             {
-                tools.Add(ToolDefinition.DeserializeToolDefinition(JsonDocument.Parse(unionToolDefinitionData).RootElement));
+                using JsonDocument toolDocument = JsonDocument.Parse(unionToolDefinitionData);
+                tools.Add(ToolDefinition.DeserializeToolDefinition(toolDocument.RootElement));
             }
-            DefaultTools = tools;
+            return tools;
         }
+        return [];
     }
 }

--- a/.dotnet/src/Custom/Assistants/AssistantClient.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantClient.cs
@@ -626,10 +626,10 @@ public partial class AssistantClient
         options ??= new();
         return new(
             assistantId,
-            options.OverrideModel,
-            options.OverrideInstructions,
+            options.ModelOverride,
+            options.InstructionsOverride,
             options.AdditionalInstructions,
-            ToInternalBinaryDataList(options.OverrideTools),
+            ToInternalBinaryDataList(options.ToolsOverride),
             options.Metadata,
             serializedAdditionalRawData: null);
     }
@@ -645,9 +645,9 @@ public partial class AssistantClient
         return new Internal.Models.CreateThreadAndRunRequest(
             assistantId,
             internalThreadOptions,
-            runOptions?.OverrideModel,
-            runOptions.OverrideInstructions,
-            ToInternalBinaryDataList(runOptions?.OverrideTools),
+            runOptions?.ModelOverride,
+            runOptions.InstructionsOverride,
+            ToInternalBinaryDataList(runOptions?.ToolsOverride),
             runOptions?.Metadata,
             serializedAdditionalRawData: null);
     }

--- a/.dotnet/src/Custom/Assistants/AssistantCreationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantCreationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;
@@ -13,16 +10,16 @@ public partial class AssistantCreationOptions
     /// <summary>
     /// An optional display name for the assistant.
     /// </summary>
-    public string Name { get; set; }
+    public string Name { get; init; }
     /// <summary>
     /// A description to associate with the assistant.
     /// </summary>
-    public string Description { get; set; }
+    public string Description { get; init; }
 
     /// <summary>
     /// Default instructions for the assistant to use when creating messages.
     /// </summary>
-    public string Instructions { get; set; }
+    public string Instructions { get; init; }
 
     /// <summary>
     /// A collection of default tool definitions to enable for the assistant. Available tools include:

--- a/.dotnet/src/Custom/Assistants/AssistantModificationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantModificationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;
@@ -13,22 +10,22 @@ public partial class AssistantModificationOptions
     /// <summary>
     /// The new model that the assistant should use when creating messages.
     /// </summary>
-    public string Model { get; }
+    public string Model { get; init; }
 
     /// <summary>
     /// A new, friendly name for the assistant. Its <see cref="Assistant.Id"/> will remain unchanged.
     /// </summary>
-    public string Name { get; }
+    public string Name { get; init; }
 
     /// <summary>
     /// A new description to associate with the assistant.
     /// </summary>
-    public string Description { get; }
+    public string Description { get; init; }
 
     /// <summary>
     /// New, default instructions for the assistant to use when creating messages.
     /// </summary>
-    public string Instructions { get; }
+    public string Instructions { get; init; }
 
     /// <summary>
     /// A new collection of default tool definitions to enable for the assistant. Available tools include:

--- a/.dotnet/src/Custom/Assistants/AssistantThread.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantThread.cs
@@ -24,7 +24,7 @@ public partial class AssistantThread
     internal AssistantThread(Internal.Models.ThreadObject internalThread)
     {
         Id = internalThread.Id;
-        Metadata = internalThread.Metadata;
+        Metadata = internalThread.Metadata ?? new Dictionary<string, string>();
         CreatedAt = internalThread.CreatedAt;
     }
 

--- a/.dotnet/src/Custom/Assistants/CodeInterpreterToolInfo.cs
+++ b/.dotnet/src/Custom/Assistants/CodeInterpreterToolInfo.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/FunctionToolDefinition.cs
+++ b/.dotnet/src/Custom/Assistants/FunctionToolDefinition.cs
@@ -1,24 +1,20 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Assistants;
 
 public partial class FunctionToolDefinition : ToolDefinition
 {
-    public required string Name { get; set; }
-    public string Description { get; set; }
-    public BinaryData Parameters { get; set; }
+    public required string FunctionName { get; init; }
+    public string Description { get; init; }
+    public BinaryData Parameters { get; init; }
 
     [SetsRequiredMembers]
     public FunctionToolDefinition(string name, string description = null, BinaryData parameters = null)
     {
-        Name = name;
+        FunctionName = name;
         Description = description;
         Parameters = parameters;
     }
@@ -74,7 +70,7 @@ public partial class FunctionToolDefinition : ToolDefinition
         writer.WriteString("type"u8, "function"u8);
         writer.WritePropertyName("function"u8);
         writer.WriteStartObject();
-        writer.WriteString("name"u8, Name);
+        writer.WriteString("name"u8, FunctionName);
         if (Optional.IsDefined(Description))
         {
             writer.WriteString("description"u8, Description);

--- a/.dotnet/src/Custom/Assistants/FunctionToolInfo.cs
+++ b/.dotnet/src/Custom/Assistants/FunctionToolInfo.cs
@@ -1,22 +1,18 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Assistants;
 
 public partial class FunctionToolInfo : ToolInfo
 {
-    public string Name { get; }
+    public string FunctionName { get; }
     public string Description { get; }
     public BinaryData Parameters { get; }
 
     internal FunctionToolInfo(string name, string description, BinaryData parameters)
     {
-        Name = name;
+        FunctionName = name;
         Description = description;
         Parameters = parameters;
     }
@@ -68,7 +64,7 @@ public partial class FunctionToolInfo : ToolInfo
         writer.WriteString("type"u8, "function"u8);
         writer.WritePropertyName("function"u8);
         writer.WriteStartObject();
-        writer.WriteString("name"u8, Name);
+        writer.WriteString("name"u8, FunctionName);
         if (Optional.IsDefined(Description))
         {
             writer.WriteString("description"u8, Description);

--- a/.dotnet/src/Custom/Assistants/MessageContent.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/MessageContent.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/MessageCreationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/MessageCreationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/MessageImageFileContent.cs
+++ b/.dotnet/src/Custom/Assistants/MessageImageFileContent.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/MessageTextContent.cs
+++ b/.dotnet/src/Custom/Assistants/MessageTextContent.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -18,7 +17,7 @@ public class MessageTextContent : MessageContent
     internal MessageTextContent(string text, IReadOnlyList<TextContentAnnotation> annotations)
     {
         Text = text;
-        Annotations = annotations;
+        Annotations = annotations ?? [];
     }
 
     internal override void WriteDerived(Utf8JsonWriter writer, ModelReaderWriterOptions options)

--- a/.dotnet/src/Custom/Assistants/RequiredFunctionToolCall.cs
+++ b/.dotnet/src/Custom/Assistants/RequiredFunctionToolCall.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 
@@ -6,13 +5,13 @@ namespace OpenAI.Assistants;
 
 public partial class RequiredFunctionToolCall : RequiredToolCall
 {
-    public string Name { get; }
+    public string FunctionName { get; }
     public string Arguments { get; }
 
     internal RequiredFunctionToolCall(string id, string name, string arguments)
         : base(id)
     {
-        Name = name;
+        FunctionName = name;
         Arguments = arguments;
     }
 

--- a/.dotnet/src/Custom/Assistants/RequiredToolCall.cs
+++ b/.dotnet/src/Custom/Assistants/RequiredToolCall.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/RetrievalToolDefinition.cs
+++ b/.dotnet/src/Custom/Assistants/RetrievalToolDefinition.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/RetrievalToolInfo.cs
+++ b/.dotnet/src/Custom/Assistants/RetrievalToolInfo.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/RunCreationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/RunCreationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;
@@ -10,26 +7,24 @@ namespace OpenAI.Assistants;
 /// </summary>
 public partial class RunCreationOptions
 {
-
-
     /// <summary>
     /// A run-specific model name that will override the assistant's defined model. If not provided, the assistant's
     /// selection will be used.
     /// </summary>
-    public string OverrideModel { get; set; }
+    public string ModelOverride { get; init; }
 
     /// <summary>
     /// A run specific replacement for the assistant's default instructions that will override the assistant-level
     /// instructions. If not specified, the assistant's instructions will be used.
     /// </summary>
-    public string OverrideInstructions { get; set; }
+    public string InstructionsOverride { get; init; }
 
     /// <summary>
     /// Run-specific additional instructions that will be appended to the assistant-level instructions solely for this
-    /// run. Unlike <see cref="OverrideInstructions"/>, the assistant's instructions are preserved and these additional
+    /// run. Unlike <see cref="InstructionsOverride"/>, the assistant's instructions are preserved and these additional
     /// instructions are concatenated.
     /// </summary>
-    public string AdditionalInstructions { get; set; }
+    public string AdditionalInstructions { get; init; }
 
     /// <summary>
     /// A run-specific collection of tool definitions that will override the assistant-level defaults. If not provided,
@@ -51,7 +46,7 @@ public partial class RunCreationOptions
     /// </list>
     /// </para>
     /// </summary>
-    public IList<ToolDefinition> OverrideTools { get; } = new ChangeTrackingList<ToolDefinition>();
+    public IList<ToolDefinition> ToolsOverride { get; } = new ChangeTrackingList<ToolDefinition>();
 
     /// <summary>
     /// An optional key/value mapping of additional, supplemental data items to attach to the <see cref="ThreadRun"/>.

--- a/.dotnet/src/Custom/Assistants/RunError.cs
+++ b/.dotnet/src/Custom/Assistants/RunError.cs
@@ -1,5 +1,3 @@
-using OpenAI.Chat;
-
 namespace OpenAI.Assistants;
 
 public partial class RunError

--- a/.dotnet/src/Custom/Assistants/RunModificationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/RunModificationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/RunRequiredAction.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/RunRequiredAction.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;

--- a/.dotnet/src/Custom/Assistants/TextContentAnnotation.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentAnnotation.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/TextContentFileCitationAnnotation.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentFileCitationAnnotation.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/TextContentFilePathAnnotation.cs
+++ b/.dotnet/src/Custom/Assistants/TextContentFilePathAnnotation.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/ThreadCreationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/ThreadCreationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 
 namespace OpenAI.Assistants;

--- a/.dotnet/src/Custom/Assistants/ThreadInitializationMessage.cs
+++ b/.dotnet/src/Custom/Assistants/ThreadInitializationMessage.cs
@@ -1,6 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System.ClientModel.Internal;
-
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 

--- a/.dotnet/src/Custom/Assistants/ThreadMessage.cs
+++ b/.dotnet/src/Custom/Assistants/ThreadMessage.cs
@@ -53,8 +53,8 @@ public partial class ThreadMessage
         AssistantId = internalMessage.AssistantId;
         ThreadId = internalMessage.ThreadId;
         RunId = internalMessage.RunId;
-        Metadata = internalMessage.Metadata;
-        FileIds = internalMessage.FileIds;
+        Metadata = internalMessage.Metadata ?? new Dictionary<string, string>();
+        FileIds = internalMessage.FileIds ?? [];
         CreatedAt = internalMessage.CreatedAt;
         Role = convertedRole;
         ContentItems = content;

--- a/.dotnet/src/Custom/Assistants/ThreadRun.cs
+++ b/.dotnet/src/Custom/Assistants/ThreadRun.cs
@@ -61,9 +61,8 @@ public partial class ThreadRun
             "expired" => RunStatus.Expired,
             _ => throw new ArgumentException(nameof(Status)),
         };
-        Metadata = internalRun.Metadata;
-        FileIds = internalRun.FileIds;
-        Metadata = internalRun.Metadata;
+        Metadata = internalRun.Metadata ?? new Dictionary<string, string>();
+        FileIds = internalRun.FileIds ?? [];
         Model = internalRun.Model;
         Instructions = internalRun.Instructions;
 
@@ -77,21 +76,21 @@ public partial class ThreadRun
             Usage = new(internalRun.Usage);
         }
 
+        List<ToolInfo> tools = [];
         if (internalRun.Tools != null)
         {
-            List<ToolInfo> tools = [];
             foreach (BinaryData unionToolInfo in internalRun.Tools)
             {
                 tools.Add(ToolInfo.DeserializeToolInfo(JsonDocument.Parse(unionToolInfo).RootElement));
             }
-            Tools = tools;
         }
+        Tools = tools;
 
+        List<RunRequiredAction> actions = [];
         IReadOnlyList<Internal.Models.RunToolCallObject> internalFunctionCalls
             = internalRun.RequiredAction?.SubmitToolOutputs?.ToolCalls;
         if (internalFunctionCalls != null)
         {
-            List<RunRequiredAction> actions = [];
             foreach (Internal.Models.RunToolCallObject internalToolCall in internalFunctionCalls)
             {
                 actions.Add(new RequiredFunctionToolCall(
@@ -99,7 +98,7 @@ public partial class ThreadRun
                     internalToolCall.Function.Name,
                     internalToolCall.Function.Arguments));
             }
-            RequiredActions = actions;
         }
+        RequiredActions = actions;
     }
 }

--- a/.dotnet/src/Custom/Assistants/ToolInfo.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolInfo.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Assistants/ToolOutput.Serialization.cs
+++ b/.dotnet/src/Custom/Assistants/ToolOutput.Serialization.cs
@@ -1,10 +1,6 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Assistants;
 

--- a/.dotnet/src/Custom/Assistants/ToolOutput.cs
+++ b/.dotnet/src/Custom/Assistants/ToolOutput.cs
@@ -5,10 +5,8 @@ namespace OpenAI.Assistants;
 
 public partial class ToolOutput
 {
-    [JsonPropertyName("tool_call_id")]
-    public required string Id { get; set; }
-    [JsonPropertyName("output")]
-    public string Output { get; set; }
+    public required string Id { get; init; }
+    public string Output { get; init; }
 
     public ToolOutput()
     { }

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -3,7 +3,6 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.IO;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -314,6 +313,7 @@ public partial class AudioClient
                 AudioDataFormat.Mpga => "mpga",
                 AudioDataFormat.Ogg => "ogg",
                 AudioDataFormat.Opus => "opus",
+                AudioDataFormat.Pcm => "pcm",
                 AudioDataFormat.Wav => "wav",
                 AudioDataFormat.Webm => "webm",
                 _ => throw new ArgumentException(nameof(options.ResponseFormat)),

--- a/.dotnet/src/Custom/Audio/AudioDataFormat.cs
+++ b/.dotnet/src/Custom/Audio/AudioDataFormat.cs
@@ -74,6 +74,11 @@ public enum AudioDataFormat
     /// </summary>
     Opus,
     /// <summary>
+    /// PCM, an uncompressed, lossless format that is similar to WAV but uses headerless 24khz audio chunks rather than
+    /// a header-configured format.
+    /// </summary>
+    Pcm,
+    /// <summary>
     /// WAV, an uncompressed, lossless format with maximum quality, highest file size, and minimal decoding.
     /// <para>
     /// <c>wav</c> is supported as input into translation and transcription but is <b>not</b> available for

--- a/.dotnet/src/Custom/Audio/AudioTranscription.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscription.cs
@@ -11,15 +11,15 @@ public partial class AudioTranscription
     public TimeSpan? Duration { get; }
     public string Text { get; }
     public IReadOnlyList<TranscribedWord> Words { get; }
-    public IReadOnlyList<TranscriptionSegment> Segments { get; }
+    public IReadOnlyList<TranscribedSegment> Segments { get; }
 
-    internal AudioTranscription(string language, TimeSpan? duration, string text, IReadOnlyList<TranscribedWord> words, IReadOnlyList<TranscriptionSegment> segments)
+    internal AudioTranscription(string language, TimeSpan? duration, string text, IReadOnlyList<TranscribedWord> words, IReadOnlyList<TranscribedSegment> segments)
     {
         Language = language;
         Duration = duration;
         Text = text;
-        Words = words;
-        Segments = segments;
+        Words = words ?? [];
+        Segments = segments ?? [];
     }
 
     internal static AudioTranscription Deserialize(BinaryData content)
@@ -34,7 +34,7 @@ public partial class AudioTranscription
         TimeSpan? duration = null;
         string text = null;
         List<TranscribedWord> words = null;
-        List<TranscriptionSegment> segments = null;
+        List<TranscribedSegment> segments = null;
 
         foreach (JsonProperty topLevelProperty in element.EnumerateObject())
         {
@@ -67,7 +67,7 @@ public partial class AudioTranscription
                 segments = [];
                 foreach (JsonElement segmentElement in topLevelProperty.Value.EnumerateArray())
                 {
-                    segments.Add(TranscriptionSegment.DeserializeTranscriptionSegment(segmentElement, options));
+                    segments.Add(TranscribedSegment.DeserializeTranscriptionSegment(segmentElement, options));
                 }
                 continue;
             }

--- a/.dotnet/src/Custom/Audio/AudioTranscriptionFormat.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscriptionFormat.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace OpenAI.Audio;
 
 public enum AudioTranscriptionFormat

--- a/.dotnet/src/Custom/Audio/AudioTranscriptionOptions.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscriptionOptions.cs
@@ -8,12 +8,12 @@ namespace OpenAI.Audio;
 
 public partial class AudioTranscriptionOptions
 {
-    public string Language { get; set; }
-    public string Prompt { get; set; }
-    public AudioTranscriptionFormat? ResponseFormat { get; set; }
-    public float? Temperature { get; set; }
-    public bool? EnableWordTimestamps { get; set; }
-    public bool? EnableSegmentTimestamps { get; set; }
+    public string Language { get; init; }
+    public string Prompt { get; init; }
+    public AudioTranscriptionFormat? ResponseFormat { get; init; }
+    public float? Temperature { get; init; }
+    public bool? EnableWordTimestamps { get; init; }
+    public bool? EnableSegmentTimestamps { get; init; }
 
     internal MultipartFormDataBinaryContent ToMultipartContent(Stream fileStream, string fileName, string model)
     {

--- a/.dotnet/src/Custom/Audio/AudioTranslationOptions.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranslationOptions.cs
@@ -6,9 +6,9 @@ namespace OpenAI.Audio;
 
 public partial class AudioTranslationOptions
 {
-    public string Prompt { get; set;  }
-    public AudioTranscriptionFormat? ResponseFormat { get; set; }
-    public float? Temperature { get; set; }
+    public string Prompt { get; init;  }
+    public AudioTranscriptionFormat? ResponseFormat { get; init; }
+    public float? Temperature { get; init; }
 
     internal MultipartFormDataBinaryContent ToMultipartContent(Stream fileStream, string fileName, string model)
     {

--- a/.dotnet/src/Custom/Audio/TextToSpeechOptions.cs
+++ b/.dotnet/src/Custom/Audio/TextToSpeechOptions.cs
@@ -19,11 +19,11 @@ public partial class TextToSpeechOptions
     /// </list>
     /// </para>
     /// </summary>
-    public AudioDataFormat? ResponseFormat { get; set; }
+    public AudioDataFormat? ResponseFormat { get; init; }
 
     /// <summary>
     /// A multiplicative <c>speed</c> factor to apply to the generated audio, with 1.0 being the default and valid
     /// values ranging from 0.25 to 4.0.
     /// </summary>
-    public float? SpeedMultiplier { get; set; }
+    public float? SpeedMultiplier { get; init; }
 }

--- a/.dotnet/src/Custom/Audio/TranscribedSegment.cs
+++ b/.dotnet/src/Custom/Audio/TranscribedSegment.cs
@@ -2,11 +2,10 @@ using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Threading;
 
 namespace OpenAI.Audio;
 
-public readonly partial struct TranscriptionSegment
+public readonly partial struct TranscribedSegment
 {
     public int Id { get; }
     public int SeekOffset { get; }
@@ -19,21 +18,21 @@ public readonly partial struct TranscriptionSegment
     public float CompressionRatio { get; }
     public float NoSpeechProbability { get; }
 
-    internal TranscriptionSegment(int id, int seekOffset, TimeSpan start, TimeSpan end, string text, IReadOnlyList<int> tokenIds, float temperature, float averageLogProbability, float compressionRatio, float noSpeechProbability)
+    internal TranscribedSegment(int id, int seekOffset, TimeSpan start, TimeSpan end, string text, IReadOnlyList<int> tokenIds, float temperature, float averageLogProbability, float compressionRatio, float noSpeechProbability)
     {
         Id = id;
         SeekOffset = seekOffset;
         Start = start;
         End = end;
         Text = text;
-        TokenIds = tokenIds;
+        TokenIds = tokenIds ?? [];
         Temperature = temperature;
         AverageLogProbability = averageLogProbability;
         CompressionRatio = compressionRatio;
         NoSpeechProbability = noSpeechProbability;
     }
 
-    internal static TranscriptionSegment DeserializeTranscriptionSegment(JsonElement element, ModelReaderWriterOptions options = default)
+    internal static TranscribedSegment DeserializeTranscriptionSegment(JsonElement element, ModelReaderWriterOptions options = default)
     {
         int id = 0;
         int seekOffset = 0;
@@ -104,6 +103,6 @@ public readonly partial struct TranscriptionSegment
             }
         }
 
-        return new TranscriptionSegment(id, seekOffset, start, end, text, tokenIds, temperature, averageLogProbability, compressionRatio, noSpeechProbability);
+        return new TranscribedSegment(id, seekOffset, start, end, text, tokenIds, temperature, averageLogProbability, compressionRatio, noSpeechProbability);
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatCompletion.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletion.cs
@@ -1,4 +1,3 @@
-using OpenAI.ClientShared.Internal;
 using System;
 using System.Collections.Generic;
 
@@ -58,9 +57,9 @@ public class ChatCompletion
             _ => throw new ArgumentException(nameof(internalChoice.FinishReason)),
         };
         Content = internalChoice.Message.Content;
+        ChangeTrackingList<ChatToolCall> toolCalls = [];
         if (internalChoice.Message.ToolCalls != null)
         {
-            ChangeTrackingList<ChatToolCall> toolCalls = [];
             foreach (Internal.Models.ChatCompletionMessageToolCall internalToolCall in internalChoice.Message.ToolCalls)
             {
                 if (internalToolCall.Type == "function")
@@ -68,15 +67,12 @@ public class ChatCompletion
                     toolCalls.Add(new ChatFunctionToolCall(internalToolCall.Id, internalToolCall.Function.Name, internalToolCall.Function.Arguments));
                 }
             }
-            ToolCalls = toolCalls;
         }
+        ToolCalls = toolCalls;
         if (internalChoice.Message.FunctionCall != null)
         {
             FunctionCall = new(internalChoice.Message.FunctionCall.Name, internalChoice.Message.FunctionCall.Arguments);
         }
-        if (internalChoice.Logprobs != null)
-        {
-            LogProbabilities = ChatLogProbabilityCollection.FromInternalData(internalChoice.Logprobs);
-        }
+        LogProbabilities = ChatLogProbabilityCollection.FromInternalData(internalChoice.Logprobs);
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
@@ -1,6 +1,4 @@
-using OpenAI.ClientShared.Internal;
 using System;
-using System.ClientModel.Internal;
 
 using System.Collections.Generic;
 using System.Text.Json;
@@ -13,37 +11,37 @@ namespace OpenAI.Chat;
 public partial class ChatCompletionOptions
 {
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.FrequencyPenalty" />
-    public double? FrequencyPenalty { get; set; }
+    public double? FrequencyPenalty { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.LogitBias" />
-    public IDictionary<int, int> TokenSelectionBiases { get; set; } = new ChangeTrackingDictionary<int, int>();
+    public IDictionary<int, int> TokenSelectionBiases { get; init; } = new ChangeTrackingDictionary<int, int>();
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Logprobs" />
-    public bool? IncludeLogProbabilities { get; set; }
+    public bool? IncludeLogProbabilities { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.TopLogprobs" />
-    public int? LogProbabilityCount { get; set; }
+    public int? LogProbabilityCount { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.MaxTokens" />
-    public int? MaxTokens { get; set; }
+    public int? MaxTokens { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.PresencePenalty" />
-    public double? PresencePenalty { get; set; }
+    public double? PresencePenalty { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.ResponseFormat" />
-    public ChatResponseFormat? ResponseFormat { get; set; }
+    public ChatResponseFormat? ResponseFormat { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Seed" />
-    public int? Seed { get; set; }
+    public int? Seed { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Stop" />
     public IList<string> StopSequences { get; } = new ChangeTrackingList<string>();
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Temperature" />
-    public double? Temperature { get; set; }
+    public double? Temperature { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.TopP" />
-    public double? NucleusSamplingFactor { get; set; }
+    public double? NucleusSamplingFactor { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Tools" />
     public IList<ChatToolDefinition> Tools { get; } = new ChangeTrackingList<ChatToolDefinition>();
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.ToolChoice" />
-    public ChatToolConstraint? ToolConstraint { get; set; }
+    public ChatToolConstraint? ToolConstraint { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.User" />
-    public string User { get; set; }
+    public string User { get; init; }
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.Functions" />
     public IList<ChatFunctionDefinition> Functions { get; } = new ChangeTrackingList<ChatFunctionDefinition>();
     /// <inheritdoc cref="Internal.Models.CreateChatCompletionRequest.FunctionCall" />
-    public ChatFunctionConstraint? FunctionConstraint { get; set; }
+    public ChatFunctionConstraint? FunctionConstraint { get; init; }
 
     internal BinaryData GetInternalStopSequences()
     {
@@ -73,7 +71,7 @@ public partial class ChatCompletionOptions
             {
                 Internal.Models.FunctionObject functionObject = new(
                     functionTool.Description,
-                    functionTool.Name,
+                    functionTool.FunctionName,
                     CreateInternalFunctionParameters(functionTool.Parameters),
                     serializedAdditionalRawData: null);
                 internalTools.Add(new(functionObject));
@@ -89,7 +87,7 @@ public partial class ChatCompletionOptions
         {
             Internal.Models.ChatCompletionFunctions internalFunction = new(
                 function.Description,
-                function.Name,
+                function.FunctionName,
                 CreateInternalFunctionParameters(function.Parameters),
                 serializedAdditionalRawData: null);
             internalFunctions.Add(internalFunction);

--- a/.dotnet/src/Custom/Chat/ChatFunctionCall.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionCall.Serialization.cs
@@ -1,9 +1,5 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace OpenAI.Chat;

--- a/.dotnet/src/Custom/Chat/ChatFunctionDefinition.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionDefinition.cs
@@ -11,12 +11,12 @@ public class ChatFunctionDefinition
     /// <summary>
     /// The name of the function.
     /// </summary>
-    public required string Name { get; set; }
+    public required string FunctionName { get; init; }
     /// <summary>
-    /// A friendly description of the function. This supplements <see cref="Name"/> in informing the model about when
+    /// A friendly description of the function. This supplements <see cref="FunctionName"/> in informing the model about when
     /// it should call the function.
     /// </summary>
-    public string Description { get; set; }
+    public string Description { get; init; }
     /// <summary>
     /// The parameter information for the function, provided in JSON Schema format.
     /// </summary>
@@ -39,7 +39,7 @@ public class ChatFunctionDefinition
     /// })
     /// </code></para>
     /// </remarks>
-    public BinaryData Parameters { get; set; }
+    public BinaryData Parameters { get; init; }
     /// <summary>
     /// Creates a new instance of <see cref="ChatFunctionDefinition"/>.
     /// </summary>
@@ -53,7 +53,7 @@ public class ChatFunctionDefinition
     [SetsRequiredMembers]
     public ChatFunctionDefinition(string name, string description = null, BinaryData parameters = null)
     {
-        Name = name;
+        FunctionName = name;
         Description = description;
         Parameters = parameters;
     }

--- a/.dotnet/src/Custom/Chat/ChatFunctionToolCall.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionToolCall.cs
@@ -1,5 +1,3 @@
-using System;
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;

--- a/.dotnet/src/Custom/Chat/ChatFunctionToolDefinition.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunctionToolDefinition.cs
@@ -11,12 +11,12 @@ public class ChatFunctionToolDefinition : ChatToolDefinition
     /// <summary>
     /// The name of the function that the tool represents.
     /// </summary>
-    public required string Name { get; set; }
+    public required string FunctionName { get; init; }
     /// <summary>
-    /// A friendly description of the function. This supplements <see cref="Name"/> in informing the model about when
+    /// A friendly description of the function. This supplements <see cref="FunctionName"/> in informing the model about when
     /// it should call the function.
     /// </summary>
-    public string Description { get; set; }
+    public string Description { get; init; }
     /// <summary>
     /// The parameter information for the function, provided in JSON Schema format.
     /// </summary>
@@ -39,7 +39,7 @@ public class ChatFunctionToolDefinition : ChatToolDefinition
     /// })
     /// </code></para>
     /// </remarks>
-    public BinaryData Parameters { get; set; }
+    public BinaryData Parameters { get; init; }
     /// <summary>
     /// Creates a new instance of <see cref="ChatFunctionToolDefinition"/>.
     /// </summary>
@@ -53,7 +53,7 @@ public class ChatFunctionToolDefinition : ChatToolDefinition
     [SetsRequiredMembers]
     public ChatFunctionToolDefinition(string name, string description = null, BinaryData parameters = null)
     {
-        Name = name;
+        FunctionName = name;
         Description = description;
         Parameters = parameters;
     }

--- a/.dotnet/src/Custom/Chat/ChatLogProbabilityCollection.cs
+++ b/.dotnet/src/Custom/Chat/ChatLogProbabilityCollection.cs
@@ -16,7 +16,7 @@ public class ChatLogProbabilityCollection : ReadOnlyCollection<ChatLogProbabilit
     {
         if (internalLogprobs == null)
         {
-            return null;
+            return new([]);
         }
         List<ChatLogProbabilityResult> logProbabilities = [];
         foreach (Internal.Models.ChatCompletionTokenLogprob internalLogprob in internalLogprobs.Content)

--- a/.dotnet/src/Custom/Chat/ChatMessageContent.cs
+++ b/.dotnet/src/Custom/Chat/ChatMessageContent.cs
@@ -96,10 +96,16 @@ public partial class ChatMessageContent
     public static implicit operator ChatMessageContent(string value) => FromText(value);
 
     /// <summary>
-    /// An implicit operator allowing a content item to be treated as a string.
+    /// An explicit operator allowing a content item to be treated as a string.
     /// </summary>
     /// <param name="content"></param>
-    public static implicit operator string(ChatMessageContent content) => content.ToText();
+    public static explicit operator string(ChatMessageContent content) => content.ToText();
+
+    /// <summary>
+    /// An explicit operator allowing a content item to be treated as a URI.
+    /// </summary>
+    /// <param name="content"></param>
+    public static explicit operator Uri(ChatMessageContent content) => content.ToUri();
 
     /// <inheritdoc/>
     public override string ToString()

--- a/.dotnet/src/Custom/Chat/ChatRequestAssistantMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestAssistantMessage.cs
@@ -17,7 +17,7 @@ public class ChatRequestAssistantMessage : ChatRequestMessage
     /// An optional <c>name</c> associated with the assistant message. This is typically defined with a <c>system</c>
     /// message and is used to differentiate between multiple participants of the same role.
     /// </summary>
-    public string Name { get; set; }
+    public string ParticipantName { get; init; }
 
     /// <summary>
     /// The <c>tool_calls</c> furnished by the model that are needed to continue the logical conversation across chat
@@ -105,9 +105,9 @@ public class ChatRequestAssistantMessage : ChatRequestMessage
 
     internal override void WriteDerivedAdditions(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        if (Optional.IsDefined(Name))
+        if (Optional.IsDefined(ParticipantName))
         {
-            writer.WriteString("name"u8, Name);
+            writer.WriteString("name"u8, ParticipantName);
         }
         if (Optional.IsCollectionDefined(ToolCalls))
         {

--- a/.dotnet/src/Custom/Chat/ChatRequestFunctionMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestFunctionMessage.cs
@@ -1,4 +1,3 @@
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 
@@ -15,7 +14,7 @@ public class ChatRequestFunctionMessage : ChatRequestMessage
     /// <summary>
     /// The <c>name</c> of the called function that this message provides information from.
     /// </summary>
-    public string FunctionName { get; set; } // JSON "name"
+    public string FunctionName { get; } // JSON "name"
 
     /// <summary>
     /// Creates a new instance of <see cref="ChatRequestFunctionMessage"/>.

--- a/.dotnet/src/Custom/Chat/ChatRequestMessage.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestMessage.Serialization.cs
@@ -1,11 +1,6 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.ComponentModel.Design;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Chat;
 

--- a/.dotnet/src/Custom/Chat/ChatRequestMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestMessage.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel;
-using System.ClientModel.Primitives;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace OpenAI.Chat;

--- a/.dotnet/src/Custom/Chat/ChatRequestSystemMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestSystemMessage.cs
@@ -1,12 +1,5 @@
-using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Dynamic;
-using System.Runtime.InteropServices;
 using System.Text.Json;
-using OpenAI.ClientShared.Internal;
 
 namespace OpenAI.Chat;
 
@@ -21,7 +14,7 @@ public class ChatRequestSystemMessage : ChatRequestMessage
     /// <summary>
     /// An optional <c>name</c> for the participant.
     /// </summary>
-    public string Name { get; set; } // JSON "name"
+    public string ParticipantName { get; set; } // JSON "name"
 
     /// <summary>
     /// Creates a new instance of <see cref="ChatRequestSystemMessage"/>.
@@ -31,9 +24,9 @@ public class ChatRequestSystemMessage : ChatRequestMessage
 
     internal override void WriteDerivedAdditions(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        if (Optional.IsDefined(Name))
+        if (Optional.IsDefined(ParticipantName))
         {
-            writer.WriteString("name"u8, Name);
+            writer.WriteString("name"u8, ParticipantName);
         }
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatRequestToolMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestToolMessage.cs
@@ -1,10 +1,5 @@
-using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
-using System.Diagnostics.CodeAnalysis;
 
 namespace OpenAI.Chat;
 
@@ -30,7 +25,7 @@ public class ChatRequestToolMessage : ChatRequestMessage
     /// <summary>
     /// The <c>id</c> correlating to the prior <see cref="ChatToolCall"/> made by the model.
     /// </summary>
-    public required string ToolCallId { get; set; }
+    public string ToolCallId { get; }
 
     /// <summary>
     /// Creates a new instance of <see cref="ChatRequestToolMessage"/>.
@@ -41,7 +36,6 @@ public class ChatRequestToolMessage : ChatRequestMessage
     ///     that resolves the tool call and allows the logical conversation to continue. No format restrictions (e.g.
     ///     JSON) are imposed on the content emitted by tools.
     /// </param>
-    [SetsRequiredMembers]
     public ChatRequestToolMessage(string toolCallId, string content)
         : base(ChatRole.Tool, content)
     {

--- a/.dotnet/src/Custom/Chat/ChatRequestUserMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatRequestUserMessage.cs
@@ -1,13 +1,7 @@
-using System.ClientModel.Internal;
-
-using System;
-using System.Collections.Generic;
-using System.Dynamic;
-using System.Text.Json;
-using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Linq;
-using OpenAI.ClientShared.Internal;
+using System.Text.Json;
 
 namespace OpenAI.Chat;
 
@@ -21,7 +15,7 @@ public class ChatRequestUserMessage : ChatRequestMessage
     /// <summary>
     /// An optional <c>name</c> for the participant.
     /// </summary>
-    public string Name { get; set; }
+    public string ParticipantName { get; init; }
 
     /// <summary>
     /// Creates a new instance of <see cref="ChatRequestUserMessage"/> with ordinary text <c>content</c>.
@@ -57,9 +51,9 @@ public class ChatRequestUserMessage : ChatRequestMessage
 
     internal override void WriteDerivedAdditions(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        if (Optional.IsDefined(Name))
+        if (Optional.IsDefined(ParticipantName))
         {
-            writer.WriteString("name"u8, Name);
+            writer.WriteString("name"u8, ParticipantName);
         }
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatResponseFormat.cs
+++ b/.dotnet/src/Custom/Chat/ChatResponseFormat.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OpenAI.Chat;
 
 /// <summary>

--- a/.dotnet/src/Custom/Chat/ChatToolCall.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatToolCall.Serialization.cs
@@ -1,7 +1,4 @@
 using System;
-using System.ClientModel.Internal;
-
-using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 

--- a/.dotnet/src/Custom/Chat/ChatToolCall.cs
+++ b/.dotnet/src/Custom/Chat/ChatToolCall.cs
@@ -11,5 +11,5 @@ public abstract partial class ChatToolCall
     /// A unique identifier associated with the tool call, used in a subsequent <see cref="ChatRequestToolMessage"/> to
     /// resolve the tool call and continue the logical conversation.
     /// </summary>
-    public required string Id { get; set; }
+    public required string Id { get; init; }
 }

--- a/.dotnet/src/Custom/Chat/ChatToolConstraint.cs
+++ b/.dotnet/src/Custom/Chat/ChatToolConstraint.cs
@@ -37,7 +37,7 @@ public readonly struct ChatToolConstraint : IEquatable<ChatToolConstraint>
                 type = "function",
                 function = new
                 {
-                    name = functionToolDefinition.Name,
+                    name = functionToolDefinition.FunctionName,
                 }
             });
         }

--- a/.dotnet/src/Custom/Chat/StreamingChatUpdate.cs
+++ b/.dotnet/src/Custom/Chat/StreamingChatUpdate.cs
@@ -220,7 +220,7 @@ public partial class StreamingChatUpdate
                     int choiceIndex = 0;
                     ChatFinishReason? finishReason = null;
                     List<StreamingToolCallUpdate> toolCallUpdates = [];
-                    ChatLogProbabilityCollection logProbabilities = null;
+                    ChatLogProbabilityCollection logProbabilities = new([]);
 
                     foreach (JsonProperty choiceProperty in choiceElement.EnumerateObject())
                     {

--- a/.dotnet/src/Custom/Chat/StreamingFunctionToolCallUpdate.cs
+++ b/.dotnet/src/Custom/Chat/StreamingFunctionToolCallUpdate.cs
@@ -20,7 +20,7 @@ public partial class StreamingFunctionToolCallUpdate : StreamingToolCallUpdate
     /// parallel tool calls when streaming.
     /// </para>
     /// </remarks>
-    public string Name { get; }
+    public string FunctionName { get; }
 
     /// <summary>
     /// The next new segment of the function arguments for the function tool called by a streaming tool call.
@@ -43,7 +43,7 @@ public partial class StreamingFunctionToolCallUpdate : StreamingToolCallUpdate
         string functionArgumentsUpdate)
         : base("function", id, toolCallIndex)
     {
-        Name = functionName;
+        FunctionName = functionName;
         ArgumentsUpdate = functionArgumentsUpdate;
     }
 

--- a/.dotnet/src/Custom/Embeddings/EmbeddingOptions.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingOptions.cs
@@ -2,7 +2,7 @@ namespace OpenAI.Embeddings;
 
 public class EmbeddingOptions
 {
-    public string User { get; set; }
+    public string User { get; init; }
 
-    public int? Dimensions { get; set; }
+    public int? Dimensions { get; init; }
 }

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -91,13 +91,7 @@ public partial class FileClient
 
     public virtual ClientResult<OpenAIFileInfoCollection> GetFileInfoList(OpenAIFilePurpose? purpose = null)
     {
-        Internal.Models.OpenAIFilePurpose? internalPurpose = ToInternalFilePurpose(purpose);
-        string internalPurposeText = null;
-        if (internalPurpose != null)
-        {
-            internalPurposeText = internalPurpose.ToString();
-        }
-        ClientResult<Internal.Models.ListFilesResponse> result = Shim.GetFiles(internalPurposeText);
+        ClientResult<Internal.Models.ListFilesResponse> result = Shim.GetFiles(purpose?.ToString());
         List<OpenAIFileInfo> infoItems = [];
         foreach (Internal.Models.OpenAIFile internalFile in result.Value.Data)
         {
@@ -108,13 +102,7 @@ public partial class FileClient
 
     public virtual async Task<ClientResult<OpenAIFileInfoCollection>> GetFileInfoListAsync(OpenAIFilePurpose? purpose = null)
     {
-        Internal.Models.OpenAIFilePurpose? internalPurpose = ToInternalFilePurpose(purpose);
-        string internalPurposeText = null;
-        if (internalPurpose != null)
-        {
-            internalPurposeText = internalPurpose.ToString();
-        }
-        ClientResult<Internal.Models.ListFilesResponse> result = await Shim.GetFilesAsync(internalPurposeText).ConfigureAwait(false);
+        ClientResult<Internal.Models.ListFilesResponse> result = await Shim.GetFilesAsync(purpose?.ToString()).ConfigureAwait(false);
         List<OpenAIFileInfo> infoItems = [];
         foreach (Internal.Models.OpenAIFile internalFile in result.Value.Data)
         {
@@ -202,22 +190,6 @@ public partial class FileClient
         message.Apply(options);
 
         return message;
-    }
-
-    private static Internal.Models.OpenAIFilePurpose? ToInternalFilePurpose(OpenAIFilePurpose? purpose)
-    {
-        if (purpose == null)
-        {
-            return null;
-        }
-        return purpose switch
-        {
-            OpenAIFilePurpose.FineTuning => Internal.Models.OpenAIFilePurpose.FineTune,
-            OpenAIFilePurpose.FineTuningResults => Internal.Models.OpenAIFilePurpose.FineTuneResults,
-            OpenAIFilePurpose.Assistants => Internal.Models.OpenAIFilePurpose.Assistants,
-            OpenAIFilePurpose.AssistantOutputs => Internal.Models.OpenAIFilePurpose.AssistantsOutput,
-            _ => throw new ArgumentException($"Unsupported file purpose: {purpose}"),
-        };
     }
 
     private static PipelineMessageClassifier _responseErrorClassifier200;

--- a/.dotnet/src/Custom/Files/OpenAIFileInfo.cs
+++ b/.dotnet/src/Custom/Files/OpenAIFileInfo.cs
@@ -13,28 +13,9 @@ public partial class OpenAIFileInfo
     internal OpenAIFileInfo(Internal.Models.OpenAIFile internalFile)
     {
         Id = internalFile.Id;
-        Purpose = internalFile.Purpose.ToString() switch
-        {
-            "assistants" => OpenAIFilePurpose.Assistants,
-            "assistants_output" => OpenAIFilePurpose.AssistantOutputs,
-            "batch" => OpenAIFilePurpose.BatchInput,
-            "batch_output" => OpenAIFilePurpose.BatchOutput,
-            "fine-tune" => OpenAIFilePurpose.FineTuning,
-            "fine-tune-results" => OpenAIFilePurpose.FineTuningResults,
-            _ => throw new ArgumentException(nameof(internalFile)),
-        };
+        Purpose = internalFile.Purpose.ToString();
         Filename = internalFile.Filename;
         Size = internalFile.Bytes;
         CreatedAt = internalFile.CreatedAt;
     }
-}
-
-public enum OpenAIFilePurpose
-{
-    Assistants,
-    AssistantOutputs,
-    BatchInput,
-    BatchOutput,
-    FineTuning,
-    FineTuningResults,
 }

--- a/.dotnet/src/Custom/Files/OpenAIFileInfo.cs
+++ b/.dotnet/src/Custom/Files/OpenAIFileInfo.cs
@@ -15,10 +15,12 @@ public partial class OpenAIFileInfo
         Id = internalFile.Id;
         Purpose = internalFile.Purpose.ToString() switch
         {
-            "fine-tune" => OpenAIFilePurpose.FineTuning,
-            "fine-tune-results" => OpenAIFilePurpose.FineTuningResults,
             "assistants" => OpenAIFilePurpose.Assistants,
             "assistants_output" => OpenAIFilePurpose.AssistantOutputs,
+            "batch" => OpenAIFilePurpose.BatchInput,
+            "batch_output" => OpenAIFilePurpose.BatchOutput,
+            "fine-tune" => OpenAIFilePurpose.FineTuning,
+            "fine-tune-results" => OpenAIFilePurpose.FineTuningResults,
             _ => throw new ArgumentException(nameof(internalFile)),
         };
         Filename = internalFile.Filename;
@@ -29,8 +31,10 @@ public partial class OpenAIFileInfo
 
 public enum OpenAIFilePurpose
 {
-    FineTuning,
-    FineTuningResults,
     Assistants,
     AssistantOutputs,
+    BatchInput,
+    BatchOutput,
+    FineTuning,
+    FineTuningResults,
 }

--- a/.dotnet/src/Custom/Files/OpenAIFilePurpose.cs
+++ b/.dotnet/src/Custom/Files/OpenAIFilePurpose.cs
@@ -1,0 +1,48 @@
+using System;
+using System.ComponentModel;
+
+namespace OpenAI.Files;
+
+public readonly partial struct OpenAIFilePurpose
+{
+    private readonly string _value;
+
+    /// <summary> Initializes a new instance of <see cref="OpenAIFilePurpose"/>. </summary>
+    /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
+    public OpenAIFilePurpose(string value)
+    {
+        _value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    internal OpenAIFilePurpose(Internal.Models.OpenAIFilePurpose internalPurpose)
+        : this(internalPurpose.ToString())
+    { }
+
+    /// <summary> fine-tune. </summary>
+    public static OpenAIFilePurpose FineTune { get; } = new OpenAIFilePurpose(Internal.Models.OpenAIFilePurpose.FineTune);
+    /// <summary> fine-tune-results. </summary>
+    public static OpenAIFilePurpose FineTuneResults { get; } = new OpenAIFilePurpose(Internal.Models.OpenAIFilePurpose.FineTuneResults);
+    /// <summary> assistants. </summary>
+    public static OpenAIFilePurpose Assistants { get; } = new OpenAIFilePurpose(Internal.Models.OpenAIFilePurpose.Assistants);
+    /// <summary> assistants_output. </summary>
+    public static OpenAIFilePurpose AssistantsOutput { get; } = new OpenAIFilePurpose(Internal.Models.OpenAIFilePurpose.AssistantsOutput);
+
+    /// <summary> Determines if two <see cref="OpenAIFilePurpose"/> values are the same. </summary>
+    public static bool operator ==(OpenAIFilePurpose left, OpenAIFilePurpose right) => left.Equals(right);
+    /// <summary> Determines if two <see cref="OpenAIFilePurpose"/> values are not the same. </summary>
+    public static bool operator !=(OpenAIFilePurpose left, OpenAIFilePurpose right) => !left.Equals(right);
+    /// <summary> Converts a string to a <see cref="OpenAIFilePurpose"/>. </summary>
+    public static implicit operator OpenAIFilePurpose(string value) => new OpenAIFilePurpose(value);
+
+    /// <inheritdoc />
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override bool Equals(object obj) => obj is OpenAIFilePurpose other && Equals(other);
+    /// <inheritdoc />
+    public bool Equals(OpenAIFilePurpose other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
+
+    /// <inheritdoc />
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+    /// <inheritdoc />
+    public override string ToString() => _value;
+}

--- a/.dotnet/src/Custom/Files/UploadFileOptions.cs
+++ b/.dotnet/src/Custom/Files/UploadFileOptions.cs
@@ -12,14 +12,7 @@ internal class UploadFileOptions
 
         content.Add(file, "file", fileName);
 
-        string purposeValue = purpose switch
-        {
-            OpenAIFilePurpose.FineTuning => "fine-tune",
-            OpenAIFilePurpose.Assistants => "assistants",
-            _ => throw new ArgumentException($"Unsupported purpose for file upload: {purpose}"),
-        };
-
-        content.Add(purposeValue, "\"purpose\"");
+        content.Add(purpose.ToString(), "\"purpose\"");
 
         return content;
     }

--- a/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningManagementClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ClientModel;
+﻿using System.ClientModel;
 
 namespace OpenAI.FineTuningManagement;
 

--- a/.dotnet/src/Custom/Images/GeneratedImage.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImage.cs
@@ -9,7 +9,7 @@ public class GeneratedImage
 {
     /// <summary>
     /// The binary image data received from the response, provided when
-    /// <see cref="ImageGenerationOptions.ResponseFormat"/> is set to <see cref="ImageResponseFormat.Bytes"/>.
+    /// <see cref="ImageGenerationOptions.ResponseFormat"/> is set to <see cref="GeneratedImageFormat.Bytes"/>.
     /// </summary>
     /// <remarks>
     /// This property is mutually exclusive with <see cref="ImageUri"/> and will be <c>null</c> when the other
@@ -18,7 +18,7 @@ public class GeneratedImage
     public BinaryData ImageBytes { get; }
     /// <summary>
     /// A temporary internet location for an image, provided by default or when
-    /// <see cref="ImageGenerationOptions.ResponseFormat"/> is set to <see cref="ImageResponseFormat.Uri"/>.
+    /// <see cref="ImageGenerationOptions.ResponseFormat"/> is set to <see cref="GeneratedImageFormat.Uri"/>.
     /// </summary>
     /// <remarks>
     /// This property is mutually exclusive with <see cref="ImageBytes"/> and will be <c>null</c> when the other

--- a/.dotnet/src/Custom/Images/GeneratedImageCollection.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageCollection.cs
@@ -10,7 +10,16 @@ namespace OpenAI.Images;
 /// </summary>
 public class GeneratedImageCollection : ReadOnlyCollection<GeneratedImage>
 {
-    internal GeneratedImageCollection(IList<GeneratedImage> list) : base(list) { }
+    /// <summary>
+    /// The timestamp at which the result images were generated.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; }
+
+    internal GeneratedImageCollection(IList<GeneratedImage> list, DateTimeOffset createdAt)
+        : base(list)
+    {
+        CreatedAt = createdAt;
+    }
 
     internal static GeneratedImageCollection Deserialize(BinaryData content)
     {
@@ -28,6 +37,6 @@ public class GeneratedImageCollection : ReadOnlyCollection<GeneratedImage>
             images.Add(new GeneratedImage(response, i));
         }
 
-        return new GeneratedImageCollection(images);
+        return new GeneratedImageCollection(images, response.Created);
     }
 }

--- a/.dotnet/src/Custom/Images/GeneratedImageFormat.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageFormat.cs
@@ -6,17 +6,17 @@ namespace OpenAI.Images;
 /// Represents the available output methods for generated images.
 /// <list type="bullet">
 /// <item>
-///     <c>url</c> - <see cref="ImageResponseFormat.Uri"/> - Default, provides a temporary internet location that
+///     <c>url</c> - <see cref="GeneratedImageFormat.Uri"/> - Default, provides a temporary internet location that
 ///     the generated image can be retrieved from.
 /// </item>
 /// <item>
-///     <c>b64_json</c> - <see cref="ImageResponseFormat.Bytes"/> - Provides the full image data on the response,
+///     <c>b64_json</c> - <see cref="GeneratedImageFormat.Bytes"/> - Provides the full image data on the response,
 ///     encoded in the result as a base64 string. This offers the fastest round trip time but can drastically
 ///     increase the size of response payloads.
 /// </item>
 /// </list>
 /// </summary>
-public enum ImageResponseFormat
+public enum GeneratedImageFormat
 {
     /// <summary>
     /// Instructs the request to return image data directly on the response, encoded as a base64 string in the response

--- a/.dotnet/src/Custom/Images/GeneratedImageQuality.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageQuality.cs
@@ -11,7 +11,7 @@ namespace OpenAI.Images;
 /// <item><see cref="High"/> - <c>hd</c> - Better consistency and finer details, but may be slower. </item>
 /// </list>
 /// </remarks>
-public enum ImageQuality
+public enum GeneratedImageQuality
 {
     /// <summary>
     /// The <c>hd</c> image quality that provides finer details and greater consistency but may be slower.

--- a/.dotnet/src/Custom/Images/GeneratedImageSize.Serialization.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageSize.Serialization.cs
@@ -9,30 +9,30 @@ namespace OpenAI.Images;
 /// <summary>
 /// Represents the available output dimensions for generated images.
 /// </summary>
-public partial class GeneratedImageSize : IJsonModel<GeneratedImageSize>
+public readonly partial struct GeneratedImageSize : IJsonModel<GeneratedImageSize>
 {
     GeneratedImageSize IJsonModel<GeneratedImageSize>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<ChatCompletionFunctionCallOption>)this).GetFormatFromOptions(options) : options.Format;
+        var format = options.Format == "W" ? ((IJsonModel<GeneratedImageSize>)this).GetFormatFromOptions(options) : options.Format;
         if (format != "J")
         {
             throw new FormatException($"The model {nameof(GeneratedImageSize)} does not support '{format}' format.");
         }
 
         using JsonDocument document = JsonDocument.ParseValue(ref reader);
-        return DeserializeGeneratedImageSize(document.RootElement, options);
+        return DeserializeGeneratedImageSize(document.RootElement, options).Value;
     }
 
     GeneratedImageSize IPersistableModel<GeneratedImageSize>.Create(BinaryData data, ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<ChatCompletionFunctionCallOption>)this).GetFormatFromOptions(options) : options.Format;
+        var format = options.Format == "W" ? ((IPersistableModel<GeneratedImageSize>)this).GetFormatFromOptions(options) : options.Format;
 
         switch (format)
         {
             case "J":
                 {
                     using JsonDocument document = JsonDocument.Parse(data);
-                    return DeserializeGeneratedImageSize(document.RootElement, options);
+                    return DeserializeGeneratedImageSize(document.RootElement, options).Value;
                 }
             default:
                 throw new FormatException($"The model {nameof(GeneratedImageSize)} does not support '{options.Format}' format.");
@@ -43,7 +43,7 @@ public partial class GeneratedImageSize : IJsonModel<GeneratedImageSize>
 
     void IJsonModel<GeneratedImageSize>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
     {
-        var format = options.Format == "W" ? ((IPersistableModel<ChatCompletionFunctionCallOption>)this).GetFormatFromOptions(options) : options.Format;
+        var format = options.Format == "W" ? ((IJsonModel<GeneratedImageSize>)this).GetFormatFromOptions(options) : options.Format;
         if (format != "J")
         {
             throw new FormatException($"The model {nameof(ChatCompletionFunctionCallOption)} does not support '{format}' format.");
@@ -64,7 +64,7 @@ public partial class GeneratedImageSize : IJsonModel<GeneratedImageSize>
         }
     }
 
-    internal static GeneratedImageSize DeserializeGeneratedImageSize(JsonElement element, ModelReaderWriterOptions options = null)
+    internal static GeneratedImageSize? DeserializeGeneratedImageSize(JsonElement element, ModelReaderWriterOptions options = null)
     {
         if (element.ValueKind != JsonValueKind.String)
         {

--- a/.dotnet/src/Custom/Images/GeneratedImageSize.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageSize.cs
@@ -3,7 +3,7 @@ namespace OpenAI.Images;
 /// <summary>
 /// Represents the available output dimensions for generated images.
 /// </summary>
-public partial class GeneratedImageSize
+public readonly partial struct GeneratedImageSize
 {
     /// <summary>
     /// Gets the desired width, in pixels, for an image.
@@ -71,15 +71,13 @@ public partial class GeneratedImageSize
     public static readonly GeneratedImageSize W1792xH1024 = new(1792, 1024);
 
     /// <inheritdoc/>
-    public static bool operator ==(GeneratedImageSize left, GeneratedImageSize right)
-        => ((left is null) == (right is null)) && (left is null || left.Equals(right));
+    public static bool operator ==(GeneratedImageSize left, GeneratedImageSize right) => left.Equals(right);
 
     /// <inheritdoc/>
-    public static bool operator !=(GeneratedImageSize left, GeneratedImageSize right)
-        => ((left is null) != (right is null)) || (left is not null && !left.Equals(right));
+    public static bool operator !=(GeneratedImageSize left, GeneratedImageSize right) => !left.Equals(right);
 
     /// <inheritdoc/>
-    public bool Equals(GeneratedImageSize other) => other?.Width == Width && other?.Height == Height;
+    public bool Equals(GeneratedImageSize other) => other.Width == Width && other.Height == Height;
 
     /// <inheritdoc/>
     public override bool Equals(object obj) => obj is GeneratedImageSize other && Equals(other);

--- a/.dotnet/src/Custom/Images/GeneratedImageStyle.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageStyle.cs
@@ -5,7 +5,7 @@ namespace OpenAI.Images;
 /// generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real
 /// looking images. This param is only supported for <c>dall-e-3</c>.
 /// </summary>
-public enum ImageStyle
+public enum GeneratedImageStyle
 {
     /// <summary>
     /// The <c>vivid</c> style, with which the model will tend towards hyper-realistic, dramatic imagery.

--- a/.dotnet/src/Custom/Images/ImageClient.cs
+++ b/.dotnet/src/Custom/Images/ImageClient.cs
@@ -4,7 +4,6 @@ using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -83,15 +82,9 @@ public partial class ImageClient
         ImageGenerationOptions options = null)
     {
         Internal.Models.CreateImageRequest request = CreateInternalImageRequest(prompt, imageCount, options);
-        ClientResult<Internal.Models.ImagesResponse> response = Shim.CreateImage(request);
-
-        List<GeneratedImage> images = [];
-        for (int i = 0; i < response.Value.Data.Count; i++)
-        {
-            images.Add(new GeneratedImage(response.Value, i));
-        }
-
-        return ClientResult.FromValue(new GeneratedImageCollection(images), response.GetRawResponse());
+        ClientResult response = Shim.CreateImage(BinaryContent.Create(request));
+        GeneratedImageCollection resultValue = GeneratedImageCollection.Deserialize(response.GetRawResponse().Content);
+        return ClientResult.FromValue(resultValue, response.GetRawResponse());
     }
 
     /// <summary>
@@ -110,15 +103,9 @@ public partial class ImageClient
         ImageGenerationOptions options = null)
     {
         Internal.Models.CreateImageRequest request = CreateInternalImageRequest(prompt, imageCount, options);
-        ClientResult<Internal.Models.ImagesResponse> response = await Shim.CreateImageAsync(request).ConfigureAwait(false);
-
-        List<GeneratedImage> images = [];
-        for (int i = 0; i < response.Value.Data.Count; i++)
-        {
-            images.Add(new GeneratedImage(response.Value, i));
-        }
-
-        return ClientResult.FromValue(new GeneratedImageCollection(images), response.GetRawResponse());
+        ClientResult response = await Shim.CreateImageAsync(BinaryContent.Create(request));
+        GeneratedImageCollection resultValue = GeneratedImageCollection.Deserialize(response.GetRawResponse().Content);
+        return ClientResult.FromValue(resultValue, response.GetRawResponse());
     }
 
     // convenience method - sync; Stream overload
@@ -352,8 +339,8 @@ public partial class ImageClient
         {
             internalQuality = options.Quality switch
             {
-                ImageQuality.Standard => Internal.Models.CreateImageRequestQuality.Standard,
-                ImageQuality.High => Internal.Models.CreateImageRequestQuality.Hd,
+                GeneratedImageQuality.Standard => Internal.Models.CreateImageRequestQuality.Standard,
+                GeneratedImageQuality.High => Internal.Models.CreateImageRequestQuality.Hd,
                 _ => throw new ArgumentException(nameof(options.Quality)),
             };
         }
@@ -380,8 +367,8 @@ public partial class ImageClient
         {
             internalStyle = options.Style switch
             {
-                ImageStyle.Vivid => Internal.Models.CreateImageRequestStyle.Vivid,
-                ImageStyle.Natural => Internal.Models.CreateImageRequestStyle.Natural,
+                GeneratedImageStyle.Vivid => Internal.Models.CreateImageRequestStyle.Vivid,
+                GeneratedImageStyle.Natural => Internal.Models.CreateImageRequestStyle.Natural,
                 _ => throw new ArgumentException(nameof(options.Style)),
             };
         }

--- a/.dotnet/src/Custom/Images/ImageClient.cs
+++ b/.dotnet/src/Custom/Images/ImageClient.cs
@@ -255,8 +255,8 @@ public partial class ImageClient
         {
             internalFormat = options.ResponseFormat switch
             {
-                ImageResponseFormat.Bytes => Internal.Models.CreateImageRequestResponseFormat.B64Json,
-                ImageResponseFormat.Uri => Internal.Models.CreateImageRequestResponseFormat.Url,
+                GeneratedImageFormat.Bytes => Internal.Models.CreateImageRequestResponseFormat.B64Json,
+                GeneratedImageFormat.Uri => Internal.Models.CreateImageRequestResponseFormat.Url,
                 _ => throw new ArgumentException(nameof(options.ResponseFormat)),
             };
         }

--- a/.dotnet/src/Custom/Images/ImageEditOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageEditOptions.cs
@@ -21,7 +21,7 @@ public partial class ImageEditOptions
     public string MaskFileName { get; init; }
 
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.ResponseFormat"/>
-    public ImageResponseFormat? ResponseFormat { get; init; }
+    public GeneratedImageFormat? ResponseFormat { get; init; }
 
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.Size"/>
     public GeneratedImageSize? Size { get; init; }
@@ -55,8 +55,8 @@ public partial class ImageEditOptions
         {
             string format = ResponseFormat switch
             {
-                ImageResponseFormat.Uri => "url",
-                ImageResponseFormat.Bytes => "b64_json",
+                GeneratedImageFormat.Uri => "url",
+                GeneratedImageFormat.Bytes => "b64_json",
                 _ => throw new ArgumentException(nameof(ResponseFormat)),
             };
 

--- a/.dotnet/src/Custom/Images/ImageEditOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageEditOptions.cs
@@ -11,23 +11,23 @@ namespace OpenAI.Images;
 public partial class ImageEditOptions
 {
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.Mask"/>
-    public BinaryData MaskBytes { get; set; }
+    public BinaryData MaskBytes { get; init; }
 
     // The generator will need to add file-name to models for properties that
     // represent files in order to enable setting the header.
     /// <summary>
     /// TODO
     /// </summary>
-    public string MaskFileName { get; set; }
+    public string MaskFileName { get; init; }
 
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.ResponseFormat"/>
-    public ImageResponseFormat? ResponseFormat { get; set; }
+    public ImageResponseFormat? ResponseFormat { get; init; }
 
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.Size"/>
-    public GeneratedImageSize Size { get; set; }
+    public GeneratedImageSize? Size { get; init; }
 
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.User"/>
-    public string User { get; set; }
+    public string User { get; init; }
 
     internal MultipartFormDataBinaryContent ToMultipartContent(Stream fileStream,
         string fileName,

--- a/.dotnet/src/Custom/Images/ImageGenerationOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageGenerationOptions.cs
@@ -23,17 +23,17 @@ public partial class ImageGenerationOptions
     /// Specifies the desired output representation of the generated image.
     /// <list type="bullet">
     /// <item>
-    ///     <c>url</c> - <see cref="ImageResponseFormat.Uri"/> - Default, provides a temporary internet location that
+    ///     <c>url</c> - <see cref="GeneratedImageFormat.Uri"/> - Default, provides a temporary internet location that
     ///     the generated image can be retrieved from.
     /// </item>
     /// <item>
-    ///     <c>b64_json</c> - <see cref="ImageResponseFormat.Bytes"/> - Provides the full image data on the response,
+    ///     <c>b64_json</c> - <see cref="GeneratedImageFormat.Bytes"/> - Provides the full image data on the response,
     ///     encoded in the result as a base64 string. This offers the fastest round trip time but can drastically
     ///     increase the size of response payloads.
     /// </item>
     /// </list>
     /// </summary>
-    public ImageResponseFormat? ResponseFormat { get; init; }
+    public GeneratedImageFormat? ResponseFormat { get; init; }
     /// <summary>
     /// Specifies the dimensions of the generated image. Larger images take longer to create.
     /// <para>

--- a/.dotnet/src/Custom/Images/ImageGenerationOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageGenerationOptions.cs
@@ -10,15 +10,15 @@ public partial class ImageGenerationOptions
     /// the <c>dall-e-3</c> model.
     /// <list type="bullet">
     /// <item>
-    ///     <c>hd</c> - <see cref="ImageQuality.High"/> - Finer details, greater consistency, slower, more intensive.
+    ///     <c>hd</c> - <see cref="GeneratedImageQuality.High"/> - Finer details, greater consistency, slower, more intensive.
     /// </item>
     /// <item>
-    ///     <c>standard</c> - <see cref="ImageQuality.Standard"/> - The default quality level that's faster and less
+    ///     <c>standard</c> - <see cref="GeneratedImageQuality.Standard"/> - The default quality level that's faster and less
     ///     intensive but may also be less detailed and consistent than <c>hd</c>.
     /// </item>
     /// </list>
     /// </summary>
-    public ImageQuality? Quality { get; set; }
+    public GeneratedImageQuality? Quality { get; init; }
     /// <summary>
     /// Specifies the desired output representation of the generated image.
     /// <list type="bullet">
@@ -33,7 +33,7 @@ public partial class ImageGenerationOptions
     /// </item>
     /// </list>
     /// </summary>
-    public ImageResponseFormat? ResponseFormat { get; set; }
+    public ImageResponseFormat? ResponseFormat { get; init; }
     /// <summary>
     /// Specifies the dimensions of the generated image. Larger images take longer to create.
     /// <para>
@@ -53,23 +53,23 @@ public partial class ImageGenerationOptions
     /// </list>
     /// </para>
     /// </summary>
-    public GeneratedImageSize Size { get; set; }
+    public GeneratedImageSize? Size { get; init; }
     /// <summary>
     /// The style kind to guide the generation of the image.
     /// <list type="bullet">
     /// <item>
-    ///     <c>vivid</c> - <see cref="ImageStyle.Vivid"/> - default, a style that tends towards more realistic,
+    ///     <c>vivid</c> - <see cref="GeneratedImageStyle.Vivid"/> - default, a style that tends towards more realistic,
     ///     dramatic images.
     /// </item>
     /// <item>
-    ///     <c>natural</c> - <see cref="ImageStyle.Natural"/> - a more subdued style with less tendency towards
+    ///     <c>natural</c> - <see cref="GeneratedImageStyle.Natural"/> - a more subdued style with less tendency towards
     ///     realism and striking imagery.
     /// </item>
     /// </list>
     /// </summary>
-    public ImageStyle? Style { get; set; }
+    public GeneratedImageStyle? Style { get; init; }
     /// <summary>
     /// An optional identifier for the end user that can help OpenAI monitor for and detect abuse.
     /// </summary>
-    public string User { get; set; }
+    public string User { get; init; }
 }

--- a/.dotnet/src/Custom/Images/ImageVariationOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageVariationOptions.cs
@@ -11,13 +11,13 @@ namespace OpenAI.Images;
 public partial class ImageVariationOptions
 {
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.Size"/>
-    public GeneratedImageSize Size { get; set; }
+    public GeneratedImageSize? Size { get; init; }
 
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.ResponseFormat"/>
-    public ImageResponseFormat? ResponseFormat { get; set; }
+    public ImageResponseFormat? ResponseFormat { get; init; }
 
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.User"/>
-    public string User { get; set; }
+    public string User { get; init; }
 
     internal MultipartFormDataBinaryContent ToMultipartContent(Stream fileStream, string fileName,  string model, int? imageCount)
     {

--- a/.dotnet/src/Custom/Images/ImageVariationOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageVariationOptions.cs
@@ -14,7 +14,7 @@ public partial class ImageVariationOptions
     public GeneratedImageSize? Size { get; init; }
 
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.ResponseFormat"/>
-    public ImageResponseFormat? ResponseFormat { get; init; }
+    public GeneratedImageFormat? ResponseFormat { get; init; }
 
     /// <inheritdoc cref="Internal.Models.CreateImageEditRequest.User"/>
     public string User { get; init; }
@@ -35,8 +35,8 @@ public partial class ImageVariationOptions
         {
             string format = ResponseFormat switch
             {
-                ImageResponseFormat.Uri => "url",
-                ImageResponseFormat.Bytes => "b64_json",
+                GeneratedImageFormat.Uri => "url",
+                GeneratedImageFormat.Bytes => "b64_json",
                 _ => throw new ArgumentException(nameof(ResponseFormat)),
             };
 

--- a/.dotnet/src/Custom/Models/ModelManagementClient.cs
+++ b/.dotnet/src/Custom/Models/ModelManagementClient.cs
@@ -1,5 +1,3 @@
-using OpenAI.ClientShared.Internal;
-using System;
 using System.ClientModel;
 using System.Threading.Tasks;
 

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -5,11 +5,9 @@ using OpenAI.Embeddings;
 using OpenAI.Files;
 using OpenAI.FineTuningManagement;
 using OpenAI.Images;
-using OpenAI.Internal.Models;
 using OpenAI.LegacyCompletions;
 using OpenAI.ModelManagement;
 using OpenAI.Moderations;
-using System;
 using System.ClientModel;
 using System.Diagnostics.CodeAnalysis;
 
@@ -117,17 +115,6 @@ public partial class OpenAIClient
     /// </remarks>
     /// <returns> A new <see cref="ImageClient"/>. </returns>
     public ImageClient GetImageClient(string model) => new(model, _cachedCredential, _cachedOptions);
-
-    /// <summary>
-    /// Gets a new instance of <see cref="LegacyCompletionClient"/> that reuses the client configuration details provided to
-    /// the <see cref="OpenAIClient"/> instance.
-    /// </summary>
-    /// <remarks>
-    /// This method is functionally equivalent to using the <see cref="LegacyCompletionClient"/> constructor directly with
-    /// the same configuration details.
-    /// </remarks>
-    /// <returns> A new <see cref="LegacyCompletionClient"/>. </returns>
-    public LegacyCompletionClient GetLegacyCompletionClient() => new(_cachedCredential, _cachedOptions);
 
     /// <summary>
     /// Gets a new instance of <see cref="ModelManagementClient"/> that reuses the client configuration details provided to

--- a/.dotnet/src/Custom/OpenAIClientConnector.cs
+++ b/.dotnet/src/Custom/OpenAIClientConnector.cs
@@ -1,7 +1,5 @@
 using System;
 using System.ClientModel;
-using System.ClientModel.Internal;
-
 
 namespace OpenAI;
 
@@ -22,7 +20,6 @@ internal partial class OpenAIClientConnector
         ApiKeyCredential credential = null,
         OpenAIClientOptions options = null)
     {
-        if (model is null) throw new ArgumentNullException(nameof(model));
         Model = model;
         Endpoint ??= options?.Endpoint ?? new(Environment.GetEnvironmentVariable(s_OpenAIEndpointEnvironmentVariable) ?? s_defaultOpenAIV1Endpoint);
         credential ??= new(Environment.GetEnvironmentVariable(s_OpenAIApiKeyEnvironmentVariable) ?? string.Empty);

--- a/.dotnet/src/Custom/OpenAIClientOptions.cs
+++ b/.dotnet/src/Custom/OpenAIClientOptions.cs
@@ -1,15 +1,12 @@
 using System;
-using System.ClientModel;
-using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Threading;
 
 namespace OpenAI;
 
 /// <summary>
 /// Client-level options for the OpenAI service.
 /// </summary>
-public partial class OpenAIClientOptions : RequestOptions
+public partial class OpenAIClientOptions : ClientPipelineOptions
 {
     /// <summary>
     /// Gets or sets a non-default base endpoint that clients should use when connecting.

--- a/.dotnet/src/Generated/Models/CreateTranscriptionRequest.cs
+++ b/.dotnet/src/Generated/Models/CreateTranscriptionRequest.cs
@@ -44,7 +44,7 @@ namespace OpenAI.Internal.Models
         /// <summary> Initializes a new instance of <see cref="CreateTranscriptionRequest"/>. </summary>
         /// <param name="file">
         /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4,
-        /// mpeg, mpga, m4a, ogg, wav, or webm.
+        /// mpeg, mpga, m4a, ogg, pcm, wav, or webm.
         /// </param>
         /// <param name="model">
         /// ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model)
@@ -63,7 +63,7 @@ namespace OpenAI.Internal.Models
         /// <summary> Initializes a new instance of <see cref="CreateTranscriptionRequest"/>. </summary>
         /// <param name="file">
         /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4,
-        /// mpeg, mpga, m4a, ogg, wav, or webm.
+        /// mpeg, mpga, m4a, ogg, pcm, wav, or webm.
         /// </param>
         /// <param name="model">
         /// ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model)
@@ -114,7 +114,7 @@ namespace OpenAI.Internal.Models
 
         /// <summary>
         /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4,
-        /// mpeg, mpga, m4a, ogg, wav, or webm.
+        /// mpeg, mpga, m4a, ogg, pcm, wav, or webm.
         /// <para>
         /// To assign a byte[] to this property use <see cref="BinaryData.FromBytes(byte[])"/>.
         /// The byte[] will be serialized to a Base64 encoded string.

--- a/.dotnet/src/Generated/Models/CreateTranslationRequest.cs
+++ b/.dotnet/src/Generated/Models/CreateTranslationRequest.cs
@@ -44,7 +44,7 @@ namespace OpenAI.Internal.Models
         /// <summary> Initializes a new instance of <see cref="CreateTranslationRequest"/>. </summary>
         /// <param name="file">
         /// The audio file object (not file name) to translate, in one of these formats: flac, mp3, mp4,
-        /// mpeg, mpga, m4a, ogg, wav, or webm.
+        /// mpeg, mpga, m4a, ogg, pcm, wav, or webm.
         /// </param>
         /// <param name="model">
         /// ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model)
@@ -62,7 +62,7 @@ namespace OpenAI.Internal.Models
         /// <summary> Initializes a new instance of <see cref="CreateTranslationRequest"/>. </summary>
         /// <param name="file">
         /// The audio file object (not file name) to translate, in one of these formats: flac, mp3, mp4,
-        /// mpeg, mpga, m4a, ogg, wav, or webm.
+        /// mpeg, mpga, m4a, ogg, pcm, wav, or webm.
         /// </param>
         /// <param name="model">
         /// ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model)
@@ -100,7 +100,7 @@ namespace OpenAI.Internal.Models
 
         /// <summary>
         /// The audio file object (not file name) to translate, in one of these formats: flac, mp3, mp4,
-        /// mpeg, mpga, m4a, ogg, wav, or webm.
+        /// mpeg, mpga, m4a, ogg, pcm, wav, or webm.
         /// <para>
         /// To assign a byte[] to this property use <see cref="BinaryData.FromBytes(byte[])"/>.
         /// The byte[] will be serialized to a Base64 encoded string.

--- a/.dotnet/src/Generated/Models/OpenAIFilePurpose.cs
+++ b/.dotnet/src/Generated/Models/OpenAIFilePurpose.cs
@@ -21,6 +21,8 @@ namespace OpenAI.Internal.Models
         private const string FineTuneResultsValue = "fine-tune-results";
         private const string AssistantsValue = "assistants";
         private const string AssistantsOutputValue = "assistants_output";
+        private const string BatchValue = "batch";
+        private const string BatchOutputValue = "batch_output";
 
         /// <summary> fine-tune. </summary>
         public static OpenAIFilePurpose FineTune { get; } = new OpenAIFilePurpose(FineTuneValue);
@@ -30,6 +32,10 @@ namespace OpenAI.Internal.Models
         public static OpenAIFilePurpose Assistants { get; } = new OpenAIFilePurpose(AssistantsValue);
         /// <summary> assistants_output. </summary>
         public static OpenAIFilePurpose AssistantsOutput { get; } = new OpenAIFilePurpose(AssistantsOutputValue);
+        /// <summary> batch. </summary>
+        public static OpenAIFilePurpose Batch { get; } = new OpenAIFilePurpose(BatchValue);
+        /// <summary> batch_output. </summary>
+        public static OpenAIFilePurpose BatchOutput { get; } = new OpenAIFilePurpose(BatchOutputValue);
         /// <summary> Determines if two <see cref="OpenAIFilePurpose"/> values are the same. </summary>
         public static bool operator ==(OpenAIFilePurpose left, OpenAIFilePurpose right) => left.Equals(right);
         /// <summary> Determines if two <see cref="OpenAIFilePurpose"/> values are not the same. </summary>

--- a/.dotnet/src/Generated/Models/OpenAIFilePurpose.cs
+++ b/.dotnet/src/Generated/Models/OpenAIFilePurpose.cs
@@ -21,8 +21,6 @@ namespace OpenAI.Internal.Models
         private const string FineTuneResultsValue = "fine-tune-results";
         private const string AssistantsValue = "assistants";
         private const string AssistantsOutputValue = "assistants_output";
-        private const string BatchValue = "batch";
-        private const string BatchOutputValue = "batch_output";
 
         /// <summary> fine-tune. </summary>
         public static OpenAIFilePurpose FineTune { get; } = new OpenAIFilePurpose(FineTuneValue);
@@ -32,10 +30,6 @@ namespace OpenAI.Internal.Models
         public static OpenAIFilePurpose Assistants { get; } = new OpenAIFilePurpose(AssistantsValue);
         /// <summary> assistants_output. </summary>
         public static OpenAIFilePurpose AssistantsOutput { get; } = new OpenAIFilePurpose(AssistantsOutputValue);
-        /// <summary> batch. </summary>
-        public static OpenAIFilePurpose Batch { get; } = new OpenAIFilePurpose(BatchValue);
-        /// <summary> batch_output. </summary>
-        public static OpenAIFilePurpose BatchOutput { get; } = new OpenAIFilePurpose(BatchOutputValue);
         /// <summary> Determines if two <see cref="OpenAIFilePurpose"/> values are the same. </summary>
         public static bool operator ==(OpenAIFilePurpose left, OpenAIFilePurpose right) => left.Equals(right);
         /// <summary> Determines if two <see cref="OpenAIFilePurpose"/> values are not the same. </summary>

--- a/.dotnet/src/OpenAI.csproj
+++ b/.dotnet/src/OpenAI.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Description>This is the OpenAI client library for developing .NET applications with rich experience.</Description>
     <AssemblyTitle>SDK Code Generation OpenAI</AssemblyTitle>
+    <Version>1.0.0-beta.1</Version>
     <PackageTags>OpenAI</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/.dotnet/tests/Samples/Assistants/Sample03_FunctionCalling.cs
+++ b/.dotnet/tests/Samples/Assistants/Sample03_FunctionCalling.cs
@@ -28,13 +28,13 @@ namespace OpenAI.Samples
 
         private static readonly FunctionToolDefinition getCurrentLocationFunction = new()
         {
-            Name = GetCurrentLocationFunctionName,
+            FunctionName = GetCurrentLocationFunctionName,
             Description = "Get the user's current location"
         };
 
         private static readonly FunctionToolDefinition getCurrentWeatherFunction = new()
         {
-            Name = GetCurrentWeatherFunctionName,
+            FunctionName = GetCurrentWeatherFunctionName,
             Description = "Get the current weather in a given location",
             Parameters = BinaryData.FromString("""
                 {
@@ -105,7 +105,7 @@ namespace OpenAI.Samples
                     {
                         RequiredFunctionToolCall requiredFunctionToolCall = action as RequiredFunctionToolCall;
 
-                        switch (requiredFunctionToolCall?.Name)
+                        switch (requiredFunctionToolCall?.FunctionName)
                         {
                             case GetCurrentLocationFunctionName:
                                 {

--- a/.dotnet/tests/Samples/Assistants/Sample03_FunctionCallingAsync.cs
+++ b/.dotnet/tests/Samples/Assistants/Sample03_FunctionCallingAsync.cs
@@ -59,7 +59,7 @@ namespace OpenAI.Samples
                     {
                         RequiredFunctionToolCall requiredFunctionToolCall = action as RequiredFunctionToolCall;
 
-                        switch (requiredFunctionToolCall?.Name)
+                        switch (requiredFunctionToolCall?.FunctionName)
                         {
                             case GetCurrentLocationFunctionName:
                                 {

--- a/.dotnet/tests/Samples/Chat/Sample03_FunctionCalling.cs
+++ b/.dotnet/tests/Samples/Chat/Sample03_FunctionCalling.cs
@@ -29,13 +29,13 @@ namespace OpenAI.Samples
 
         private static readonly ChatFunctionToolDefinition getCurrentLocationFunction = new()
         {
-            Name = GetCurrentLocationFunctionName,
+            FunctionName = GetCurrentLocationFunctionName,
             Description = "Get the user's current location"
         };
 
         private static readonly ChatFunctionToolDefinition getCurrentWeatherFunction = new()
         {
-            Name = GetCurrentWeatherFunctionName,
+            FunctionName = GetCurrentWeatherFunctionName,
             Description = "Get the current weather in a given location",
             Parameters = BinaryData.FromString("""
                 {

--- a/.dotnet/tests/Samples/CombinationSamples.cs
+++ b/.dotnet/tests/Samples/CombinationSamples.cs
@@ -21,8 +21,8 @@ namespace OpenAI.Samples.Miscellaneous
                 "a majestic alpaca on a mountain ridge, backed by an expansive blue sky accented with sparse clouds",
                 new()
                 {
-                    Style = ImageStyle.Vivid,
-                    Quality = ImageQuality.High,
+                    Style = GeneratedImageStyle.Vivid,
+                    Quality = GeneratedImageQuality.High,
                     Size = GeneratedImageSize.W1792xH1024,
                 });
             GeneratedImage imageGeneration = imageResult.Value;
@@ -42,7 +42,7 @@ namespace OpenAI.Samples.Miscellaneous
                 {
                     MaxTokens = 2048,
                 });
-            string chatResponseText = chatResult.Value.Content;
+            string chatResponseText = (string)chatResult.Value.Content;
             Console.WriteLine($"Art critique of majestic alpaca:\n{chatResponseText}");
 
             // Finally, we'll get some text-to-speech for that critical evaluation using tts-1-hd:
@@ -79,7 +79,7 @@ namespace OpenAI.Samples.Miscellaneous
                 {
                     MaxTokens = 2048,
                 });
-            string description = creativeWriterResult.Value.Content;
+            string description = creativeWriterResult.Value.Content.ToText();
             Console.WriteLine($"Creative helper's creature description:\n{description}");
 
             // Asynchronously, in parallel to the next steps, we'll get the creative description in the voice of Onyx
@@ -109,7 +109,7 @@ namespace OpenAI.Samples.Miscellaneous
                 new ImageGenerationOptions()
                 {
                     Size = GeneratedImageSize.W1792xH1024,
-                    Quality = ImageQuality.High,
+                    Quality = GeneratedImageQuality.High,
                 });
             Uri imageLocation = imageGenerationResult.Value.ImageUri;
             Console.WriteLine($"Creature image available at:\n{imageLocation.AbsoluteUri}");
@@ -127,7 +127,7 @@ namespace OpenAI.Samples.Miscellaneous
                 {
                     MaxTokens = 2048,
                 });
-            string appraisal = criticalAppraisalResult.Value.Content;
+            string appraisal = (string)criticalAppraisalResult.Value.Content;
             Console.WriteLine($"Critic's appraisal:\n{appraisal}");
 
             // Finally, we'll get that art expert's laudations in the voice of Fable

--- a/.dotnet/tests/Samples/Images/Sample01_SimpleImage.cs
+++ b/.dotnet/tests/Samples/Images/Sample01_SimpleImage.cs
@@ -23,9 +23,9 @@ namespace OpenAI.Samples
 
             ImageGenerationOptions options = new()
             {
-                Quality = ImageQuality.High,
+                Quality = GeneratedImageQuality.High,
                 Size = GeneratedImageSize.W1792xH1024,
-                Style = ImageStyle.Vivid,
+                Style = GeneratedImageStyle.Vivid,
                 ResponseFormat = ImageResponseFormat.Bytes
             };
 

--- a/.dotnet/tests/Samples/Images/Sample01_SimpleImage.cs
+++ b/.dotnet/tests/Samples/Images/Sample01_SimpleImage.cs
@@ -26,7 +26,7 @@ namespace OpenAI.Samples
                 Quality = GeneratedImageQuality.High,
                 Size = GeneratedImageSize.W1792xH1024,
                 Style = GeneratedImageStyle.Vivid,
-                ResponseFormat = ImageResponseFormat.Bytes
+                ResponseFormat = GeneratedImageFormat.Bytes
             };
 
             GeneratedImage image = client.GenerateImage(prompt, options);

--- a/.dotnet/tests/Samples/Images/Sample01_SimpleImageAsync.cs
+++ b/.dotnet/tests/Samples/Images/Sample01_SimpleImageAsync.cs
@@ -27,7 +27,7 @@ namespace OpenAI.Samples
                 Quality = GeneratedImageQuality.High,
                 Size = GeneratedImageSize.W1792xH1024,
                 Style = GeneratedImageStyle.Vivid,
-                ResponseFormat = ImageResponseFormat.Bytes
+                ResponseFormat = GeneratedImageFormat.Bytes
             };
 
             GeneratedImage image = await client.GenerateImageAsync(prompt, options);

--- a/.dotnet/tests/Samples/Images/Sample01_SimpleImageAsync.cs
+++ b/.dotnet/tests/Samples/Images/Sample01_SimpleImageAsync.cs
@@ -24,9 +24,9 @@ namespace OpenAI.Samples
 
             ImageGenerationOptions options = new()
             {
-                Quality = ImageQuality.High,
+                Quality = GeneratedImageQuality.High,
                 Size = GeneratedImageSize.W1792xH1024,
-                Style = ImageStyle.Vivid,
+                Style = GeneratedImageStyle.Vivid,
                 ResponseFormat = ImageResponseFormat.Bytes
             };
 

--- a/.dotnet/tests/Samples/Images/Sample02_SimpleImageEdit.cs
+++ b/.dotnet/tests/Samples/Images/Sample02_SimpleImageEdit.cs
@@ -28,7 +28,7 @@ namespace OpenAI.Samples
                 Mask = mask,
                 MaskFileName = maskFileName,
                 Size = GeneratedImageSize.W1024xH1024,
-                ResponseFormat = ImageResponseFormat.Bytes
+                ResponseFormat = GeneratedImageFormat.Bytes
             };
 
             GeneratedImageCollection images = client.GenerateImageEdits(inputImage, imageFileName, prompt, 1, options);

--- a/.dotnet/tests/Samples/Images/Sample02_SimpleImageEditAsync.cs
+++ b/.dotnet/tests/Samples/Images/Sample02_SimpleImageEditAsync.cs
@@ -29,7 +29,7 @@ namespace OpenAI.Samples
                 Mask = mask,
                 MaskFileName = maskFileName,
                 Size = GeneratedImageSize.W1024xH1024,
-                ResponseFormat = ImageResponseFormat.Bytes
+                ResponseFormat = GeneratedImageFormat.Bytes
             };
 
             GeneratedImageCollection images = await client.GenerateImageEditsAsync(inputImage, imageFileName, prompt, 1, options);

--- a/.dotnet/tests/Samples/Images/Sample03_SimpleImageVariation.cs
+++ b/.dotnet/tests/Samples/Images/Sample03_SimpleImageVariation.cs
@@ -19,7 +19,7 @@ namespace OpenAI.Samples
             ImageVariationOptions options = new()
             {
                 Size = GeneratedImageSize.W1024xH1024,
-                ResponseFormat = ImageResponseFormat.Bytes
+                ResponseFormat = GeneratedImageFormat.Bytes
             };
 
             GeneratedImageCollection images = client.GenerateImageVariations(inputImage, 1, options);

--- a/.dotnet/tests/Samples/Images/Sample03_SimpleImageVariationAsync.cs
+++ b/.dotnet/tests/Samples/Images/Sample03_SimpleImageVariationAsync.cs
@@ -20,7 +20,7 @@ namespace OpenAI.Samples
             ImageVariationOptions options = new()
             {
                 Size = GeneratedImageSize.W1024xH1024,
-                ResponseFormat = ImageResponseFormat.Bytes
+                ResponseFormat = GeneratedImageFormat.Bytes
             };
 
             GeneratedImageCollection images = await client.GenerateImageVariationsAsync(inputImage, 1, options);

--- a/.dotnet/tests/TestScenarios/AssistantTests.cs
+++ b/.dotnet/tests/TestScenarios/AssistantTests.cs
@@ -70,7 +70,7 @@ public partial class AssistantTests
                 {
                     new FunctionToolDefinition()
                     {
-                        Name = "get_favorite_food_for_day_of_week",
+                        FunctionName = "get_favorite_food_for_day_of_week",
                         Description = "gets the user's favorite food for a given day of the week, like Tuesday",
                         Parameters = BinaryData.FromObjectAsJson(new
                         {

--- a/.dotnet/tests/TestScenarios/ChatToolConstraints.cs
+++ b/.dotnet/tests/TestScenarios/ChatToolConstraints.cs
@@ -16,12 +16,12 @@ public partial class ChatToolConstraintTests
 
         ChatFunctionToolDefinition functionTool = new()
         {
-            Name = "test_function_tool",
+            FunctionName = "test_function_tool",
             Description = "description isn't applicable",
         };
 
         ChatToolConstraint constraintFromDefinition = new(functionTool);
-        Assert.That(constraintFromDefinition.ToString(), Is.EqualTo(@$"{{""type"":""function"",""function"":{{""name"":""{functionTool.Name}""}}}}"));
+        Assert.That(constraintFromDefinition.ToString(), Is.EqualTo(@$"{{""type"":""function"",""function"":{{""name"":""{functionTool.FunctionName}""}}}}"));
 
         ChatToolConstraint otherConstraint = new(new ChatFunctionToolDefinition("test_function_tool"));
         Assert.That(constraintFromDefinition, Is.EqualTo(otherConstraint));
@@ -32,10 +32,6 @@ public partial class ChatToolConstraintTests
     public void ConstraintsWork()
     {
         ChatClient client = new("gpt-3.5-turbo");
-        ChatCompletionOptions options = new()
-        {
-            Tools = { s_numberForWordTool },
-        };
 
         foreach (var (constraint, reason) in new (ChatToolConstraint?, ChatFinishReason)[]
         {
@@ -45,7 +41,11 @@ public partial class ChatToolConstraintTests
             (ChatToolConstraint.Auto, ChatFinishReason.ToolCalls),
         })
         {
-            options.ToolConstraint = constraint;
+            ChatCompletionOptions options = new()
+            {
+                Tools = { s_numberForWordTool },
+                ToolConstraint = constraint,
+            };
             ClientResult<ChatCompletion> result = client.CompleteChat("What's the number for the word 'banana'?", options);
             Assert.That(result.Value.FinishReason, Is.EqualTo(reason));
         }
@@ -53,7 +53,7 @@ public partial class ChatToolConstraintTests
 
     private static ChatFunctionToolDefinition s_numberForWordTool = new()
     {
-        Name = "get_number_for_word",
+        FunctionName = "get_number_for_word",
         Description = "gets an arbitrary number assigned to a given word",
         Parameters = BinaryData.FromObjectAsJson(new
         {

--- a/.dotnet/tests/TestScenarios/ChatToolTests.cs
+++ b/.dotnet/tests/TestScenarios/ChatToolTests.cs
@@ -17,7 +17,7 @@ public partial class ChatToolTests
         ChatClient client = new("gpt-3.5-turbo");
         ChatFunctionToolDefinition getFavoriteColorTool = new()
         {
-            Name = "get_favorite_color",
+            FunctionName = "get_favorite_color",
             Description = "gets the favorite color of the caller",
         };
         ChatCompletionOptions options = new()
@@ -30,7 +30,7 @@ public partial class ChatToolTests
         var functionToolCall = result.Value.ToolCalls[0] as ChatFunctionToolCall;
         var toolCallArguments = BinaryData.FromString(functionToolCall.Arguments).ToObjectFromJson<Dictionary<string, object>>();
         Assert.That(functionToolCall, Is.Not.Null);
-        Assert.That(functionToolCall.Name, Is.EqualTo(getFavoriteColorTool.Name));
+        Assert.That(functionToolCall.Name, Is.EqualTo(getFavoriteColorTool.FunctionName));
         Assert.That(functionToolCall.Id, Is.Not.Null.Or.Empty);
         Assert.That(toolCallArguments.Count, Is.EqualTo(0));
 
@@ -50,7 +50,7 @@ public partial class ChatToolTests
         ChatClient client = GetTestClient<ChatClient>(TestScenario.Chat);
         ChatFunctionToolDefinition favoriteColorForMonthTool = new()
         {
-            Name = "get_favorite_color_for_month",
+            FunctionName = "get_favorite_color_for_month",
             Description = "gets the caller's favorite color for a given month",
             Parameters = BinaryData.FromString("""
                 {
@@ -77,7 +77,7 @@ public partial class ChatToolTests
         Assert.That(result.Value.FinishReason, Is.EqualTo(ChatFinishReason.ToolCalls));
         Assert.That(result.Value.ToolCalls?.Count, Is.EqualTo(1));
         var functionToolCall = result.Value.ToolCalls[0] as ChatFunctionToolCall;
-        Assert.That(functionToolCall.Name, Is.EqualTo(favoriteColorForMonthTool.Name));
+        Assert.That(functionToolCall.Name, Is.EqualTo(favoriteColorForMonthTool.FunctionName));
         JsonObject argumentsJson = JsonSerializer.Deserialize<JsonObject>(functionToolCall.Arguments);
         Assert.That(argumentsJson.Count, Is.EqualTo(1));
         Assert.That(argumentsJson.ContainsKey("month_name"));

--- a/.dotnet/tests/TestScenarios/ImageGenerationTests.cs
+++ b/.dotnet/tests/TestScenarios/ImageGenerationTests.cs
@@ -26,8 +26,8 @@ public partial class ImageGenerationTests
         ImageClient client = GetTestClient();
         ClientResult<GeneratedImage> result = client.GenerateImage("an isolated stop sign", new ImageGenerationOptions()
         {
-            Quality = ImageQuality.Standard,
-            Style = ImageStyle.Natural,
+            Quality = GeneratedImageQuality.Standard,
+            Style = GeneratedImageStyle.Natural,
         });
         Assert.That(result.Value.ImageUri, Is.Not.Null);
     }

--- a/.dotnet/tests/TestScenarios/LegacyCompletions.cs
+++ b/.dotnet/tests/TestScenarios/LegacyCompletions.cs
@@ -2,8 +2,6 @@
 using OpenAI.LegacyCompletions;
 using System;
 using System.ClientModel;
-using System.ClientModel;
-using System.ClientModel.Primitives;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 

--- a/.dotnet/tests/TestScenarios/TextToSpeechTests.cs
+++ b/.dotnet/tests/TestScenarios/TextToSpeechTests.cs
@@ -24,11 +24,7 @@ public partial class TextToSpeechTests
     public void OutputFormatWorks(AudioDataFormat? responseFormat)
     {
         AudioClient client = new("tts-1");
-        TextToSpeechOptions options = new();
-        if (responseFormat != null)
-        {
-            options.ResponseFormat = responseFormat;
-        }
+        TextToSpeechOptions options = responseFormat == null ? new() : new() { ResponseFormat = responseFormat };
         ClientResult<BinaryData> result = client.GenerateSpeechFromText("Hello, world!", TextToSpeechVoice.Alloy, options);
         Assert.That(result.Value, Is.Not.Null);
     }

--- a/.dotnet/tests/Utility/TestHelpers.cs
+++ b/.dotnet/tests/Utility/TestHelpers.cs
@@ -33,7 +33,6 @@ internal static class TestHelpers
     {
         OpenAIClientOptions options = new();
         options.AddPolicy(GetDumpPolicy(), PipelinePosition.PerTry);
-        options.ErrorOptions = throwOnError ? ClientErrorBehaviors.Default : ClientErrorBehaviors.NoThrow;
         object clientObject = scenario switch
         {
             TestScenario.Chat => new ChatClient(overrideModel ?? "gpt-3.5-turbo", credential: null, options),

--- a/.dotnet/tests/Utility/TestHelpers.cs
+++ b/.dotnet/tests/Utility/TestHelpers.cs
@@ -29,7 +29,7 @@ internal static class TestHelpers
         Moderations,
     }
 
-    public static T GetTestClient<T>(TestScenario scenario, string overrideModel = null, bool throwOnError = true)
+    public static T GetTestClient<T>(TestScenario scenario, string overrideModel = null)
     {
         OpenAIClientOptions options = new();
         options.AddPolicy(GetDumpPolicy(), PipelinePosition.PerTry);

--- a/audio/models.tsp
+++ b/audio/models.tsp
@@ -39,7 +39,7 @@ model CreateSpeechRequest {
 model CreateTranscriptionRequest {
   /**
    * The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4,
-   * mpeg, mpga, m4a, ogg, wav, or webm.
+   * mpeg, mpga, m4a, ogg, pcm, wav, or webm.
    */
   @encode("binary")
   @extension("x-oaiTypeLabel", "file")
@@ -94,7 +94,7 @@ model CreateTranscriptionRequest {
 model CreateTranslationRequest {
   /**
    * The audio file object (not file name) to translate, in one of these formats: flac, mp3, mp4,
-   * mpeg, mpga, m4a, ogg, wav, or webm.
+   * mpeg, mpga, m4a, ogg, pcm, wav, or webm.
    */
   @encode("binary")
   @extension("x-oaiTypeLabel", "file")

--- a/files/models.tsp
+++ b/files/models.tsp
@@ -33,9 +33,7 @@ alias FILE_PURPOSE =
   | "fine-tune"
   | "fine-tune-results"
   | "assistants"
-  | "assistants_output"
-  | "batch"
-  | "batch_output";
+  | "assistants_output";
 
 /** The `File` object represents a document that has been uploaded to OpenAI. */
 model OpenAIFile {

--- a/files/models.tsp
+++ b/files/models.tsp
@@ -33,7 +33,9 @@ alias FILE_PURPOSE =
   | "fine-tune"
   | "fine-tune-results"
   | "assistants"
-  | "assistants_output";
+  | "assistants_output"
+  | "batch"
+  | "batch_output";
 
 /** The `File` object represents a document that has been uploaded to OpenAI. */
 model OpenAIFile {

--- a/tsp-output/@typespec/openapi3/openapi.yaml
+++ b/tsp-output/@typespec/openapi3/openapi.yaml
@@ -4921,8 +4921,6 @@ components:
             - fine-tune-results
             - assistants
             - assistants_output
-            - batch
-            - batch_output
           description: |-
             The intended purpose of the file. Supported values are `fine-tune`, `fine-tune-results`,
             `assistants`, and `assistants_output`.

--- a/tsp-output/@typespec/openapi3/openapi.yaml
+++ b/tsp-output/@typespec/openapi3/openapi.yaml
@@ -379,8 +379,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/CreateTranscriptionResponseJson'
                   - $ref: '#/components/schemas/CreateTranscriptionResponseVerboseJson'
+                  - $ref: '#/components/schemas/CreateTranscriptionResponseJson'
             text/plain:
               schema:
                 type: string
@@ -410,8 +410,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/CreateTranslationResponseJson'
                   - $ref: '#/components/schemas/CreateTranslationResponseVerboseJson'
+                  - $ref: '#/components/schemas/CreateTranslationResponseJson'
             text/plain:
               schema:
                 type: string
@@ -3771,7 +3771,7 @@ components:
           format: binary
           description: |-
             The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4,
-            mpeg, mpga, m4a, ogg, wav, or webm.
+            mpeg, mpga, m4a, ogg, pcm, wav, or webm.
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -3889,7 +3889,7 @@ components:
           format: binary
           description: |-
             The audio file object (not file name) to translate, in one of these formats: flac, mp3, mp4,
-            mpeg, mpga, m4a, ogg, wav, or webm.
+            mpeg, mpga, m4a, ogg, pcm, wav, or webm.
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -4921,6 +4921,8 @@ components:
             - fine-tune-results
             - assistants
             - assistants_output
+            - batch
+            - batch_output
           description: |-
             The intended purpose of the file. Supported values are `fine-tune`, `fine-tune-results`,
             `assistants`, and `assistants_output`.


### PR DESCRIPTION
A few of the changes in #42 were contentious and we'd like to extract some of the more straightforward updates for the March release target.

This pulls in several of the aforementioned PR's changes:

- `OpenAIClientOptions` now appropriate derives from `PipelineClientOptions`
- `GetLegacyCompletionClient` is removed from `OpenAIClient`
- `Name` properties have been clarified in non-trivial cases:
  - Several `Name` properties pertaining to functions are renamed to `FunctionName`
  - Message-specific participant `Name` properties are renamed to `ParticipantName`
- Public setters on request models are removed, replaced where appropriate with `init`
- Response model collection types are now initialized to empty where they were previously null
- `ChatMessageContent` type conversions to string and (new) Uri are explicit instead of implicit
- `CreatedAt` is now present on `GeneratedImageCollection` (in addition to its existing copy-placement in constituent `GeneratedImage` instances) 
- (new) Assistants override properties are renamed to e.g. `InstructionsOverride` to avoid misleading apparent verb symbols like `OverrideInstructions`

Incidentals:

- Many files have accumulated `using` statements cleaned up
- `batch` and `batch_output` are added to `OpenAIFilePurpose`
- `pcm` is added to transcription/translation formats

Intentionally deferred:

- Introduction of nullable reference types (contentious, complex)
- Comprehensive serialization update w/helper (complex)
- Rename of `content` to `text` on `ChatRequestAssistantMessage` (contentious)