### PR TITLE
change one model to see diff

### DIFF
--- a/.dotnet/src/Custom/Assistants/AssistantModificationOptions.cs
+++ b/.dotnet/src/Custom/Assistants/AssistantModificationOptions.cs
@@ -5,7 +5,7 @@ namespace OpenAI.Assistants;
 /// <summary>
 /// Represents additional options available when modifying an existing <see cref="Assistant"/>.
 /// </summary>
-[CodeGenModel("ModifyAssistantRequest")]
+[CodeGenModel("AssistantModificationOptions")]
 public partial class AssistantModificationOptions
 {
     /// <summary>
@@ -19,18 +19,15 @@ public partial class AssistantModificationOptions
     /// </para>
     /// There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `file_search`, or `function`.
     /// </summary>
-    [CodeGenMember("Tools")]
     public IList<ToolDefinition> DefaultTools { get; init; } = new ChangeTrackingList<ToolDefinition>();
 
     // CUSTOM: reuse common request/response models for tool resources. Note that modification operations use the
     //          response models (which do not contain resource initialization helpers).
 
     /// <inheritdoc cref="ToolResources"/>
-    [CodeGenMember("ToolResources")]
     public ToolResources ToolResources { get; init; }
 
     /// <inheritdoc cref="AssistantResponseFormat"/>
-    [CodeGenMember("ResponseFormat")]
     public AssistantResponseFormat ResponseFormat { get; init; }
 
     /// <summary>
@@ -38,6 +35,5 @@ public partial class AssistantModificationOptions
     ///
     /// We generally recommend altering this or temperature but not both.
     /// </summary>
-    [CodeGenMember("TopP")]
     public float? NucleusSamplingFactor { get; init; }
 }

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -20,7 +20,6 @@ namespace OpenAI;
 /// A top-level client factory that enables convenient creation of scenario-specific sub-clients while reusing shared
 /// configuration details like endpoint, authentication, and pipeline customization.
 /// </summary>
-[CodeGenModel("OpenAIClient")]
 [CodeGenSuppress("OpenAIClient", typeof(ApiKeyCredential))]
 [CodeGenSuppress("OpenAIClient", typeof(Uri), typeof(ApiKeyCredential), typeof(OpenAIClientOptions))]
 [CodeGenSuppress("GetAssistantClientClient")]

--- a/.dotnet/src/Custom/OpenAIClientOptions.cs
+++ b/.dotnet/src/Custom/OpenAIClientOptions.cs
@@ -6,7 +6,6 @@ namespace OpenAI;
 /// <summary>
 /// Client-level options for the OpenAI service.
 /// </summary>
