### PR TITLE
Apply custom codegen deserialization to TimeSpan[?]

### DIFF
--- a/.dotnet/src/Custom/Audio/AudioTranscription.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscription.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
 
 namespace OpenAI.Audio;
 
 [CodeGenModel("CreateTranscriptionResponseVerboseJson")]
+[CodeGenSerialization(nameof(Duration), DeserializationValueHook = nameof(DeserializeNullableTimespan))]
 public partial class AudioTranscription
 {
     // CUSTOM: Made private. This property does not add value in the context of a strongly-typed class.
@@ -11,4 +14,8 @@ public partial class AudioTranscription
     // CUSTOM: Made nullable because this is an optional property.
     /// <summary> TODO. </summary>
     public TimeSpan? Duration { get; }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void DeserializeNullableTimespan(JsonProperty property, ref TimeSpan? nullableTimespan)
+        => CustomSerialization.DeserializeNullableTimeSpan(property, ref nullableTimespan);
 }

--- a/.dotnet/src/Custom/Audio/AudioTranslation.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranslation.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
 
 namespace OpenAI.Audio;
 
 [CodeGenModel("CreateTranslationResponseVerboseJson")]
+[CodeGenSerialization(nameof(Duration), DeserializationValueHook = nameof(DeserializeNullableTimespan))]
 public partial class AudioTranslation
 {
     // CUSTOM: Made private. This property does not add value in the context of a strongly-typed class.
@@ -11,4 +14,8 @@ public partial class AudioTranslation
     // CUSTOM: Made nullable because this is an optional property.
     /// <summary> TODO. </summary>
     public TimeSpan? Duration { get; }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void DeserializeNullableTimespan(JsonProperty property, ref TimeSpan? nullableTimespan)
+        => CustomSerialization.DeserializeNullableTimeSpan(property, ref nullableTimespan);
 }

--- a/.dotnet/src/Custom/Audio/TranscribedSegment.cs
+++ b/.dotnet/src/Custom/Audio/TranscribedSegment.cs
@@ -1,8 +1,13 @@
+using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
 
 namespace OpenAI.Audio;
 
 [CodeGenModel("TranscriptionSegment")]
+[CodeGenSerialization(nameof(Start), DeserializationValueHook = nameof(DeserializeTimeSpan))]
+[CodeGenSerialization(nameof(End), DeserializationValueHook = nameof(DeserializeTimeSpan))]
 public readonly partial struct TranscribedSegment
 {
     // CUSTOM: Rename.
@@ -20,4 +25,8 @@ public readonly partial struct TranscribedSegment
     // CUSTOM: Rename.
     [CodeGenMember("NoSpeechProb")]
     public double NoSpeechProbability { get; }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void DeserializeTimeSpan(JsonProperty property, ref TimeSpan timespan)
+        => CustomSerialization.DeserializeTimeSpan(property, ref timespan);
 }

--- a/.dotnet/src/Custom/Audio/TranscribedWord.cs
+++ b/.dotnet/src/Custom/Audio/TranscribedWord.cs
@@ -1,6 +1,15 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
 namespace OpenAI.Audio;
 
 [CodeGenModel("TranscriptionWord")]
+[CodeGenSerialization(nameof(Start), DeserializationValueHook = nameof(DeserializeTimeSpan))]
+[CodeGenSerialization(nameof(End), DeserializationValueHook = nameof(DeserializeTimeSpan))]
 public readonly partial struct TranscribedWord
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void DeserializeTimeSpan(JsonProperty property, ref TimeSpan timespan)
+        => CustomSerialization.DeserializeTimeSpan(property, ref timespan);
 }

--- a/.dotnet/src/Generated/Models/AudioTranscription.Serialization.cs
+++ b/.dotnet/src/Generated/Models/AudioTranscription.Serialization.cs
@@ -109,7 +109,7 @@ namespace OpenAI.Audio
                 }
                 if (property.NameEquals("duration"u8))
                 {
-                    duration = TimeSpan.FromSeconds(property.Value.GetInt32());
+                    DeserializeNullableTimespan(property, ref duration);
                     continue;
                 }
                 if (property.NameEquals("text"u8))

--- a/.dotnet/src/Generated/Models/AudioTranslation.Serialization.cs
+++ b/.dotnet/src/Generated/Models/AudioTranslation.Serialization.cs
@@ -98,7 +98,7 @@ namespace OpenAI.Audio
                 }
                 if (property.NameEquals("duration"u8))
                 {
-                    duration = TimeSpan.FromSeconds(property.Value.GetInt32());
+                    DeserializeNullableTimespan(property, ref duration);
                     continue;
                 }
                 if (property.NameEquals("text"u8))

