### PR TITLE
Add protocol variants of CompleteChatStreaming (BufferResponse = false)

### DIFF
--- a/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
@@ -26,4 +26,23 @@ public partial class ChatClient
         PipelineResponse response = await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false);
         return ClientResult.FromResponse(response);
     }
+
+    /// <inheritdoc cref="Internal.Chat.CreateChatCompletion(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual ClientResult CompleteChatStreaming(BinaryContent content, RequestOptions options = null)
+    {
+            using PipelineMessage message = CreateChatCompletionPipelineMessage(content, options);
+            message.BufferResponse = false;
+            return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
+    }
+
+    /// <inheritdoc cref="Internal.Chat.CreateChatCompletionAsync(BinaryContent, RequestOptions)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public virtual async Task<ClientResult> CompleteChatStreamingAsync(BinaryContent content, RequestOptions options = null)
+    {
+        using PipelineMessage message = CreateChatCompletionPipelineMessage(content, options);
+        message.BufferResponse = false;
+        PipelineResponse response = await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false);
+        return ClientResult.FromResponse(response);
+    }
 }

--- a/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.Protocol.cs
@@ -31,9 +31,10 @@ public partial class ChatClient
     [EditorBrowsable(EditorBrowsableState.Never)]
     public virtual ClientResult CompleteChatStreaming(BinaryContent content, RequestOptions options = null)
     {
-            using PipelineMessage message = CreateChatCompletionPipelineMessage(content, options);
-            message.BufferResponse = false;
-            return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
+        using PipelineMessage message = CreateChatCompletionPipelineMessage(content, options);
+        message.BufferResponse = false;
+        _ = Pipeline.ProcessMessage(message, options);
+        return ClientResult.FromResponse(message.ExtractResponse());
     }
 
     /// <inheritdoc cref="Internal.Chat.CreateChatCompletionAsync(BinaryContent, RequestOptions)"/>
@@ -42,7 +43,7 @@ public partial class ChatClient
     {
         using PipelineMessage message = CreateChatCompletionPipelineMessage(content, options);
         message.BufferResponse = false;
-        PipelineResponse response = await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false);
-        return ClientResult.FromResponse(response);
+        _ = await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false);
+        return ClientResult.FromResponse(message.ExtractResponse());
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatClient.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.cs
@@ -252,9 +252,7 @@ public partial class ChatClient
         Argument.AssertNotNull(messages, nameof(messages));
         Internal.Models.CreateChatCompletionRequest internalRequest = CreateInternalRequest(messages, options, choiceCount, stream: true);
         using BinaryContent content = BinaryContent.Create(internalRequest);
-        PipelineMessage requestMessage = CreateChatCompletionPipelineMessage(content, null, bufferResponse: false);
-        PipelineResponse response = Pipeline.ProcessMessage(requestMessage, null);
-        ClientResult protocolResult = ClientResult.FromResponse(response);
+        ClientResult protocolResult = CompleteChatStreaming(content, (RequestOptions)null);
         return StreamingClientResult<StreamingChatUpdate>.CreateFromResponse(
             protocolResult,
             (responseForEnumeration) => SseAsyncEnumerator<StreamingChatUpdate>.EnumerateFromSseStream(
@@ -285,9 +283,7 @@ public partial class ChatClient
         Argument.AssertNotNull(messages, nameof(messages));
         Internal.Models.CreateChatCompletionRequest internalRequest = CreateInternalRequest(messages, options, choiceCount, stream: true);
         using BinaryContent content = BinaryContent.Create(internalRequest);
-        PipelineMessage requestMessage = CreateChatCompletionPipelineMessage(content, null, bufferResponse: false);
-        PipelineResponse response = Pipeline.ProcessMessage(requestMessage, null);
-        ClientResult protocolResult = ClientResult.FromResponse(response);
+        ClientResult protocolResult = await CompleteChatStreamingAsync(content, (RequestOptions)null).ConfigureAwait(false);
         return StreamingClientResult<StreamingChatUpdate>.CreateFromResponse(
             protocolResult,
             (responseForEnumeration) => SseAsyncEnumerator<StreamingChatUpdate>.EnumerateFromSseStream(


### PR DESCRIPTION
We'll need a proper protocol-level target for convenience-layer methods (including in the AOAI derived library) to invoke the "don't buffer the response" behavior for streaming.

Having this 1-to-1 mapping isn't perfect since it doesn't enforce or automate the emplacement of `"stream": true` in the request body, but it's a very clear enablement approach.