### PR TITLE
Standardize FileClient method names

### DIFF
--- a/.dotnet/src/Custom/Files/FileClient.Protocol.cs
+++ b/.dotnet/src/Custom/Files/FileClient.Protocol.cs
@@ -39,7 +39,7 @@ public partial class FileClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> UploadAsync(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual async Task<ClientResult> UploadFileAsync(BinaryContent content, string contentType, RequestOptions options = null)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));
@@ -69,7 +69,7 @@ public partial class FileClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult Upload(BinaryContent content, string contentType, RequestOptions options = null)
+    public virtual ClientResult UploadFile(BinaryContent content, string contentType, RequestOptions options = null)
     {
         Argument.AssertNotNull(content, nameof(content));
         Argument.AssertNotNullOrEmpty(contentType, nameof(contentType));
@@ -167,7 +167,7 @@ public partial class FileClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> DeleteAsync(string fileId, RequestOptions options)
+    public virtual async Task<ClientResult> DeleteFileAsync(string fileId, RequestOptions options)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
 
@@ -188,7 +188,7 @@ public partial class FileClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult Delete(string fileId, RequestOptions options)
+    public virtual ClientResult DeleteFile(string fileId, RequestOptions options)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
 
@@ -209,7 +209,7 @@ public partial class FileClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> DownloadContentAsync(string fileId, RequestOptions options)
+    public virtual async Task<ClientResult> DownloadFileAsync(string fileId, RequestOptions options)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
 
@@ -230,7 +230,7 @@ public partial class FileClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult DownloadContent(string fileId, RequestOptions options)
+    public virtual ClientResult DownloadFile(string fileId, RequestOptions options)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
 

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -88,7 +88,7 @@ public partial class FileClient
         };
 
         using MultipartFormDataBinaryContent content = options.ToMultipartContent(file, filename);
-        ClientResult result = await UploadAsync(content, content.ContentType).ConfigureAwait(false);
+        ClientResult result = await UploadFileAsync(content, content.ContentType).ConfigureAwait(false);
         return ClientResult.FromValue(OpenAIFileInfo.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
@@ -117,7 +117,7 @@ public partial class FileClient
         };
 
         using MultipartFormDataBinaryContent content = options.ToMultipartContent(file, filename);
-        ClientResult result = Upload(content, content.ContentType);
+        ClientResult result = UploadFile(content, content.ContentType);
         return ClientResult.FromValue(OpenAIFileInfo.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
@@ -170,11 +170,11 @@ public partial class FileClient
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
     /// <remarks> Delete file. </remarks>
-    public virtual async Task<ClientResult<DeleteFileResponse>> DeleteAsync(string fileId)
+    public virtual async Task<ClientResult<DeleteFileResponse>> DeleteFileAsync(string fileId)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
 
-        ClientResult result = await DeleteAsync(fileId, null).ConfigureAwait(false);
+        ClientResult result = await DeleteFileAsync(fileId, null).ConfigureAwait(false);
         return ClientResult.FromValue(DeleteFileResponse.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
@@ -183,11 +183,11 @@ public partial class FileClient
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
     /// <remarks> Delete file. </remarks>
-    public virtual ClientResult<DeleteFileResponse> Delete(string fileId)
+    public virtual ClientResult<DeleteFileResponse> DeleteFile(string fileId)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
 
-        ClientResult result = Delete(fileId, null);
+        ClientResult result = DeleteFile(fileId, null);
         return ClientResult.FromValue(DeleteFileResponse.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
@@ -196,11 +196,11 @@ public partial class FileClient
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
     /// <remarks> Download file. </remarks>
-    public virtual async Task<ClientResult<BinaryData>> DownloadContentAsync(string fileId)
+    public virtual async Task<ClientResult<BinaryData>> DownloadFileAsync(string fileId)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
 
-        ClientResult result = await DownloadContentAsync(fileId, null).ConfigureAwait(false);
+        ClientResult result = await DownloadFileAsync(fileId, null).ConfigureAwait(false);
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
     }
 
@@ -209,11 +209,11 @@ public partial class FileClient
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
     /// <remarks> Download file. </remarks>
-    public virtual ClientResult<BinaryData> DownloadContent(string fileId)
+    public virtual ClientResult<BinaryData> DownloadFile(string fileId)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
 
-        ClientResult result = DownloadContent(fileId, null);
+        ClientResult result = DownloadFile(fileId, null);
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
     }
 }