--- a/.dotnet/src/Generated/Models/TranscribedSegment.Serialization.cs
+++ b/.dotnet/src/Generated/Models/TranscribedSegment.Serialization.cs
@@ -110,12 +110,12 @@ namespace OpenAI.Audio
                 }
                 if (property.NameEquals("start"u8))
                 {
-                    start = TimeSpan.FromSeconds(property.Value.GetInt32());
+                    DeserializeTimeSpan(property, ref start);
                     continue;
                 }
                 if (property.NameEquals("end"u8))
                 {
-                    end = TimeSpan.FromSeconds(property.Value.GetInt32());
+                    DeserializeTimeSpan(property, ref end);
                     continue;
                 }
                 if (property.NameEquals("text"u8))

--- a/.dotnet/src/Generated/Models/TranscribedWord.Serialization.cs
+++ b/.dotnet/src/Generated/Models/TranscribedWord.Serialization.cs
@@ -79,12 +79,12 @@ namespace OpenAI.Audio
                 }
                 if (property.NameEquals("start"u8))
                 {
-                    start = TimeSpan.FromSeconds(property.Value.GetInt32());
+                    DeserializeTimeSpan(property, ref start);
                     continue;
                 }
                 if (property.NameEquals("end"u8))
                 {
-                    end = TimeSpan.FromSeconds(property.Value.GetInt32());
+                    DeserializeTimeSpan(property, ref end);
                     continue;
                 }
                 if (options.Format != "W")

