### PR TITLE
Transcription update, including timestamp granularities

### DIFF
--- a/.dotnet/README.md
+++ b/.dotnet/README.md
@@ -538,6 +538,51 @@ Product 113045 sold 22 units in February. Here is the trend graph showing its sa
 January, February, and March.
 ```
 
+## Audio transcription
+
+In this sample, an audio file is transcribed using the whisper speech-to-text model, including both word- and audio-segment-level timestamp information.
+
+```csharp
+OpenAIClient openAIClient = new("<insert your OpenAI API key here>");
+AudioClient audioClient = openAIClient.GetAudioClient("whisper-1");
+
+AudioTranscriptionOptions options = new()
+{
+    ResponseFormat = AudioTranscriptionFormat.Verbose,
+    TimestampGranularityFlags = AudioTimestampGranularity.Word | AudioTimestampGranularity.Segment,
+};
+
+using FileStream audioStream = File.OpenRead(Path.Combine("Assets", "<audio file path>"));
+AudioTranscription transcription = audioClient.TranscribeAudio(audioStream, "<audio file path>", options);
+
+Console.WriteLine($"Transcription: {transcription.Text}");
+Console.WriteLine($"Words:");
+foreach (TranscribedWord word in transcription.Words)
+{
+    Console.WriteLine($"  {word.Word,10}: {word.Start.TotalMilliseconds,4:0} - {word.End.TotalMilliseconds,4:0}");
+}
+Console.WriteLine($"Segments:");
+foreach (TranscribedSegment segment in transcription.Segments)
+{
+    Console.WriteLine($"  [{segment.Id}] {segment.Text}: {segment.Start.TotalMilliseconds,4:0} - {segment.End.TotalMilliseconds,4:0}");
+}
+```
+
+The output of the above, providing a "hello world" file, yields:
+
+```csharp
+    Transcription: Hello, world. This is a test.
+Words:
+       Hello:  960 - 1280
+       world: 1400 - 1540
+        This: 1780 - 1900
+          is: 1900 - 2000
+           a: 2000 - 2240
+        test: 2240 - 2400
+Segments:
+  [0]  Hello, world. This is a test.:  960 - 2400
+```
+
 ## Advanced scenarios
 
 ### Using protocol methods

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -83,9 +83,6 @@ public partial class AudioClient
         return Shim.CreateSpeechAsync(request);
     }
 
-    public virtual ClientResult<AudioTranscription> TranscribeAudio(FileStream audio, AudioTranscriptionOptions options = null)
-        => TranscribeAudio(audio, Path.GetFileName(audio.Name), options);
-
     public virtual ClientResult<AudioTranscription> TranscribeAudio(Stream audio, string fileName, AudioTranscriptionOptions options = null)
     {
         Argument.AssertNotNull(audio, nameof(audio));
@@ -103,9 +100,6 @@ public partial class AudioClient
 
         return ClientResult.FromValue(value, response);
     }
-
-    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(FileStream audio, AudioTranscriptionOptions options = null)
-        => await TranscribeAudioAsync(audio, Path.GetFileName(audio.Name), options).ConfigureAwait(false);
 
     public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(Stream audio, string filename, AudioTranscriptionOptions options = null)
     {

--- a/.dotnet/src/Custom/Audio/AudioTimestampGranularity.cs
+++ b/.dotnet/src/Custom/Audio/AudioTimestampGranularity.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace OpenAI.Audio;
+
+[Flags]
+public enum AudioTimestampGranularity
+{
+    /// <summary>
+    /// The default value that, when equivalent to a request's flags, specifies no specific audio timestamp granularity
+    /// and defers to the default timestamp behavior.
+    /// </summary>
+    Default,
+    /// <summary>
+    /// The value that, when present in the request's flags, specifies that audio information should include word-level
+    /// timestamp information.
+    /// </summary>
+    Word,
+    /// <summary>
+    /// The value that, when present in the request's flags, specifies that audio information should include
+    /// segment-level timestamp information.
+    /// </summary>
+    Segment,
+}

--- a/.dotnet/tests/Samples/Audio/Sample02_SimpleTranscription.cs
+++ b/.dotnet/tests/Samples/Audio/Sample02_SimpleTranscription.cs
@@ -16,7 +16,7 @@ namespace OpenAI.Samples
             string filePath = Path.Combine("Assets", "speed-talking.wav");
             using FileStream fileStream = File.OpenRead(filePath);
 
-            AudioTranscription transcription = client.TranscribeAudio(fileStream);
+            AudioTranscription transcription = client.TranscribeAudio(fileStream, "speed-talking.wav");
 
             Console.WriteLine($"{transcription.Text}");
         }

--- a/.dotnet/tests/Samples/Audio/Sample02_SimpleTranscriptionAsync.cs
+++ b/.dotnet/tests/Samples/Audio/Sample02_SimpleTranscriptionAsync.cs
@@ -17,7 +17,7 @@ namespace OpenAI.Samples
             string filePath = Path.Combine("Assets", "speed-talking.wav");
             using FileStream fileStream = File.OpenRead(filePath);
 
-            AudioTranscription transcription = await client.TranscribeAudioAsync(fileStream);
+            AudioTranscription transcription = await client.TranscribeAudioAsync(fileStream, "speed-talking.wav");
 
             Console.WriteLine($"{transcription.Text}");
         }

--- a/.dotnet/tests/TestScenarios/Audio/TranscriptionTests.cs
+++ b/.dotnet/tests/TestScenarios/Audio/TranscriptionTests.cs
@@ -1,6 +1,8 @@
 ﻿using NUnit.Framework;
 using OpenAI.Audio;
+using System;
 using System.ClientModel;
+using System.Collections.Generic;
 using System.IO;
 using static OpenAI.Tests.TestHelpers;
 
@@ -19,22 +21,68 @@ public partial class TranscriptionTests
     }
 
     [Test]
-    public void WordTimestampsWork()
+    [TestCase(AudioTimestampGranularity.Default)]
+    [TestCase(AudioTimestampGranularity.Word)]
+    [TestCase(AudioTimestampGranularity.Segment)]
+    [TestCase(AudioTimestampGranularity.Word | AudioTimestampGranularity.Segment)]
+    public void TimestampsWork(AudioTimestampGranularity granularityFlags)
     {
         AudioClient client = GetTestClient();
         using FileStream inputStream = File.OpenRead(Path.Combine("Assets", "hello_world.m4a"));
         ClientResult<AudioTranscription> transcriptionResult = client.TranscribeAudio(inputStream, "hello_world.m4a", new AudioTranscriptionOptions()
         {
-             EnableWordTimestamps = true,
-             EnableSegmentTimestamps = true,
              ResponseFormat = AudioTranscriptionFormat.Verbose,
+             Temperature = 0.4f,
+             TimestampGranularityFlags = granularityFlags,
         });
         Assert.That(transcriptionResult.Value, Is.Not.Null);
-        // Assert.That(transcriptionResult.Value.Segments, Is.Null);
-        // Assert.That(transcriptionResult.Value.Words, Is.Not.Null.Or.Empty);
-        // Assert.That(transcriptionResult.Value.Words[1].Word, Contains.Substring("world"));
-        // Assert.That(transcriptionResult.Value.Words[1].Start, Is.GreaterThan(TimeSpan.FromMilliseconds(0)));
-        // Assert.That(transcriptionResult.Value.Words[1].End, Is.GreaterThan(TimeSpan.FromMilliseconds(0)));
+
+        Console.WriteLine(transcriptionResult.GetRawResponse().Content.ToString());
+
+        IReadOnlyList<TranscribedWord> words = transcriptionResult.Value.Words;
+        IReadOnlyList<TranscribedSegment> segments = transcriptionResult.Value.Segments;
+
+        bool wordTimestampsPresent = words?.Count > 0;
+        bool segmentTimestampsPresent = segments?.Count > 0;
+
+        bool wordTimestampsExpected = granularityFlags.HasFlag(AudioTimestampGranularity.Word);
+        bool segmentTimestampsExpected = granularityFlags.HasFlag(AudioTimestampGranularity.Segment)
+            || granularityFlags == AudioTimestampGranularity.Default;
+
+        Assert.That(wordTimestampsPresent, Is.EqualTo(wordTimestampsExpected));
+        Assert.That(segmentTimestampsPresent, Is.EqualTo(segmentTimestampsExpected));
+
+        for (int i = 0; i < (words?.Count ?? 0); i++)
+        {
+            if (i > 0)
+            {
+                Assert.That(words[i].Start, Is.GreaterThanOrEqualTo(words[i - 1].End));
+            }
+            Assert.That(words[i].End, Is.GreaterThan(words[i].Start));
+            Assert.That(string.IsNullOrEmpty(words[i].Word), Is.False);
+        }
+
+        for (int i = 0; i < (segments?.Count ?? 0); i++)
+        {
+            if (i > 0)
+            {
+                Assert.That(segments[i].Id, Is.GreaterThan(segments[i - 1].Id));
+                Assert.That(segments[i].SeekOffset, Is.GreaterThan(0));
+                Assert.That(segments[i].Start, Is.GreaterThanOrEqualTo(segments[i - 1].End));
+            }
+            Assert.That(segments[i].End, Is.GreaterThan(segments[i].Start));
+            Assert.That(string.IsNullOrEmpty(segments[i].Text), Is.False);
+            Assert.That(segments[i].TokenIds, Is.Not.Null.Or.Empty);
+            foreach (int tokenId in segments[i].TokenIds)
+            {
+                Assert.That(tokenId, Is.GreaterThan(0));
+            }
+            Assert.That(segments[i].Temperature, Is.LessThan(-0.001f).Or.GreaterThan(0.001f));
+            Assert.That(segments[i].AverageLogProbability, Is.LessThan(-0.001f).Or.GreaterThan(0.001f));
+            Assert.That(segments[i].CompressionRatio, Is.LessThan(-0.001f).Or.GreaterThan(0.001f));
+            Assert.That(segments[i].NoSpeechProbability, Is.LessThan(-0.001f).Or.GreaterThan(0.001f));
+        }
     }
+
     private static AudioClient GetTestClient() => GetTestClient<AudioClient>(TestScenario.Transcription);
 }


### PR DESCRIPTION
- Introduces enum-flag-based `AudioTimestampGranularity` from the branded AOAI SDK
- Based on stoub feedback, removes `FileStream`-only transcription overloads as that's not considered reliable
- Adds readme coverage for transcription

Closes [#43335](https://github.com/Azure/azure-sdk-for-net/issues/43335)
