### PR TITLE
Address retry behavior issues

### DIFF
--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -237,11 +237,9 @@ public partial class OpenAIClient
             perCallPolicies: [
                 CreateAddBetaFeatureHeaderPolicy(),
                 CreateAddCustomHeadersPolicy(options),
-            ],
-            perTryPolicies:
-            [
                 ApiKeyAuthenticationPolicy.CreateHeaderApiKeyPolicy(credential, AuthorizationHeader, AuthorizationApiKeyPrefix)
             ],
+            perTryPolicies: [],
             beforeTransportPolicies: []);
     }
 

--- a/.dotnet/src/Custom/OpenAIClientOptions.cs
+++ b/.dotnet/src/Custom/OpenAIClientOptions.cs
@@ -9,6 +9,11 @@ namespace OpenAI;
 [CodeGenModel("OpenAIClientOptions")]
 public partial class OpenAIClientOptions : ClientPipelineOptions
 {
+    public OpenAIClientOptions()
+    {
+        RetryPolicy = new HeaderInformedRetryPolicy();
+    }
+
     /// <summary>
     /// A non-default base endpoint that clients should use when connecting.
     /// </summary>
@@ -28,4 +33,32 @@ public partial class OpenAIClientOptions : ClientPipelineOptions
     /// An optional ID added to OpenAI-Project header
     /// </summary>
     public string ProjectId { get; init; }
+
+    private class HeaderInformedRetryPolicy : ClientRetryPolicy
+    {
+        protected override TimeSpan GetNextDelay(PipelineMessage message, int tryCount)
+        {
+            TimeSpan? TryGetTimeSpanFromHeader(string headerName, int millisecondsPerValue = 1, bool allowDateTimeOffset = false)
+            {
+                if (double.TryParse(
+                    message?.Response?.Headers?.TryGetValue(headerName, out string textValue) == true ? textValue : null,
+                    out double doubleValue) == true)
+                {
+                    return TimeSpan.FromMilliseconds(millisecondsPerValue * doubleValue);
+                }
+                else if (allowDateTimeOffset && DateTimeOffset.TryParse(headerName, out DateTimeOffset delayUntil))
+                {
+                    return delayUntil - DateTimeOffset.Now;
+                }
+                return null;
+            }
+
+            TimeSpan? delayFromHeader =
+                TryGetTimeSpanFromHeader("retry-after-ms")
+                ?? TryGetTimeSpanFromHeader("x-ms-retry-after-ms")
+                ?? TryGetTimeSpanFromHeader("Retry-After", millisecondsPerValue: 1000, allowDateTimeOffset: true);
+
+            return delayFromHeader ?? base.GetNextDelay(message, tryCount);
+        }
+    }
 }


### PR DESCRIPTION
## Problems

1. We currently don't honor `Retry-After` or related headers, instead just using exponential backoff against the default 800ms and 3 attempts (800, 1600, 3200)
2. Because the authorization header is added per-call instead of per-try, retry attempts fail with no authorization

## Approach

1. Add a private `HeaderInformedRetryPolicy` that uses the provided header values if present, falling back to the default behavior otherwise
2. Move the authorization header policy application to per-try