### PR TITLE
[ModelFactory] Implemented Files, Models, and Moderations factories

### DIFF
--- a/.dotnet/src/Custom/Embeddings/OpenAIEmbeddingsModelFactory.cs
+++ b/.dotnet/src/Custom/Embeddings/OpenAIEmbeddingsModelFactory.cs
@@ -26,7 +26,7 @@ public static partial class OpenAIEmbeddingsModelFactory
         return new EmbeddingCollection(
             items.ToList(),
             model,
-            @object: default,
+            InternalCreateEmbeddingResponseObject.List,
             usage,
             serializedAdditionalRawData: null);
     }

--- a/.dotnet/src/Custom/Files/OpenAIFilesModelFactory.cs
+++ b/.dotnet/src/Custom/Files/OpenAIFilesModelFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenAI.Files;
 
@@ -28,6 +29,9 @@ public static partial class OpenAIFilesModelFactory
     {
         items ??= new List<OpenAIFileInfo>();
 
-        return new OpenAIFileInfoCollection(items);
+        return new OpenAIFileInfoCollection(
+            items.ToList(),
+            InternalListFilesResponseObject.List,
+            serializedAdditionalRawData: null);
     }
 }

--- a/.dotnet/src/Custom/Files/OpenAIFilesModelFactory.cs
+++ b/.dotnet/src/Custom/Files/OpenAIFilesModelFactory.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OpenAI.Files;
+
+/// <summary> Model factory for models. </summary>
+public static partial class OpenAIFilesModelFactory
+{
+    /// <summary> Initializes a new instance of <see cref="OpenAI.Files.OpenAIFileInfo"/>. </summary>
+    /// <returns> A new <see cref="OpenAI.Files.OpenAIFileInfo"/> instance for mocking. </returns>
+    public static OpenAIFileInfo OpenAIFileInfo(string id = null, long? sizeInBytes = null, DateTimeOffset createdAt = default, string filename = null, OpenAIFilePurpose purpose = default, OpenAIFileStatus status = default, string statusDetails = null)
+    {
+        return new OpenAIFileInfo(
+            id,
+            sizeInBytes,
+            createdAt,
+            filename,
+            @object: InternalOpenAIFileObject.File,
+            purpose,
+            status,
+            statusDetails,
+            serializedAdditionalRawData: null);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="OpenAI.Files.OpenAIFileInfoCollection"/>. </summary>
+    /// <returns> A new <see cref="OpenAI.Files.OpenAIFileInfoCollection"/> instance for mocking. </returns>
+    public static OpenAIFileInfoCollection OpenAIFileInfoCollection(IEnumerable<OpenAIFileInfo> items = null)
+    {
+        items ??= new List<OpenAIFileInfo>();
+
+        return new OpenAIFileInfoCollection(items);
+    }
+}

--- a/.dotnet/src/Custom/Models/OpenAIModelsModelFactory.cs
+++ b/.dotnet/src/Custom/Models/OpenAIModelsModelFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenAI.Models;
 
@@ -24,6 +25,9 @@ public static partial class OpenAIModelsModelFactory
     {
         items ??= new List<OpenAIModelInfo>();
 
-        return new OpenAIModelInfoCollection(items);
+        return new OpenAIModelInfoCollection(
+            InternalListModelsResponseObject.List,
+            items.ToList(),
+            serializedAdditionalRawData: null);
     }
 }

--- a/.dotnet/src/Custom/Models/OpenAIModelsModelFactory.cs
+++ b/.dotnet/src/Custom/Models/OpenAIModelsModelFactory.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OpenAI.Models;
+
+/// <summary> Model factory for models. </summary>
+public static partial class OpenAIModelsModelFactory
+{
+    /// <summary> Initializes a new instance of <see cref="OpenAI.Models.OpenAIModelInfo"/>. </summary>
+    /// <returns> A new <see cref="OpenAI.Models.OpenAIModelInfo"/> instance for mocking. </returns>
+    public static OpenAIModelInfo OpenAIModelInfo(string id = null, DateTimeOffset createdAt = default, string ownedBy = null)
+    {
+        return new OpenAIModelInfo(
+            id,
+            createdAt,
+            InternalModelObject.Model,
+            ownedBy,
+            serializedAdditionalRawData: null);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="OpenAI.Models.OpenAIModelInfoCollection"/>. </summary>
+    /// <returns> A new <see cref="OpenAI.Models.OpenAIModelInfoCollection"/> instance for mocking. </returns>
+    public static OpenAIModelInfoCollection OpenAIModelInfoCollection(IEnumerable<OpenAIModelInfo> items = null)
+    {
+        items ??= new List<OpenAIModelInfo>();
+
+        return new OpenAIModelInfoCollection(items);
+    }
+}

--- a/.dotnet/src/Custom/Moderations/OpenAIModerationsModelFactory.cs
+++ b/.dotnet/src/Custom/Moderations/OpenAIModerationsModelFactory.cs
@@ -21,7 +21,8 @@ public static partial class OpenAIModerationsModelFactory
             sexual,
             sexualMinors,
             violence,
-            violenceGraphic);
+            violenceGraphic,
+            serializedAdditionalRawData: null);
     }
 
     /// <summary> Initializes a new instance of <see cref="OpenAI.Moderations.ModerationCategoryScores"/>. </summary>
