### PR TITLE
Add filename-based audio transcription overloads

### DIFF
--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -161,16 +161,16 @@ public partial class AudioClient
     /// The provided file path's extension (like .mp3) will be used to infer the format of the input audio. The
     /// operation may fail if the file extension and input audio format do not match.
     /// </remarks>
-    /// <param name="filePath"> The path of the audio file to transcribe. </param>
+    /// <param name="audioFilePath"> The path of the audio file to transcribe. </param>
     /// <param name="options"> Options for the transcription. </param>
     /// <returns> Audio transcription data for the provided file. </returns>
-    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
-    public virtual Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(string filePath, AudioTranscriptionOptions options = null)
+    /// <exception cref="ArgumentNullException"> <paramref name="audioFilePath"/> was null. </exception>
+    public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(string audioFilePath, AudioTranscriptionOptions options = null)
     {
-        Argument.AssertNotNull(filePath, nameof(filePath));
+        Argument.AssertNotNull(audioFilePath, nameof(audioFilePath));
 
-        using FileStream audioStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
-        return TranscribeAudioAsync(audioStream, filePath, options);
+        using FileStream audioStream = File.OpenRead(audioFilePath);
+        return await TranscribeAudioAsync(audioStream, audioFilePath, options);
     }
 
     /// <summary>
@@ -180,16 +180,16 @@ public partial class AudioClient
     /// The provided file path's extension (like .mp3) will be used to infer the format of the input audio. The
     /// operation may fail if the file extension and input audio format do not match.
     /// </remarks>
-    /// <param name="filePath"> The path of the audio file to transcribe. </param>
+    /// <param name="audioFilePath"> The path of the audio file to transcribe. </param>
     /// <param name="options"> Options for the transcription. </param>
     /// <returns> Audio transcription data for the provided file. </returns>
-    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
-    public virtual ClientResult<AudioTranscription> TranscribeAudio(string filePath, AudioTranscriptionOptions options = null)
+    /// <exception cref="ArgumentNullException"> <paramref name="audioFilePath"/> was null. </exception>
+    public virtual ClientResult<AudioTranscription> TranscribeAudio(string audioFilePath, AudioTranscriptionOptions options = null)
     {
-        Argument.AssertNotNull(filePath, nameof(filePath));
+        Argument.AssertNotNull(audioFilePath, nameof(audioFilePath));
 
-        using FileStream audioStream = File.OpenRead(filePath);
-        return TranscribeAudio(audioStream, filePath, options);
+        using FileStream audioStream = File.OpenRead(audioFilePath);
+        return TranscribeAudio(audioStream, audioFilePath, options);
     }
 
     #endregion
@@ -241,16 +241,16 @@ public partial class AudioClient
     /// The provided file path's extension (like .mp3) will be used to infer the format of the input audio. The
     /// operation may fail if the file extension and input audio format do not match.
     /// </remarks>
-    /// <param name="filePath"> The path of the audio file to translate. </param>
+    /// <param name="audioFilePath"> The path of the audio file to translate. </param>
     /// <param name="options"> Options for the translation. </param>
     /// <returns> Audio translation data for the provided file. </returns>
-    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
-    public virtual ClientResult<AudioTranslation> TranslateAudio(string filePath, AudioTranslationOptions options = null)
+    /// <exception cref="ArgumentNullException"> <paramref name="audioFilePath"/> was null. </exception>
+    public virtual ClientResult<AudioTranslation> TranslateAudio(string audioFilePath, AudioTranslationOptions options = null)
     {
-        Argument.AssertNotNull(filePath, nameof(filePath));
+        Argument.AssertNotNull(audioFilePath, nameof(audioFilePath));
 
-        using FileStream audioStream = File.OpenRead(filePath);
-        return TranslateAudio(audioStream, filePath, options);
+        using FileStream audioStream = File.OpenRead(audioFilePath);
+        return TranslateAudio(audioStream, audioFilePath, options);
     }
 
     /// <summary>
@@ -260,16 +260,16 @@ public partial class AudioClient
     /// The provided file path's extension (like .mp3) will be used to infer the format of the input audio. The
     /// operation may fail if the file extension and input audio format do not match.
     /// </remarks>
-    /// <param name="filePath"> The path of the audio file to translate. </param>
+    /// <param name="audioFilePath"> The path of the audio file to translate. </param>
     /// <param name="options"> Options for the translation. </param>
     /// <returns> Audio translation data for the provided file. </returns>