--- a/.dotnet/src/Utility/CustomSerialization.cs
+++ b/.dotnet/src/Utility/CustomSerialization.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace OpenAI;
+
+internal static class CustomSerialization
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void DeserializeTimeSpan(JsonProperty property, ref TimeSpan timespan)
+    {
+        timespan = property.Value.ValueKind switch
+        {
+            JsonValueKind.Number => TimeSpan.FromSeconds(property.Value.GetDouble()),
+            _ => throw new ArgumentException(
+                $"Unsupported 'TimeSpan' deserialization for JSON value kind: {property.Value.ValueKind}"),
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void DeserializeNullableTimeSpan(JsonProperty property, ref TimeSpan? nullableTimespan)
+    {
+        nullableTimespan = property.Value.ValueKind switch
+        {
+            JsonValueKind.Null => null,
+            JsonValueKind.Number => TimeSpan.FromSeconds(property.Value.GetDouble()),
+            _ => throw new ArgumentException(
+                $"Unsupported 'TimeSpan?' deserialization for JSON value kind: {property.Value.ValueKind}"),
+        };
+    }
+}

--- a/tsp-output/@typespec/openapi3/openapi.yaml
+++ b/tsp-output/@typespec/openapi3/openapi.yaml
@@ -2067,7 +2067,6 @@ components:
           type: string
           enum:
             - text
-            - json_object
           description: The type of the content part.
         text:
           type: string
@@ -2130,7 +2129,6 @@ components:
           type: string
           enum:
             - user
-            - assistant
           description: The role of the messages author, in this case `user`.
         name:
           type: string
@@ -2251,7 +2249,6 @@ components:
         - type: string
           enum:
             - none
-            - auto
             - auto
         - $ref: '#/components/schemas/ChatCompletionNamedToolChoice'
       description: |-
@@ -2580,7 +2577,6 @@ components:
               enum:
                 - none
                 - auto
-                - auto
             - $ref: '#/components/schemas/ChatCompletionFunctionCallOption'
           description: |-
             Deprecated in favor of `tool_choice`.
@@ -2630,8 +2626,6 @@ components:
                   - tool_calls
                   - content_filter
                   - function_call
-                  - length
-                  - content_filter
                 description: |-
                   The reason the model stopped generating tokens. This will be `stop` if the model hit a
                   natural stop point or a provided stop sequence, `length` if the maximum number of tokens
@@ -2940,10 +2934,6 @@ components:
                 enum:
                   - stop
                   - length
-                  - tool_calls
-                  - content_filter
-                  - function_call
-                  - length
                   - content_filter
                 description: |-
                   The reason the model stopped generating tokens. This will be `stop` if the model hit a
@@ -3125,8 +3115,6 @@ components:
                 - type: string
                   enum:
                     - auto
-                    - low
-                    - high
                 - $ref: '#/components/schemas/BatchSize'
               description: |-
                 Number of examples in each batch. A larger batch size means that model parameters are
@@ -3137,8 +3125,6 @@ components:
                 - type: string
                   enum:
                     - auto
-                    - low
-                    - high
                 - $ref: '#/components/schemas/LearningRateMultiplier'
               description: |-
                 Scaling factor for the learning rate. A smaller learning rate may be useful to avoid 
@@ -3149,8 +3135,6 @@ components:
                 - type: string
                   enum:
                     - auto
-                    - low
-                    - high
                 - $ref: '#/components/schemas/NEpochs'
               description: |-
                 The number of epochs to train the model for. An epoch refers to one full cycle through the
@@ -3225,8 +3209,6 @@ components:
             - 256x256
             - 512x512
             - 1024x1024
-            - 512x512
-            - 1024x1024
           nullable: true
           description: The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`.
           default: 1024x1024
@@ -3234,7 +3216,6 @@ components:
           type: string
           enum:
             - url
-            - b64_json
             - b64_json
           nullable: true
           description: The format in which the generated images are returned. Must be one of `url` or `b64_json`.
@@ -3354,7 +3335,6 @@ components:
           enum:
             - url
             - b64_json
-            - b64_json
           nullable: true
           description: The format in which the generated images are returned. Must be one of `url` or `b64_json`.
           default: url
@@ -3362,8 +3342,6 @@ components:
           type: string
           enum:
             - 256x256
-            - 512x512
-            - 1024x1024
             - 512x512
             - 1024x1024
           nullable: true
@@ -3385,7 +3363,6 @@ components:
           type: string
           enum:
             - user
-            - assistant
           description: The role of the entity that is creating the message. Currently only `user` is supported.
         content:
           type: string
@@ -3802,10 +3779,6 @@ components:
             - srt
             - verbose_json
             - vtt
-            - text
-            - srt
-            - verbose_json
-            - vtt
           description: |-
             The format of the transcript output, in one of these options: json, text, srt, verbose_json, or
             vtt.
@@ -3910,10 +3883,6 @@ components:
           type: string
           enum:
             - json
-            - text
-            - srt
-            - verbose_json
-            - vtt
             - text
             - srt
             - verbose_json
@@ -4167,8 +4136,8 @@ components:
             The name of the fine-tuned model that is being created. The value will be null if the
             fine-tuning job is still running.
         finished_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: |-
             The Unix timestamp (in seconds) for when the fine-tuning job was finished. The value will be
@@ -4181,8 +4150,6 @@ components:
                 - type: string
                   enum:
                     - auto
-                    - low
-                    - high
                 - $ref: '#/components/schemas/NEpochs'
               description: |-
                 The number of epochs to train the model for. An epoch refers to one full cycle through the
@@ -4646,7 +4613,6 @@ components:
           type: string
           enum:
             - text
-            - json_object
           description: Always `text`.
         text:
           type: object
@@ -5075,28 +5041,28 @@ components:
           nullable: true
           description: The last error associated with this run. Will be `null` if there are no errors.
         expires_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: The Unix timestamp (in seconds) for when the run will expire.
         started_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: The Unix timestamp (in seconds) for when the run was started.
         cancelled_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: The Unix timestamp (in seconds) for when the run was cancelled.
         failed_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: The Unix timestamp (in seconds) for when the run failed.
         completed_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: The Unix timestamp (in seconds) for when the run was completed.
         model:
@@ -5417,25 +5383,25 @@ components:
           nullable: true
           description: The last error associated with this run step. Will be `null` if there are no errors.
         expires_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: |-
             The Unix timestamp (in seconds) for when the run step expired. A step is considered expired
             if the parent run is expired.
         cancelled_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: The Unix timestamp (in seconds) for when the run step was cancelled.
         failed_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: The Unix timestamp (in seconds) for when the run step failed.
         completed_at:
-          type: string
-          format: date-time
+          type: integer
+          format: unixtime
           nullable: true
           description: T The Unix timestamp (in seconds) for when the run step completed..
         metadata:


### PR DESCRIPTION
Our generated deserialization of decorated duration attempts to deserialize the number values from JSON as Int32; they're actually floats/doubles.

Fortunately, the serialization hooks now work and it's comparatively clean to apply custom deserialization routines for each of these.