### PR TITLE
Minor codegen fix: remove vestigial options logic

### DIFF
--- a/.dotnet/src/Custom/OpenAIClientConnector.cs
+++ b/.dotnet/src/Custom/OpenAIClientConnector.cs
@@ -24,6 +24,6 @@ internal partial class OpenAIClientConnector
         Endpoint ??= options?.Endpoint ?? new(Environment.GetEnvironmentVariable(s_OpenAIEndpointEnvironmentVariable) ?? s_defaultOpenAIV1Endpoint);
         credential ??= new(Environment.GetEnvironmentVariable(s_OpenAIApiKeyEnvironmentVariable) ?? string.Empty);
         options ??= new();
-        InternalClient = new(credential, options.InternalOptions);
+        InternalClient = new(credential, options);
     }
 }

--- a/.dotnet/src/Custom/OpenAIClientOptions.cs
+++ b/.dotnet/src/Custom/OpenAIClientOptions.cs
@@ -9,17 +9,6 @@ namespace OpenAI;
 [CodeGenModel("OpenAIClientOptions")]
 public partial class OpenAIClientOptions : ClientPipelineOptions
 {
-    // Note: this type currently proxies RequestOptions properties manually via the matching internal type. This is a
-    //       temporary extra step pending richer integration with code generation.
-
-    internal OpenAIClientOptions InternalOptions { get; }
-
-    public new void AddPolicy(PipelinePolicy policy, PipelinePosition position)
-    {
-        AddPolicy(policy, position);
-        InternalOptions.AddPolicy(policy, position);
-    }
-
     /// <summary>
     /// Gets or sets a non-default base endpoint that clients should use when connecting.
     /// </summary>


### PR DESCRIPTION
"InternalOptions" proxy is no longer necessary; infinite recursion in `AddPolicy`.