-    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
-    public virtual Task<ClientResult<AudioTranslation>> TranslateAudioAsync(string filePath, AudioTranslationOptions options = null)
+    /// <exception cref="ArgumentNullException"> <paramref name="audioFilePath"/> was null. </exception>
+    public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(string audioFilePath, AudioTranslationOptions options = null)
     {
-        Argument.AssertNotNull(filePath, nameof(filePath));
+        Argument.AssertNotNull(audioFilePath, nameof(audioFilePath));
 
-        using FileStream audioStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
-        return TranslateAudioAsync(audioStream, filePath, options);
+        using FileStream audioStream = File.OpenRead(audioFilePath);
+        return await TranslateAudioAsync(audioStream, audioFilePath, options);
     }
 
     #endregion

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -154,6 +154,44 @@ public partial class AudioClient
         return ClientResult.FromValue(AudioTranscription.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
+    /// <summary>
+    /// Transcribes audio from a file with a known path.
+    /// </summary>
+    /// <remarks>
+    /// The provided file path's extension (like .mp3) will be used to infer the format of the input audio. The
+    /// operation may fail if the file extension and input audio format do not match.
+    /// </remarks>
+    /// <param name="filePath"> The path of the audio file to transcribe. </param>
+    /// <param name="options"> Options for the transcription. </param>
+    /// <returns> Audio transcription data for the provided file. </returns>
+    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
+    public virtual Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(string filePath, AudioTranscriptionOptions options = null)
+    {
+        Argument.AssertNotNull(filePath, nameof(filePath));
+
+        using FileStream audioStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+        return TranscribeAudioAsync(audioStream, filePath, options);
+    }
+
+    /// <summary>
+    /// Transcribes audio from a file with a known path.
+    /// </summary>
+    /// <remarks>
+    /// The provided file path's extension (like .mp3) will be used to infer the format of the input audio. The
+    /// operation may fail if the file extension and input audio format do not match.
+    /// </remarks>
+    /// <param name="filePath"> The path of the audio file to transcribe. </param>
+    /// <param name="options"> Options for the transcription. </param>
+    /// <returns> Audio transcription data for the provided file. </returns>
+    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
+    public virtual ClientResult<AudioTranscription> TranscribeAudio(string filePath, AudioTranscriptionOptions options = null)
+    {
+        Argument.AssertNotNull(filePath, nameof(filePath));
+
+        using FileStream audioStream = File.OpenRead(filePath);
+        return TranscribeAudio(audioStream, filePath, options);
+    }
+
     #endregion
 
     #region TranslateAudio
@@ -194,6 +232,44 @@ public partial class AudioClient
         using MultipartFormDataBinaryContent content = options.ToMultipartContent(audio, audioFilename);
         ClientResult result = TranslateAudio(content, content.ContentType);
         return ClientResult.FromValue(AudioTranslation.FromResponse(result.GetRawResponse()), result.GetRawResponse());
+    }
+
+    /// <summary>
+    /// Translates audio into English from a file with a known path.
+    /// </summary>
+    /// <remarks>
+    /// The provided file path's extension (like .mp3) will be used to infer the format of the input audio. The
+    /// operation may fail if the file extension and input audio format do not match.
+    /// </remarks>
+    /// <param name="filePath"> The path of the audio file to translate. </param>
+    /// <param name="options"> Options for the translation. </param>
+    /// <returns> Audio translation data for the provided file. </returns>
+    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
+    public virtual ClientResult<AudioTranslation> TranslateAudio(string filePath, AudioTranslationOptions options = null)
+    {
+        Argument.AssertNotNull(filePath, nameof(filePath));
+
+        using FileStream audioStream = File.OpenRead(filePath);
+        return TranslateAudio(audioStream, filePath, options);
+    }
+
+    /// <summary>
+    /// Translates audio into English from a file with a known path.
+    /// </summary>
+    /// <remarks>
+    /// The provided file path's extension (like .mp3) will be used to infer the format of the input audio. The
+    /// operation may fail if the file extension and input audio format do not match.
+    /// </remarks>
+    /// <param name="filePath"> The path of the audio file to translate. </param>
+    /// <param name="options"> Options for the translation. </param>
+    /// <returns> Audio translation data for the provided file. </returns>
+    /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
+    public virtual Task<ClientResult<AudioTranslation>> TranslateAudioAsync(string filePath, AudioTranslationOptions options = null)
+    {
+        Argument.AssertNotNull(filePath, nameof(filePath));
+
+        using FileStream audioStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+        return TranslateAudioAsync(audioStream, filePath, options);
     }
 
     #endregion