--- a/.dotnet/tests/Samples/Assistants/Sample01_RetrievalAugmentedGeneration.cs
+++ b/.dotnet/tests/Samples/Assistants/Sample01_RetrievalAugmentedGeneration.cs
@@ -125,7 +125,7 @@ namespace OpenAI.Samples
                     else if (contentItem is MessageImageFileContent imageFileContent)
                     {
                         OpenAIFileInfo imageInfo = fileClient.GetFile(imageFileContent.FileId);
-                        BinaryData imageBytes = fileClient.DownloadContent(imageFileContent.FileId);
+                        BinaryData imageBytes = fileClient.DownloadFile(imageFileContent.FileId);
                         using FileStream stream = File.OpenWrite($"{imageInfo.Filename}.png");
                         imageBytes.ToStream().CopyTo(stream);
 

--- a/.dotnet/tests/Samples/Assistants/Sample01_RetrievalAugmentedGenerationAsync.cs
+++ b/.dotnet/tests/Samples/Assistants/Sample01_RetrievalAugmentedGenerationAsync.cs
@@ -125,7 +125,7 @@ namespace OpenAI.Samples
                     else if (contentItem is MessageImageFileContent imageFileContent)
                     {
                         OpenAIFileInfo imageInfo = await fileClient.GetFileAsync(imageFileContent.FileId);
-                        BinaryData imageBytes = await fileClient.DownloadContentAsync(imageFileContent.FileId);
+                        BinaryData imageBytes = await fileClient.DownloadFileAsync(imageFileContent.FileId);
                         using FileStream stream = File.OpenWrite($"{imageInfo.Filename}.png");
                         await imageBytes.ToStream().CopyToAsync(stream);
 

--- a/.dotnet/tests/TestScenarios/Files/FileTests.cs
+++ b/.dotnet/tests/TestScenarios/Files/FileTests.cs
@@ -40,7 +40,7 @@ public partial class FileTests
         Assert.AreEqual(uploadedFile.Id, fileInfo.Id);
         Assert.AreEqual(uploadedFile.Filename, fileInfo.Filename);
 
-        DeleteFileResponse deleteResponse = await client.DeleteAsync(uploadedFile.Id);
+        DeleteFileResponse deleteResponse = await client.DeleteFileAsync(uploadedFile.Id);
         Assert.AreEqual(uploadedFile.Id, deleteResponse.Id);
         Assert.IsTrue(deleteResponse.Deleted);
     }
@@ -53,7 +53,7 @@ public partial class FileTests
         OpenAIFileInfo fileInfo = await client.GetFileAsync("file-S7roYWamZqfMK9D979HU4q6m");
         Assert.NotNull(fileInfo);
 
-        BinaryData downloadedContent = await client.DownloadContentAsync("file-S7roYWamZqfMK9D979HU4q6m");
+        BinaryData downloadedContent = await client.DownloadFileAsync("file-S7roYWamZqfMK9D979HU4q6m");
         Assert.That(downloadedContent, Is.Not.Null);
     }
 


### PR DESCRIPTION
## Comparisons

| Changed? | Before | Current | OpenAPI Spec |
|---|---|---|---|
| X | Upload | UploadFile | createFile
| X | DownloadFileContent | DownloadFile | downloadFile
| | GetFile | GetFile | retrieveFile
| | GetFiles | GetFiles | listFiles
| X | Delete | DeleteFile | deleteFile

## Why?

Full parallelism with the spec; internal consistency. It's strange to have Upload/Delete but then DownloadFileContent/GetFile -- this reads much more smoothly.