### PR TITLE
Azure Staging: make OpenAI signing conditional, use 'Unsigned' configuration for AOAI staging

### DIFF
--- a/.dotnet.azure/Azure.AI.OpenAI.sln
+++ b/.dotnet.azure/Azure.AI.OpenAI.sln
@@ -1,0 +1,26 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35004.147
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.OpenAI", "src\Azure.AI.OpenAI.csproj", "{A80B9566-84A5-4AE4-AA0A-72B18646F1EC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenAI", "..\.dotnet\src\OpenAI.csproj", "{8BEE571B-DB25-4BE5-B9EB-2CA81D12EBC6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Unsigned|Any CPU = Unsigned|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A80B9566-84A5-4AE4-AA0A-72B18646F1EC}.Unsigned|Any CPU.ActiveCfg = Unsigned|Any CPU
+		{A80B9566-84A5-4AE4-AA0A-72B18646F1EC}.Unsigned|Any CPU.Build.0 = Unsigned|Any CPU
+		{8BEE571B-DB25-4BE5-B9EB-2CA81D12EBC6}.Unsigned|Any CPU.ActiveCfg = Unsigned|Any CPU
+		{8BEE571B-DB25-4BE5-B9EB-2CA81D12EBC6}.Unsigned|Any CPU.Build.0 = Unsigned|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A68497E4-547C-42B4-8EE4-6776A8238EE4}
+	EndGlobalSection
+EndGlobal

--- a/.dotnet.azure/src/Azure.AI.OpenAI.csproj
+++ b/.dotnet.azure/src/Azure.AI.OpenAI.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
   NOTE: This is a staging version of the file. Changes should not be made here except for reflections and replacements from azure-sdk-for-net.
         This project will be removed once direct codegen support is functional.
 
@@ -23,6 +23,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>disable</Nullable>
+    <Configurations>Unsigned</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.dotnet/src/OpenAI.csproj
+++ b/.dotnet/src/OpenAI.csproj
@@ -10,10 +10,6 @@
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
-    <!-- Sign the assembly with the specified key file. -->
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>OpenAI.snk</AssemblyOriginatorKeyFile>
-
     <!-- Generate an XML documentation file for the project. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     
@@ -39,7 +35,22 @@
 
     <!-- Disable unused fields warnings -->
     <NoWarn>$(NoWarn),0169</NoWarn>
+
+    <Configurations>Debug;Release;Unsigned</Configurations>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' != 'Unsigned'">
+    <!-- Sign the assembly with the specified key file. -->
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>OpenAI.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Azure.AI.OpenAI" Condition="'$(Configuration)' != 'Unsigned'">
+      <PublicKey>0024000004800000940000000602000000240000525341310004000001000100097ad52abbeaa2e1a1982747cc0106534f65cfea6707eaed696a3a63daea80de2512746801a7e47f88e7781e71af960d89ba2e25561f70b0e2dbc93319e0af1961a719ccf5a4d28709b2b57a5d29b7c09dc8d269a490ebe2651c4b6e6738c27c5fb2c02469fe9757f0a3479ac310d6588a50a28d7dd431b907fd325e18b9e8ed</PublicKey>
+    </InternalsVisibleTo>
+    <InternalsVisibleTo Include="Azure.AI.OpenAI" Condition="'$(Configuration)' == 'Unsigned'" />
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <!-- Allow use of unsafe code, for System.Net.ServerSentEvents polyfill on netstandard2.0
@@ -61,11 +72,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.ClientModel" Version="1.1.0-beta.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <InternalsVisibleTo Include="Azure.AI.OpenAI">
-      <PublicKey>0024000004800000940000000602000000240000525341310004000001000100097ad52abbeaa2e1a1982747cc0106534f65cfea6707eaed696a3a63daea80de2512746801a7e47f88e7781e71af960d89ba2e25561f70b0e2dbc93319e0af1961a719ccf5a4d28709b2b57a5d29b7c09dc8d269a490ebe2651c4b6e6738c27c5fb2c02469fe9757f0a3479ac310d6588a50a28d7dd431b907fd325e18b9e8ed</PublicKey>
-    </InternalsVisibleTo>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What it does:

This makes it possible to build the staged Azure library with no local-only modifications needed.

- `OpenAI.csproj` gains an 'Unsigned' configuration (unreferenced in solution, not built automatically) that will conditionally *not* sign the assembly and will use an unkeyed `InternalsVisibleTo` for local build
- The Azure staging project under `.dotnet.azure` gains a dedicated `.sln` file that *only* builds `Unsigned`
- Net: real OpenAI build will continue to sign; Azure staging build will piggyback with unsigned


## What it doesn't do:

- AOAI test code isn't included/built. The TestFramework dependency is a different onion to unravel.
- Thus: it **would have** caught the `CancellationToken` signature change; it **would not have** caught the `CreateMessage` change.