--- a/.dotnet/tests/TestScenarios/Audio/TranscriptionTests.cs
+++ b/.dotnet/tests/TestScenarios/Audio/TranscriptionTests.cs
@@ -11,21 +11,49 @@ namespace OpenAI.Tests.Audio;
 
 public partial class TranscriptionTests
 {
-    [Test]
-    public void BasicTranscriptionWorks()
+    public enum AudioSourceKind
     {
-        AudioClient client = GetTestClient();
-        using FileStream inputStream = File.OpenRead(Path.Combine("Assets", "hello_world.m4a"));
-        ClientResult<AudioTranscription> transcriptionResult = client.TranscribeAudio(inputStream, "hello_world.m4a");
-        Assert.That(transcriptionResult.Value, Is.Not.Null);
-        Assert.That(transcriptionResult.Value.Text.ToLowerInvariant(), Contains.Substring("hello"));
+        UsingStream,
+        UsingFilePath,
+    }
+
+    public enum SyncOrAsync
+    {
+        Sync,
+        Async,
     }
 
     [Test]
-    public async Task AsyncTranscriptionWorks()
+    [TestCase(AudioSourceKind.UsingStream, SyncOrAsync.Sync)]
+    [TestCase(AudioSourceKind.UsingStream, SyncOrAsync.Async)]
+    [TestCase(AudioSourceKind.UsingFilePath, SyncOrAsync.Sync)]
+    [TestCase(AudioSourceKind.UsingFilePath, SyncOrAsync.Async)]
+    public async Task TranscriptionWorks(AudioSourceKind audioSourceKind, SyncOrAsync syncOrAsync)
     {
         AudioClient client = GetTestClient();
-        AudioTranscription transcription = await client.TranscribeAudioAsync(Path.Combine("Assets", "hello_world.m4a"));
+        string filename = "hello_world.m4a";
+        string path = Path.Combine("Assets", filename);
+        AudioTranscription transcription = null;
+        if (audioSourceKind == AudioSourceKind.UsingStream)
+        {
+            using FileStream inputStream = File.OpenRead(path);
+            transcription = syncOrAsync switch
+            {
+                SyncOrAsync.Sync => client.TranscribeAudio(inputStream, filename),
+                SyncOrAsync.Async => await client.TranscribeAudioAsync(inputStream, filename),
+                _ => throw new ArgumentException(nameof(syncOrAsync)),
+            };
+        }
+        else if (audioSourceKind == AudioSourceKind.UsingFilePath)
+        {
+            transcription = syncOrAsync switch
+            {
+                SyncOrAsync.Sync => client.TranscribeAudio(path),
+                SyncOrAsync.Async => await client.TranscribeAudioAsync(path),
+                _ => throw new ArgumentException(nameof(syncOrAsync)),
+            };
+        }
+        Assert.That(transcription, Is.Not.Null);
         Assert.That(transcription.Text.ToLowerInvariant(), Contains.Substring("hello"));
     }
 

--- a/.dotnet/tests/TestScenarios/Audio/TranscriptionTests.cs
+++ b/.dotnet/tests/TestScenarios/Audio/TranscriptionTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.ClientModel;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using static OpenAI.Tests.TestHelpers;
 
 namespace OpenAI.Tests.Audio;
@@ -18,6 +19,14 @@ public partial class TranscriptionTests
         ClientResult<AudioTranscription> transcriptionResult = client.TranscribeAudio(inputStream, "hello_world.m4a");
         Assert.That(transcriptionResult.Value, Is.Not.Null);
         Assert.That(transcriptionResult.Value.Text.ToLowerInvariant(), Contains.Substring("hello"));
+    }
+
+    [Test]
+    public async Task AsyncTranscriptionWorks()
+    {
+        AudioClient client = GetTestClient();
+        AudioTranscription transcription = await client.TranscribeAudioAsync(Path.Combine("Assets", "hello_world.m4a"));
+        Assert.That(transcription.Text.ToLowerInvariant(), Contains.Substring("hello"));
     }
 
     [Test]

--- a/.dotnet/tests/TestScenarios/Audio/TranslationTests.cs
+++ b/.dotnet/tests/TestScenarios/Audio/TranslationTests.cs
@@ -2,6 +2,7 @@
 using OpenAI.Audio;
 using System.ClientModel;
 using System.IO;
