### PR TITLE
Restore PowerShell removal of cached clients -- needed for stoub change

### DIFF
--- a/.dotnet/scripts/ConvertTo-Internal.ps1
+++ b/.dotnet/scripts/ConvertTo-Internal.ps1
@@ -813,7 +813,7 @@ function Edit-GeneratedModels {
     }
 }
 
-# Edit-GeneratedOpenAIClient
+Edit-GeneratedOpenAIClient
 # Edit-GeneratedSubclients
 # Edit-GeneratedModelFactory
 Edit-GeneratedModels

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -46,25 +46,6 @@ public partial class OpenAIClient
 {
     private readonly OpenAIClientOptions _options;
 
-    // CUSTOM: Applied the Experimental attribute as needed.
-    private AudioClient _cachedAudioClient;
-    [Experimental("OPENAI001")]
-    private AssistantClient _cachedAssistantClient;
-    private BatchClient _cachedBatchClient;
-    private ChatClient _cachedChatClient;
-    private LegacyCompletionClient _cachedLegacyCompletionClient;
-    private EmbeddingClient _cachedEmbeddingClient;
-    private FileClient _cachedFileClient;
-    private FineTuningClient _cachedFineTuningClient;
-    private ImageClient _cachedImageClient;
-    private InternalAssistantMessageClient _cachedInternalAssistantMessageClient;
-    private ModelClient _cachedModelClient;
-    private ModerationClient _cachedModerationClient;
-    private InternalAssistantRunClient _cachedInternalAssistantRunClient;
-    private InternalAssistantThreadClient _cachedInternalAssistantThreadClient;
-    [Experimental("OPENAI001")]
-    private VectorStoreClient _cachedVectorStoreClient;
-
     /// <summary>
     /// The configured connection endpoint.
     /// </summary>


### PR DESCRIPTION
We already had the needed PowerShell function to keep unused cached clients out of the generated code; although "more PowerShell" is not ideal, this is a very incremental use on a single file that unblocks a corresponding "clean up the warnings" PR from stoub on the public repository:

https://github.com/openai/openai-dotnet/pull/47