-[CodeGenModel("OpenAIClientOptions")]
 public partial class OpenAIClientOptions : ClientPipelineOptions
 {
     /// <summary>

--- a/.scripts/Invoke-CodeGen.ps1
+++ b/.scripts/Invoke-CodeGen.ps1
@@ -12,7 +12,7 @@ try {
   Invoke { npm ci }
   Invoke { npm exec --no -- tsp format **/*tsp }
   Invoke { npm exec --no -- tsp compile main.tsp --emit @typespec/openapi3 }
-  Invoke { npm exec --no -- tsp compile main.tsp --emit @azure-tools/typespec-csharp --option @azure-tools/typespec-csharp.emitter-output-dir="$dotnetFolder" }
+  Invoke { npm exec --no -- tsp compile client.tsp --emit @azure-tools/typespec-csharp --option @azure-tools/typespec-csharp.emitter-output-dir="$dotnetFolder" }
   Invoke { .$PSScriptRoot\Update-ClientModel.ps1 }
   Invoke { .$PSScriptRoot\ConvertTo-Internal.ps1 }
   Invoke { .$PSScriptRoot\Add-Customizations.ps1 }

--- a/.typespec/assistants/client.tsp
+++ b/.typespec/assistants/client.tsp
@@ -1,0 +1,9 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+using OpenAI;
+
+@@clientName(ModifyAssistantRequest, "AssistantModificationOptions", "csharp");
+@@clientName(ModifyAssistantRequest.tools, "defaultTools", "csharp");
+@@clientName(ModifyAssistantRequest.top_p, "nucleusSamplingFactor", "csharp");

--- a/.typespec/client.tsp
+++ b/.typespec/client.tsp
@@ -1,0 +1,17 @@
+import "./main.tsp";
+
+//import "./audio/client.tsp";
+import "./assistants/client.tsp";
+//import "./batch/client.tsp";
+//import "./chat/client.tsp";
+//import "./completions/client.tsp";
+//import "./embeddings/client.tsp";
+//import "./files/client.tsp";
+//import "./fine-tuning/client.tsp";
+//import "./images/client.tsp";
+//import "./messages/client.tsp";
+//import "./models/client.tsp";
+//import "./moderations/client.tsp";
+//import "./runs/client.tsp";
+//import "./threads/client.tsp";
+//import "./vector-stores/client.tsp";


### PR DESCRIPTION
There are 3 reasons we can't remove more custom code for model [AssistantModificationOptions](https://github.com/joseharriaga/openai-in-typespec/pull/162/files#diff-34e9e23aa0487124150b39ada1f8874d2b84099b944b2d39627e17245e441e2cR9)

- namespace difference
- custom xml doc
- property type changes

Potential option to reduce custom code for the above issues.

For namespace we could add another decorator like this.  The value of this is it can be shared across languages and since it is an identifier for the type it makes sense to know this before the files are created.

```tsp

@@clientSubNamespace(ModifyAssistantRequest, "Assistants", "csharp");

```

We could then add 2 new CodeGen attributes.

- CodeGenPropertyType - This will take the name of a property and the type to replace
- CodeGenDoc - This will take the name of the property, the xml tag to replace / add, and the lines of text to use.  This will allow us to write custom xml docs without needing to duplicate the property definition

Example of resulting custom code for `AssistantModificationOptions`

```c#

namespace OpenAI.Assistants;

[CodeGenPropertyType(nameof(ToolResources), typeof(ToolResources))]
[CodeGenPropertyType(nameof(ResponseFormat), typeof(AssistantResponseFormat))]
[CodeGenDoc(XmlDocTag.Summary, "Represents additional options available when modifying an existing <see cref=\"Assistant\"/>.")]
[CodeGenDoc(nameof(Model), XmlDocTag.Summary, "The replacement model that the assistant should use.")]
[CodeGenDoc(nameof(DefaultTools), XmlDocTag.Summary,
[
    "<para>",
    "A list of tool enabled on the assistant.",
    "</para>",
    "There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `file_search`, or `function`."
])]
[CodeGenDoc(nameof(NucleusSamplingFactor), XmlDocTag.Summary,
[
    "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.",
    string.Empty,
    "We generally recommend altering this or temperature but not both."
])]
public partial class AssistantModificationOptions { }

```

Alternatively we could also consider some custom docs in tsp directly, but would need to come up with a format / syntax for special tags like `<see cref="Foo" />`

Before any changes from this PR or proposed the customized file looked like this for reference.

```c#

using System.Collections.Generic;

namespace OpenAI.Assistants;

/// <summary>
/// Represents additional options available when modifying an existing <see cref="Assistant"/>.
/// </summary>
[CodeGenModel("ModifyAssistantRequest")]
public partial class AssistantModificationOptions
{
    /// <summary>
    /// The replacement model that the assistant should use.
    /// </summary>
    public string Model { get; init; }

    /// <summary>
    /// <para>
    /// A list of tool enabled on the assistant.
    /// </para>
    /// There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `file_search`, or `function`.
    /// </summary>
    [CodeGenMember("Tools")]
    public IList<ToolDefinition> DefaultTools { get; init; } = new ChangeTrackingList<ToolDefinition>();

    // CUSTOM: reuse common request/response models for tool resources. Note that modification operations use the
    //          response models (which do not contain resource initialization helpers).

    /// <inheritdoc cref="ToolResources"/>
    [CodeGenMember("ToolResources")]
    public ToolResources ToolResources { get; init; }

    /// <inheritdoc cref="AssistantResponseFormat"/>
    [CodeGenMember("ResponseFormat")]
    public AssistantResponseFormat ResponseFormat { get; init; }

    /// <summary>
    /// An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
    ///
    /// We generally recommend altering this or temperature but not both.
    /// </summary>
    [CodeGenMember("TopP")]
    public float? NucleusSamplingFactor { get; init; }
}

```