+using System.Threading.Tasks;
 using static OpenAI.Tests.TestHelpers;
 
 namespace OpenAI.Tests.Audio;
@@ -16,6 +17,14 @@ public partial class TranslationTests
         ClientResult<AudioTranslation> translationResult = client.TranslateAudio(inputStream, "french.wav");
         Assert.That(translationResult.Value, Is.Not.Null);
         // Assert.That(translationResult.Value.Text.ToLowerInvariant(), Contains.Substring("hello"));
+    }
+
+    [Test]
+    public async Task AsyncTranslationWorks()
+    {
+        AudioClient client = GetTestClient();
+        AudioTranslation translation = await client.TranslateAudioAsync(Path.Combine("Assets", "french.wav"));
+        Assert.That(translation.Text, Is.Not.Null);
     }
 
     private static AudioClient GetTestClient() => GetTestClient<AudioClient>(TestScenario.Transcription);

--- a/.dotnet/tests/TestScenarios/Audio/TranslationTests.cs
+++ b/.dotnet/tests/TestScenarios/Audio/TranslationTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using OpenAI.Audio;
+using System;
 using System.ClientModel;
 using System.IO;
 using System.Threading.Tasks;
@@ -9,22 +10,49 @@ namespace OpenAI.Tests.Audio;
 
 public partial class TranslationTests
 {
-    [Test]
-    public void BasicTranslationWorks()
+    public enum AudioSourceKind
     {
-        AudioClient client = GetTestClient();
-        using FileStream inputStream = File.OpenRead(Path.Combine("Assets", "french.wav"));
-        ClientResult<AudioTranslation> translationResult = client.TranslateAudio(inputStream, "french.wav");
-        Assert.That(translationResult.Value, Is.Not.Null);
-        // Assert.That(translationResult.Value.Text.ToLowerInvariant(), Contains.Substring("hello"));
+        UsingStream,
+        UsingFilePath,
+    }
+
+    public enum SyncOrAsync
+    {
+        Sync,
+        Async,
     }
 
     [Test]
-    public async Task AsyncTranslationWorks()
+    [TestCase(AudioSourceKind.UsingStream, SyncOrAsync.Sync)]
+    [TestCase(AudioSourceKind.UsingStream, SyncOrAsync.Async)]
+    [TestCase(AudioSourceKind.UsingFilePath, SyncOrAsync.Sync)]
+    [TestCase(AudioSourceKind.UsingFilePath, SyncOrAsync.Async)]
+    public async Task TranslationWorks(AudioSourceKind audioSourceKind, SyncOrAsync syncOrAsync)
     {
         AudioClient client = GetTestClient();
-        AudioTranslation translation = await client.TranslateAudioAsync(Path.Combine("Assets", "french.wav"));
-        Assert.That(translation.Text, Is.Not.Null);
+        string filename = "french.wav";
+        string path = Path.Combine("Assets", filename);
+        AudioTranslation translation = null;
+        if (audioSourceKind == AudioSourceKind.UsingStream)
+        {
+            using FileStream audio = File.OpenRead(path);
+            translation = syncOrAsync switch
+            {
+                SyncOrAsync.Sync => client.TranslateAudio(audio, filename),
+                SyncOrAsync.Async => await client.TranslateAudioAsync(audio, filename),
+                _ => throw new ArgumentException(nameof(syncOrAsync)),
+            };
+        }
+        else if (audioSourceKind == AudioSourceKind.UsingFilePath)
+        {
+            translation = syncOrAsync switch
+            {
+                SyncOrAsync.Sync => client.TranslateAudio(path),
+                SyncOrAsync.Async => await client.TranslateAudioAsync(path),
+                _ => throw new ArgumentException(nameof(syncOrAsync)),
+            };
+        }
+        Assert.That(translation?.Text, Is.Not.Null);
     }
 
     private static AudioClient GetTestClient() => GetTestClient<AudioClient>(TestScenario.Transcription);


### PR DESCRIPTION
- Currently, we have `TranscribeAudio(Stream audio, string filename, AudioTranscriptionOptions options = null)`
- This adds `TranscribeAudio(string filename, AudioTranscriptionOptions options = null)`
- These new overloads simply open the file (with the async file flag for the async variant) and invoke the existing overloads with the conveniently opened stream