### PR TITLE
[Port] Make RequiredActionUpdate a RunUpdate

### DIFF
--- a/.dotnet/src/Custom/Assistants/Streaming/RequiredActionUpdate.cs
+++ b/.dotnet/src/Custom/Assistants/Streaming/RequiredActionUpdate.cs
@@ -11,7 +11,7 @@ namespace OpenAI.Assistants;
 /// Distinct <see cref="RequiredActionUpdate"/> instances will generated for each required action, meaning that
 /// parallel function calling will present multiple updates even if the tool calls arrive at the same time.
 /// </remarks>
-public class RequiredActionUpdate : StreamingUpdate
+public class RequiredActionUpdate : RunUpdate
 {
     /// <inheritdoc cref="InternalRequiredFunctionToolCall.InternalName"/>
     public string FunctionName => AsFunctionCall?.FunctionName;
@@ -24,13 +24,11 @@ public class RequiredActionUpdate : StreamingUpdate
 
     private InternalRequiredFunctionToolCall AsFunctionCall => _requiredAction as InternalRequiredFunctionToolCall;
 
-    private readonly ThreadRun _run;
     private readonly RequiredAction _requiredAction;
 
     internal RequiredActionUpdate(ThreadRun run, RequiredAction action)
-        : base(StreamingUpdateReason.RunRequiresAction)
+        : base(run, StreamingUpdateReason.RunRequiresAction)
     {
-        _run = run;
         _requiredAction = action;
     }
 
@@ -39,7 +37,7 @@ public class RequiredActionUpdate : StreamingUpdate
     /// update.
     /// </summary>
     /// <returns></returns>
-    public ThreadRun GetThreadRun() => _run;
+    public ThreadRun GetThreadRun() => Value;
 
     internal static IEnumerable<RequiredActionUpdate> DeserializeRequiredActionUpdates(JsonElement element)
     {


### PR DESCRIPTION
RequiredActionUpdate should inherit from RunUpdate since, if a user were to iterate through updates filtered by whether they were run updates, they would want to see any updates to the run indicating that action was required to resume the run.