@@ -39,7 +40,8 @@ public static partial class OpenAIModerationsModelFactory
             sexual,
             sexualMinors,
             violence,
-            violenceGraphic);
+            violenceGraphic,
+            serializedAdditionalRawData: null);
     }
 
     /// <summary> Initializes a new instance of <see cref="OpenAI.Moderations.ModerationCollection"/>. </summary>

--- a/.dotnet/src/Custom/Moderations/OpenAIModerationsModelFactory.cs
+++ b/.dotnet/src/Custom/Moderations/OpenAIModerationsModelFactory.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenAI.Moderations;
+
+/// <summary> Model factory for models. </summary>
+public static partial class OpenAIModerationsModelFactory
+{
+    /// <summary> Initializes a new instance of <see cref="OpenAI.Moderations.ModerationCategories"/>. </summary>
+    /// <returns> A new <see cref="OpenAI.Moderations.ModerationCategories"/> instance for mocking. </returns>
+    public static ModerationCategories ModerationCategories(bool hate = default, bool hateThreatening = default, bool harassment = default, bool harassmentThreatening = default, bool selfHarm = default, bool selfHarmIntent = default, bool selfHarmInstructions = default, bool sexual = default, bool sexualMinors = default, bool violence = default, bool violenceGraphic = default)
+    {
+        return new ModerationCategories(
+            hate,
+            hateThreatening,
+            harassment,
+            harassmentThreatening,
+            selfHarm,
+            selfHarmIntent,
+            selfHarmInstructions,
+            sexual,
+            sexualMinors,
+            violence,
+            violenceGraphic);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="OpenAI.Moderations.ModerationCategoryScores"/>. </summary>
+    /// <returns> A new <see cref="OpenAI.Moderations.ModerationCategoryScores"/> instance for mocking. </returns>
+    public static ModerationCategoryScores ModerationCategoryScores(float hate = default, float hateThreatening = default, float harassment = default, float harassmentThreatening = default, float selfHarm = default, float selfHarmIntent = default, float selfHarmInstructions = default, float sexual = default, float sexualMinors = default, float violence = default, float violenceGraphic = default)
+    {
+        return new ModerationCategoryScores(
+            hate,
+            hateThreatening,
+            harassment,
+            harassmentThreatening,
+            selfHarm,
+            selfHarmIntent,
+            selfHarmInstructions,
+            sexual,
+            sexualMinors,
+            violence,
+            violenceGraphic);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="OpenAI.Moderations.ModerationCollection"/>. </summary>
+    /// <returns> A new <see cref="OpenAI.Moderations.ModerationCollection"/> instance for mocking. </returns>
+    public static ModerationCollection ModerationCollection(string id = null, string model = null, IEnumerable<ModerationResult> items = null)
+    {
+        items ??= new List<ModerationResult>();
+
+        return new ModerationCollection(
+            id,
+            model,
+            items.ToList(),
+            serializedAdditionalRawData: null);
+    }
+
+    /// <summary> Initializes a new instance of <see cref="OpenAI.Moderations.ModerationResult"/>. </summary>
+    /// <returns> A new <see cref="OpenAI.Moderations.ModerationResult"/> instance for mocking. </returns>
+    public static ModerationResult ModerationResult(bool flagged = default, ModerationCategories categories = null, ModerationCategoryScores categoryScores = null)
+    {
+        return new ModerationResult(
+            flagged,
+            categories,
+            categoryScores,
+            serializedAdditionalRawData: null);
+    }
+}

--- a/.dotnet/tests/Embeddings/OpenAIEmbeddingsModelFactoryTests.cs
+++ b/.dotnet/tests/Embeddings/OpenAIEmbeddingsModelFactoryTests.cs
@@ -3,114 +3,113 @@ using System.Linq;
 using NUnit.Framework;
 using OpenAI.Embeddings;
 
-namespace OpenAI.Tests.Embeddings
+namespace OpenAI.Tests.Embeddings;
+
+[Parallelizable(ParallelScope.All)]
+[Category("Smoke")]
+public partial class OpenAIEmbeddingsModelFactoryTests
 {
-    [Parallelizable(ParallelScope.All)]
-    [Category("Smoke")]
-    public partial class OpenAIEmbeddingsModelFactoryTests
+    [Test]
+    public void EmbeddingWithNoPropertiesWorks()
     {
-        [Test]
-        public void EmbeddingWithNoPropertiesWorks()
-        {
-            Embedding embedding = OpenAIEmbeddingsModelFactory.Embedding();
+        Embedding embedding = OpenAIEmbeddingsModelFactory.Embedding();
 
-            Assert.That(embedding.Index, Is.EqualTo(default(int)));
-            Assert.That(embedding.Vector.ToArray(), Is.Not.Null.And.Empty);
-        }
+        Assert.That(embedding.Index, Is.EqualTo(default(int)));
+        Assert.That(embedding.Vector.ToArray(), Is.Not.Null.And.Empty);
+    }
 
-        [Test]
-        public void EmbeddingWithIndexWorks()
-        {
-            int index = 10;
-            Embedding embedding = OpenAIEmbeddingsModelFactory.Embedding(index: index);
+    [Test]
+    public void EmbeddingWithIndexWorks()
+    {
+        int index = 10;
+        Embedding embedding = OpenAIEmbeddingsModelFactory.Embedding(index: index);
 
-            Assert.That(embedding.Index, Is.EqualTo(index));
-            Assert.That(embedding.Vector.ToArray(), Is.Not.Null.And.Empty);
-        }
+        Assert.That(embedding.Index, Is.EqualTo(index));
+        Assert.That(embedding.Vector.ToArray(), Is.Not.Null.And.Empty);
+    }
 
-        [Test]
-        public void EmbeddingWithVectorWorks()
-        {
-            IEnumerable<float> vector = [ 1f, 2f, 3f ];
-            Embedding embedding = OpenAIEmbeddingsModelFactory.Embedding(vector: vector);
+    [Test]
+    public void EmbeddingWithVectorWorks()
+    {
+        IEnumerable<float> vector = [ 1f, 2f, 3f ];
+        Embedding embedding = OpenAIEmbeddingsModelFactory.Embedding(vector: vector);
 
-            Assert.That(embedding.Index, Is.EqualTo(default(int)));
-            Assert.That(embedding.Vector.ToArray().SequenceEqual(vector), Is.True);
-        }
+        Assert.That(embedding.Index, Is.EqualTo(default(int)));
+        Assert.That(embedding.Vector.ToArray().SequenceEqual(vector), Is.True);
+    }
 
-        [Test]
-        public void EmbeddingCollectionWithNoPropertiesWorks()
-        {
-            EmbeddingCollection embeddingCollection = OpenAIEmbeddingsModelFactory.EmbeddingCollection();
+    [Test]
+    public void EmbeddingCollectionWithNoPropertiesWorks()
+    {
+        EmbeddingCollection embeddingCollection = OpenAIEmbeddingsModelFactory.EmbeddingCollection();
 
-            Assert.That(embeddingCollection.Count, Is.EqualTo(0));
-            Assert.That(embeddingCollection.Model, Is.Null);
-            Assert.That(embeddingCollection.Usage, Is.Null);
-        }
+        Assert.That(embeddingCollection.Count, Is.EqualTo(0));
+        Assert.That(embeddingCollection.Model, Is.Null);
+        Assert.That(embeddingCollection.Usage, Is.Null);
+    }
 
-        [Test]
-        public void EmbeddingCollectionWithItemsWorks()
-        {
-            IEnumerable<Embedding> items = [
-                OpenAIEmbeddingsModelFactory.Embedding(index: 10),
-                OpenAIEmbeddingsModelFactory.Embedding(index: 20)
-            ];
-            EmbeddingCollection embeddingCollection = OpenAIEmbeddingsModelFactory.EmbeddingCollection(items: items);
+    [Test]
+    public void EmbeddingCollectionWithItemsWorks()
+    {
+        IEnumerable<Embedding> items = [
+            OpenAIEmbeddingsModelFactory.Embedding(index: 10),
+            OpenAIEmbeddingsModelFactory.Embedding(index: 20)
+        ];
+        EmbeddingCollection embeddingCollection = OpenAIEmbeddingsModelFactory.EmbeddingCollection(items: items);
 
-            Assert.That(embeddingCollection.SequenceEqual(items), Is.True);
-            Assert.That(embeddingCollection.Model, Is.Null);
-            Assert.That(embeddingCollection.Usage, Is.Null);
-        }
+        Assert.That(embeddingCollection.SequenceEqual(items), Is.True);
+        Assert.That(embeddingCollection.Model, Is.Null);
+        Assert.That(embeddingCollection.Usage, Is.Null);
+    }
 
-        [Test]
-        public void EmbeddingCollectionWithModelWorks()
-        {
-            string model = "supermodel";
-            EmbeddingCollection embeddingCollection = OpenAIEmbeddingsModelFactory.EmbeddingCollection(model: model);
+    [Test]
+    public void EmbeddingCollectionWithModelWorks()
+    {
+        string model = "supermodel";
+        EmbeddingCollection embeddingCollection = OpenAIEmbeddingsModelFactory.EmbeddingCollection(model: model);
 
-            Assert.That(embeddingCollection.Count, Is.EqualTo(0));
-            Assert.That(embeddingCollection.Model, Is.EqualTo(model));
-            Assert.That(embeddingCollection.Usage, Is.Null);
-        }
+        Assert.That(embeddingCollection.Count, Is.EqualTo(0));
+        Assert.That(embeddingCollection.Model, Is.EqualTo(model));
+        Assert.That(embeddingCollection.Usage, Is.Null);
+    }
 
-        [Test]
-        public void EmbeddingCollectionWithUsageWorks()
-        {
-            EmbeddingTokenUsage usage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(inputTokens: 10);
-            EmbeddingCollection embeddingCollection = OpenAIEmbeddingsModelFactory.EmbeddingCollection(usage: usage);
+    [Test]
+    public void EmbeddingCollectionWithUsageWorks()
+    {
+        EmbeddingTokenUsage usage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(inputTokens: 10);
+        EmbeddingCollection embeddingCollection = OpenAIEmbeddingsModelFactory.EmbeddingCollection(usage: usage);
 
-            Assert.That(embeddingCollection.Count, Is.EqualTo(0));
-            Assert.That(embeddingCollection.Model, Is.Null);
-            Assert.That(embeddingCollection.Usage, Is.EqualTo(usage));
-        }
+        Assert.That(embeddingCollection.Count, Is.EqualTo(0));
+        Assert.That(embeddingCollection.Model, Is.Null);
+        Assert.That(embeddingCollection.Usage, Is.EqualTo(usage));
+    }
 
-        [Test]
-        public void EmbeddingTokenUsageWithNoPropertiesWorks()
-        {
-            EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage();
+    [Test]
+    public void EmbeddingTokenUsageWithNoPropertiesWorks()
+    {
+        EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage();
 
-            Assert.That(embeddingTokenUsage.InputTokens, Is.EqualTo(default(int)));
-            Assert.That(embeddingTokenUsage.TotalTokens, Is.EqualTo(default(int)));
-        }
+        Assert.That(embeddingTokenUsage.InputTokens, Is.EqualTo(default(int)));
+        Assert.That(embeddingTokenUsage.TotalTokens, Is.EqualTo(default(int)));
+    }
 
-        [Test]
-        public void EmbeddingTokenUsageWithInputTokensWorks()
-        {
-            int inputTokens = 10;
-            EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(inputTokens: inputTokens);
+    [Test]
+    public void EmbeddingTokenUsageWithInputTokensWorks()
+    {
+        int inputTokens = 10;
+        EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(inputTokens: inputTokens);
 
-            Assert.That(embeddingTokenUsage.InputTokens, Is.EqualTo(10));
-            Assert.That(embeddingTokenUsage.TotalTokens, Is.EqualTo(default(int)));
-        }
+        Assert.That(embeddingTokenUsage.InputTokens, Is.EqualTo(10));
+        Assert.That(embeddingTokenUsage.TotalTokens, Is.EqualTo(default(int)));
+    }
 
-        [Test]
-        public void EmbeddingTokenUsageWithTotalTokensWorks()
-        {
-            int totalTokens = 10;
-            EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(totalTokens: totalTokens);
+    [Test]
+    public void EmbeddingTokenUsageWithTotalTokensWorks()
+    {
+        int totalTokens = 10;
+        EmbeddingTokenUsage embeddingTokenUsage = OpenAIEmbeddingsModelFactory.EmbeddingTokenUsage(totalTokens: totalTokens);
 
-            Assert.That(embeddingTokenUsage.InputTokens, Is.EqualTo(default(int)));
-            Assert.That(embeddingTokenUsage.TotalTokens, Is.EqualTo(totalTokens));
-        }
+        Assert.That(embeddingTokenUsage.InputTokens, Is.EqualTo(default(int)));
+        Assert.That(embeddingTokenUsage.TotalTokens, Is.EqualTo(totalTokens));
     }
 }

--- a/.dotnet/tests/Files/OpenAIFilesModelFactoryTests.cs
+++ b/.dotnet/tests/Files/OpenAIFilesModelFactoryTests.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using OpenAI.Files;
+
+namespace OpenAI.Tests.Files;
+
+[Parallelizable(ParallelScope.All)]
+[Category("Smoke")]
+public partial class OpenAIFilesModelFactoryTests
+{
+    [Test]
+    public void OpenAIFileInfoWithNoPropertiesWorks()
+    {
+        OpenAIFileInfo openAIFileInfo = OpenAIFilesModelFactory.OpenAIFileInfo();
+
+        Assert.That(openAIFileInfo.Id, Is.Null);
+        Assert.That(openAIFileInfo.SizeInBytes, Is.Null);
+        Assert.That(openAIFileInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIFileInfo.Filename, Is.Null);
+        Assert.That(openAIFileInfo.Purpose, Is.EqualTo(default(OpenAIFilePurpose)));
+        Assert.That(openAIFileInfo.Status, Is.EqualTo(default(OpenAIFileStatus)));
+        Assert.That(openAIFileInfo.StatusDetails, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIFileInfoWithIdWorks()
+    {
+        string id = "fileId";
+        OpenAIFileInfo openAIFileInfo = OpenAIFilesModelFactory.OpenAIFileInfo(id: id);
+
+        Assert.That(openAIFileInfo.Id, Is.EqualTo(id));
+        Assert.That(openAIFileInfo.SizeInBytes, Is.Null);
+        Assert.That(openAIFileInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIFileInfo.Filename, Is.Null);
+        Assert.That(openAIFileInfo.Purpose, Is.EqualTo(default(OpenAIFilePurpose)));
+        Assert.That(openAIFileInfo.Status, Is.EqualTo(default(OpenAIFileStatus)));
+        Assert.That(openAIFileInfo.StatusDetails, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIFileInfoWithSizeInBytesWorks()
+    {
+        int sizeInBytes = 1025;
+        OpenAIFileInfo openAIFileInfo = OpenAIFilesModelFactory.OpenAIFileInfo(sizeInBytes: sizeInBytes);
+
+        Assert.That(openAIFileInfo.Id, Is.Null);
+        Assert.That(openAIFileInfo.SizeInBytes, Is.EqualTo(sizeInBytes));
+        Assert.That(openAIFileInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIFileInfo.Filename, Is.Null);
+        Assert.That(openAIFileInfo.Purpose, Is.EqualTo(default(OpenAIFilePurpose)));
+        Assert.That(openAIFileInfo.Status, Is.EqualTo(default(OpenAIFileStatus)));
+        Assert.That(openAIFileInfo.StatusDetails, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIFileInfoWithCreatedAtWorks()
+    {
+        DateTimeOffset createdAt = DateTimeOffset.UtcNow;
+        OpenAIFileInfo openAIFileInfo = OpenAIFilesModelFactory.OpenAIFileInfo(createdAt: createdAt);
+
+        Assert.That(openAIFileInfo.Id, Is.Null);
+        Assert.That(openAIFileInfo.SizeInBytes, Is.Null);
+        Assert.That(openAIFileInfo.CreatedAt, Is.EqualTo(createdAt));
+        Assert.That(openAIFileInfo.Filename, Is.Null);
+        Assert.That(openAIFileInfo.Purpose, Is.EqualTo(default(OpenAIFilePurpose)));
+        Assert.That(openAIFileInfo.Status, Is.EqualTo(default(OpenAIFileStatus)));
+        Assert.That(openAIFileInfo.StatusDetails, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIFileInfoWithFilenameWorks()
+    {
+        string filename = "file.png";
+        OpenAIFileInfo openAIFileInfo = OpenAIFilesModelFactory.OpenAIFileInfo(filename: filename);
+
+        Assert.That(openAIFileInfo.Id, Is.Null);
+        Assert.That(openAIFileInfo.SizeInBytes, Is.Null);
+        Assert.That(openAIFileInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIFileInfo.Filename, Is.EqualTo(filename));
+        Assert.That(openAIFileInfo.Purpose, Is.EqualTo(default(OpenAIFilePurpose)));
+        Assert.That(openAIFileInfo.Status, Is.EqualTo(default(OpenAIFileStatus)));
+        Assert.That(openAIFileInfo.StatusDetails, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIFileInfoWithPurposeWorks()
+    {
+        OpenAIFilePurpose purpose = OpenAIFilePurpose.Vision;
+        OpenAIFileInfo openAIFileInfo = OpenAIFilesModelFactory.OpenAIFileInfo(purpose: purpose);
+
+        Assert.That(openAIFileInfo.Id, Is.Null);
+        Assert.That(openAIFileInfo.SizeInBytes, Is.Null);
+        Assert.That(openAIFileInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIFileInfo.Filename, Is.Null);
+        Assert.That(openAIFileInfo.Purpose, Is.EqualTo(purpose));
+        Assert.That(openAIFileInfo.Status, Is.EqualTo(default(OpenAIFileStatus)));
+        Assert.That(openAIFileInfo.StatusDetails, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIFileInfoWithStatusWorks()
+    {
+        OpenAIFileStatus status = OpenAIFileStatus.Uploaded;
+        OpenAIFileInfo openAIFileInfo = OpenAIFilesModelFactory.OpenAIFileInfo(status: status);
+
+        Assert.That(openAIFileInfo.Id, Is.Null);
+        Assert.That(openAIFileInfo.SizeInBytes, Is.Null);
+        Assert.That(openAIFileInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIFileInfo.Filename, Is.Null);
+        Assert.That(openAIFileInfo.Purpose, Is.EqualTo(default(OpenAIFilePurpose)));
+        Assert.That(openAIFileInfo.Status, Is.EqualTo(status));
+        Assert.That(openAIFileInfo.StatusDetails, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIFileInfoWithStatusDetailsWorks()
+    {
+        string statusDetails = "There's something off about this file.";
+        OpenAIFileInfo openAIFileInfo = OpenAIFilesModelFactory.OpenAIFileInfo(statusDetails: statusDetails);
+
+        Assert.That(openAIFileInfo.Id, Is.Null);
+        Assert.That(openAIFileInfo.SizeInBytes, Is.Null);
+        Assert.That(openAIFileInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIFileInfo.Filename, Is.Null);
+        Assert.That(openAIFileInfo.Purpose, Is.EqualTo(default(OpenAIFilePurpose)));
+        Assert.That(openAIFileInfo.Status, Is.EqualTo(default(OpenAIFileStatus)));
+        Assert.That(openAIFileInfo.StatusDetails, Is.EqualTo(statusDetails));
+    }
+
+    [Test]
+    public void OpenAIFileInfoCollectionWithNoPropertiesWorks()
+    {
+        OpenAIFileInfoCollection openAIFileInfoCollection = OpenAIFilesModelFactory.OpenAIFileInfoCollection();
+
+        Assert.That(openAIFileInfoCollection.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void OpenAIFileInfoCollectionWithItemsWorks()
+    {
+        IEnumerable<OpenAIFileInfo> items = [
+            OpenAIFilesModelFactory.OpenAIFileInfo(id: "firstFile"),
+            OpenAIFilesModelFactory.OpenAIFileInfo(id: "secondFile")
+        ];
+        OpenAIFileInfoCollection openAIFileInfoCollection = OpenAIFilesModelFactory.OpenAIFileInfoCollection(items: items);
+
+        Assert.That(openAIFileInfoCollection.SequenceEqual(items), Is.True);
+    }
+}

--- a/.dotnet/tests/Models/OpenAIModelsModelFactoryTests.cs
+++ b/.dotnet/tests/Models/OpenAIModelsModelFactoryTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using OpenAI.Models;
+
+namespace OpenAI.Tests.Models;
+
+[Parallelizable(ParallelScope.All)]
+[Category("Smoke")]
+public partial class OpenAIModelsModelFactoryTests
+{
+    [Test]
+    public void OpenAIModelInfoWithNoPropertiesWorks()
+    {
+        OpenAIModelInfo openAIModelInfo = OpenAIModelsModelFactory.OpenAIModelInfo();
+
+        Assert.That(openAIModelInfo.Id, Is.Null);
+        Assert.That(openAIModelInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIModelInfo.OwnedBy, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIModelInfoWithIdWorks()
+    {
+        string id = "modelId";
+        OpenAIModelInfo openAIModelInfo = OpenAIModelsModelFactory.OpenAIModelInfo(id: id);
+
+        Assert.That(openAIModelInfo.Id, Is.EqualTo(id));
+        Assert.That(openAIModelInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIModelInfo.OwnedBy, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIModelInfoWithCreatedAtWorks()
+    {
+        DateTimeOffset createdAt = DateTimeOffset.UtcNow;
+        OpenAIModelInfo openAIModelInfo = OpenAIModelsModelFactory.OpenAIModelInfo(createdAt: createdAt);
+
+        Assert.That(openAIModelInfo.Id, Is.Null);
+        Assert.That(openAIModelInfo.CreatedAt, Is.EqualTo(createdAt));
+        Assert.That(openAIModelInfo.OwnedBy, Is.Null);
+    }
+
+    [Test]
+    public void OpenAIModelInfoWithOwnedByWorks()
+    {
+        string ownedBy = "The people";
+        OpenAIModelInfo openAIModelInfo = OpenAIModelsModelFactory.OpenAIModelInfo(ownedBy: ownedBy);
+
+        Assert.That(openAIModelInfo.Id, Is.Null);
+        Assert.That(openAIModelInfo.CreatedAt, Is.EqualTo(default(DateTimeOffset)));
+        Assert.That(openAIModelInfo.OwnedBy, Is.EqualTo(ownedBy));
+    }
+
+    [Test]
+    public void OpenAIModelInfoCollectionWithNoPropertiesWorks()
+    {
+        OpenAIModelInfoCollection openAIModelInfoCollection = OpenAIModelsModelFactory.OpenAIModelInfoCollection();
+
+        Assert.That(openAIModelInfoCollection.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void OpenAIModelInfoCollectionWithItemsWorks()
+    {
+        IEnumerable<OpenAIModelInfo> items = [
+            OpenAIModelsModelFactory.OpenAIModelInfo(id: "firstModel"),
+            OpenAIModelsModelFactory.OpenAIModelInfo(id: "secondModel")
+        ];
+        OpenAIModelInfoCollection openAIModelInfoCollection = OpenAIModelsModelFactory.OpenAIModelInfoCollection(items: items);
+
+        Assert.That(openAIModelInfoCollection.SequenceEqual(items), Is.True);
+    }
+}

--- a/.dotnet/tests/Moderations/OpenAIModerationsModelFactoryTests.cs
+++ b/.dotnet/tests/Moderations/OpenAIModerationsModelFactoryTests.cs
@@ -1,0 +1,543 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using OpenAI.Moderations;
+
+namespace OpenAI.Tests.Moderations;
+
+[Parallelizable(ParallelScope.All)]
+[Category("Smoke")]
+public partial class OpenAIModerationsModelFactoryTests
+{
+    [Test]
+    public void ModerationCategoriesWithNoPropertiesWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories();
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithHateWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(hate: true);
+
+        Assert.That(moderationCategories.Hate, Is.True);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithHateThreateningWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(hateThreatening: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.True);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithHarassmentWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(harassment: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.True);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithHarassmentThreateningWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(harassmentThreatening: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.True);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithSelfHarmWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(selfHarm: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.True);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithSelfHarmIntentWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(selfHarmIntent: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.True);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithSelfHarmInstructionWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(selfHarmInstructions: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.True);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithSexualWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(sexual: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.True);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithSexualMinorsWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(sexualMinors: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.True);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithViolenceWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(violence: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.True);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.False);
+    }
+
+    [Test]
+    public void ModerationCategoriesWithViolenceGraphicWorks()
+    {
+        ModerationCategories moderationCategories = OpenAIModerationsModelFactory.ModerationCategories(violenceGraphic: true);
+
+        Assert.That(moderationCategories.Hate, Is.False);
+        Assert.That(moderationCategories.HateThreatening, Is.False);
+        Assert.That(moderationCategories.Harassment, Is.False);
+        Assert.That(moderationCategories.HarassmentThreatening, Is.False);
+        Assert.That(moderationCategories.SelfHarm, Is.False);
+        Assert.That(moderationCategories.SelfHarmIntent, Is.False);
+        Assert.That(moderationCategories.SelfHarmInstructions, Is.False);
+        Assert.That(moderationCategories.Sexual, Is.False);
+        Assert.That(moderationCategories.SexualMinors, Is.False);
+        Assert.That(moderationCategories.Violence, Is.False);
+        Assert.That(moderationCategories.ViolenceGraphic, Is.True);
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithNoPropertiesWorks()
+    {
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores();
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithHateWorks()
+    {
+        float hate = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(hate: hate);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(hate));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithHateThreateningWorks()
+    {
+        float hateThreatening = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(hateThreatening: hateThreatening);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(hateThreatening));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithHarassmentWorks()
+    {
+        float harassment = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(harassment: harassment);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(harassment));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithHarassmentThreateningWorks()
+    {
+        float harassmentThreatening = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(harassmentThreatening: harassmentThreatening);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(harassmentThreatening));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithSelfHarmWorks()
+    {
+        float selfHarm = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(selfHarm: selfHarm);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(selfHarm));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithSelfHarmIntentWorks()
+    {
+        float selfHarmIntent = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(selfHarmIntent: selfHarmIntent);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(selfHarmIntent));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithSelfHarmInstructionWorks()
+    {
+        float selfHarmInstructions = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(selfHarmInstructions: selfHarmInstructions);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(selfHarmInstructions));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithSexualWorks()
+    {
+        float sexual = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(sexual: sexual);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(sexual));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithSexualMinorsWorks()
+    {
+        float sexualMinors = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(sexualMinors: sexualMinors);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(sexualMinors));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithViolenceWorks()
+    {
+        float violence = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(violence: violence);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(violence));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void ModerationCategoryScoresWithViolenceGraphicWorks()
+    {
+        float violenceGraphic = 0.85f;
+        ModerationCategoryScores moderationCategoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(violenceGraphic: violenceGraphic);
+
+        Assert.That(moderationCategoryScores.Hate, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HateThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Harassment, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.HarassmentThreatening, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarm, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmIntent, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SelfHarmInstructions, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Sexual, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.SexualMinors, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.Violence, Is.EqualTo(0f));
+        Assert.That(moderationCategoryScores.ViolenceGraphic, Is.EqualTo(violenceGraphic));
+    }
+
+    [Test]
+    public void ModerationCollectionWithNoPropertiesWorks()
+    {
+        ModerationCollection moderationCollection = OpenAIModerationsModelFactory.ModerationCollection();
+
+        Assert.That(moderationCollection.Id, Is.Null);
+        Assert.That(moderationCollection.Model, Is.Null);
+        Assert.That(moderationCollection.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ModerationCollectionWithIdWorks()
+    {
+        string id = "moderationId";
+        ModerationCollection moderationCollection = OpenAIModerationsModelFactory.ModerationCollection(id: id);
+
+        Assert.That(moderationCollection.Id, Is.EqualTo(id));
+        Assert.That(moderationCollection.Model, Is.Null);
+        Assert.That(moderationCollection.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ModerationCollectionWithModelWorks()
+    {
+        string model = "supermodel";
+        ModerationCollection moderationCollection = OpenAIModerationsModelFactory.ModerationCollection(model: model);
+
+        Assert.That(moderationCollection.Id, Is.Null);
+        Assert.That(moderationCollection.Model, Is.EqualTo(model));
+        Assert.That(moderationCollection.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ModerationCollectionWithItemsWorks()
+    {
+        IEnumerable<ModerationResult> items = [
+            OpenAIModerationsModelFactory.ModerationResult(flagged: true),
+            OpenAIModerationsModelFactory.ModerationResult(flagged: false)
+        ];
+        ModerationCollection moderationCollection = OpenAIModerationsModelFactory.ModerationCollection(items: items);
+
+        Assert.That(moderationCollection.Id, Is.Null);
+        Assert.That(moderationCollection.Model, Is.Null);
+        Assert.That(moderationCollection.SequenceEqual(items), Is.True);
+    }
+
+    [Test]
+    public void ModerationResultWithNoPropertiesWorks()
+    {
+        ModerationResult moderationResult = OpenAIModerationsModelFactory.ModerationResult();
+
+        Assert.That(moderationResult.Flagged, Is.False);
+        Assert.That(moderationResult.Categories, Is.Null);
+        Assert.That(moderationResult.CategoryScores, Is.Null);
+    }
+
+    [Test]
+    public void ModerationResultWithFlaggedWorks()
+    {
+        ModerationResult moderationResult = OpenAIModerationsModelFactory.ModerationResult(flagged: true);
+
+        Assert.That(moderationResult.Flagged, Is.True);
+        Assert.That(moderationResult.Categories, Is.Null);
+        Assert.That(moderationResult.CategoryScores, Is.Null);
+    }
+
+    [Test]
+    public void ModerationResultWithCategoriesWorks()
+    {
+        ModerationCategories categories = OpenAIModerationsModelFactory.ModerationCategories(hate: true);
+        ModerationResult moderationResult = OpenAIModerationsModelFactory.ModerationResult(categories: categories);
+
+        Assert.That(moderationResult.Flagged, Is.False);
+        Assert.That(moderationResult.Categories, Is.EqualTo(categories));
+        Assert.That(moderationResult.CategoryScores, Is.Null);
+    }
+
+    [Test]
+    public void ModerationResultWithCategoryScoresWorks()
+    {
+        ModerationCategoryScores categoryScores = OpenAIModerationsModelFactory.ModerationCategoryScores(hate: 0.85f);
+        ModerationResult moderationResult = OpenAIModerationsModelFactory.ModerationResult(categoryScores: categoryScores);
+
+        Assert.That(moderationResult.Flagged, Is.False);
+        Assert.That(moderationResult.Categories, Is.Null);
+        Assert.That(moderationResult.CategoryScores, Is.EqualTo(categoryScores));
+    }
+}


### PR DESCRIPTION
Adding Model Factories for Files, Models, and Moderations models. These factories can be used to instantiate models for mocking.

At the moment there's no way to have the factories generated automatically since they are split across multiple namespaces.

I tried to keep them as close to generated code as possible. In case we manage to have the code generator generating them automatically for us, it would be ideal if we could keep changes to a minimum when migrating from manually-written to generated code.