### PR TITLE
Remove constructors that do not explicitly take a credential parameter

### DIFF
--- a/.dotnet.azure/src/Custom/Assistants/AzureAssistantClient.cs
+++ b/.dotnet.azure/src/Custom/Assistants/AzureAssistantClient.cs
@@ -17,17 +17,18 @@ internal partial class AzureAssistantClient : AssistantClient
     private readonly Uri _endpoint;
     private readonly string _apiVersion;
 
-    internal AzureAssistantClient(
-        ClientPipeline pipeline,
-        Uri endpoint,
-        AzureOpenAIClientOptions options)
-            : base(pipeline, endpoint, options)
+    internal AzureAssistantClient(ClientPipeline pipeline, Uri endpoint, AzureOpenAIClientOptions options)
+        : base(pipeline, new OpenAIClientOptions() { Endpoint = endpoint })
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
         options ??= new();
+
         _endpoint = endpoint;
         _apiVersion = options.Version;
     }
 
     protected AzureAssistantClient()
-    { }
+    {
+    }
 }

--- a/.dotnet.azure/src/Custom/Audio/AzureAudioClient.cs
+++ b/.dotnet.azure/src/Custom/Audio/AzureAudioClient.cs
@@ -18,19 +18,20 @@ internal partial class AzureAudioClient : AudioClient
     private readonly Uri _endpoint;
     private readonly string _apiVersion;
 
-    internal AzureAudioClient(
-        ClientPipeline pipeline,
-        string deploymentName,
-        Uri endpoint,
-        AzureOpenAIClientOptions options)
-            : base(pipeline, model: deploymentName, endpoint, options)
+    internal AzureAudioClient(ClientPipeline pipeline, string deploymentName, Uri endpoint, AzureOpenAIClientOptions options)
+        : base(pipeline, model: deploymentName, new OpenAIClientOptions() { Endpoint = endpoint })
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(deploymentName, nameof(deploymentName));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
         options ??= new();
+
         _deploymentName = deploymentName;
         _endpoint = endpoint;
         _apiVersion = options.Version;
     }
 
     protected AzureAudioClient()
-    { }
+    {
+    }
 }

--- a/.dotnet.azure/src/Custom/AzureOpenAIClient.cs
+++ b/.dotnet.azure/src/Custom/AzureOpenAIClient.cs
@@ -41,6 +41,7 @@ namespace Azure.AI.OpenAI;
 /// </remarks>
 public partial class AzureOpenAIClient : OpenAIClient
 {
+    private readonly Uri _endpoint;
     private readonly AzureOpenAIClientOptions _options;
 
     /// <summary>
@@ -53,64 +54,78 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// <see cref="AzureOpenAIClient(Uri,TokenCredential,AzureOpenAIClientOptions)"/>
     /// </para>
     /// </remarks>
-    /// <param name="endpoint">
-    /// <para>
-    /// The Azure OpenAI resource endpoint to use. This should not include model deployment or operation information.
-    /// </para>
-    /// <para>
-    /// Example: <c>https://my-resource.openai.azure.com</c>
-    /// </para>
-    /// </param>
-    /// <param name="credential"> The API key to use when authenticating with the specified endpoint. </param>
-    /// <param name="options"> Additional options for the client. </param>
-    public AzureOpenAIClient(Uri endpoint, ApiKeyCredential credential, AzureOpenAIClientOptions options = null)
-        : this(
-            CreatePipeline(GetApiKey(credential, requireExplicitCredential: true), options),
-            GetEndpoint(endpoint, requireExplicitEndpoint: true),
-            options)
-    {}
-
-    /// <inheritdoc cref="AzureOpenAIClient(Uri,ApiKeyCredential,AzureOpenAIClientOptions)"/>
-    public AzureOpenAIClient(Uri endpoint, AzureKeyCredential credential, AzureOpenAIClientOptions options = null)
-        : this(
-              CreatePipeline(GetApiKey(new ApiKeyCredential(credential?.Key), requireExplicitCredential: true), options),
-              GetEndpoint(endpoint, requireExplicitEndpoint: true),
-              options)
-    {}
+    /// <param name="endpoint"> The Azure OpenAI resource endpoint to use. This should not include model deployment or operation information. For example: <c>https://my-resource.openai.azure.com</c>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    public AzureOpenAIClient(Uri endpoint, ApiKeyCredential credential) : this(endpoint, credential, new AzureOpenAIClientOptions())
+    {
+    }
 
     /// <summary>
-    /// Creates a new instance of <see cref="AzureOpenAIClient"/> that will connect to an Azure OpenAI service resource
-    /// using endpoint and authentication settings from available configuration information.
+    /// Creates a new instance of <see cref="AzureOpenAIClient"/> that will connect to a specified Azure OpenAI
+    /// service resource endpoint using an API key.
     /// </summary>
     /// <remarks>
     /// <para>
     /// For token-based authentication, including the use of managed identity, please use the alternate constructor:
     /// <see cref="AzureOpenAIClient(Uri,TokenCredential,AzureOpenAIClientOptions)"/>
     /// </para>
+    /// </remarks>
+    /// <param name="endpoint"> The Azure OpenAI resource endpoint to use. This should not include model deployment or operation information. For example: <c>https://my-resource.openai.azure.com</c>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    public AzureOpenAIClient(Uri endpoint, AzureKeyCredential credential) : this(endpoint, credential, new AzureOpenAIClientOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="AzureOpenAIClient"/> that will connect to an Azure OpenAI service resource
+    /// using token authentication, including for tokens issued via managed identity.
+    /// </summary>
+    /// <remarks>
+    /// For API-key-based authentication, please use the alternate constructor:
+    /// <see cref="AzureOpenAIClient(Uri,ApiKeyCredential,AzureOpenAIClientOptions)"/>
+    /// </remarks>
+    /// <param name="endpoint"> The Azure OpenAI resource endpoint to use. This should not include model deployment or operation information. For example: <c>https://my-resource.openai.azure.com</c>. </param>
+    /// <param name="credential"> The token credential to authenticate with the service. </param>
+    public AzureOpenAIClient(Uri endpoint, TokenCredential credential) : this(endpoint, credential, new AzureOpenAIClientOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="AzureOpenAIClient"/> that will connect to a specified Azure OpenAI
+    /// service resource endpoint using an API key.
+    /// </summary>
+    /// <remarks>
     /// <para>
-    /// The client selects its resource endpoint in the following order of precedence:
-    /// <list type="number">
-    /// <item> The <see cref="OpenAIClientOptions.Endpoint"/> property on <paramref name="options"/>, if available </item>
-    /// <item> The setting in an applicable IConfiguration instance, if available </item>
-    /// <item> The value of the <c>AZURE_OPENAI_ENDPOINT</c> environment variable, if present </item>
-    /// </list>
-    /// </para>
-    /// The client selects its API key credential in the following order of precedence:
-    /// <list type="number">
-    /// <item> The setting in an applicable IConfiguration instance, if available </item>
-    /// <item> The value of the <c>AZURE_OPENAI_API_KEY</c> environment variable, if present </item>
-    /// </list>
-    /// <para>
-    /// Note: resource endpoints should not include model deployment or operation information.
-    /// </para>
-    /// <para>
-    /// Example: <c>https://my-resource.openai.azure.com</c>
+    /// For token-based authentication, including the use of managed identity, please use the alternate constructor:
+    /// <see cref="AzureOpenAIClient(Uri,TokenCredential,AzureOpenAIClientOptions)"/>
     /// </para>
     /// </remarks>
-    /// <param name="options"> Additional options for the client. </param>
-    public AzureOpenAIClient(AzureOpenAIClientOptions options = null)
-        : this(CreatePipeline(GetApiKey(), options), GetEndpoint(), options)
-    {}
+    /// <param name="endpoint"> The Azure OpenAI resource endpoint to use. This should not include model deployment or operation information. For example: <c>https://my-resource.openai.azure.com</c>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    public AzureOpenAIClient(Uri endpoint, ApiKeyCredential credential, AzureOpenAIClientOptions options)
+        : this(CreatePipeline(credential, options), endpoint, options)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="AzureOpenAIClient"/> that will connect to a specified Azure OpenAI
+    /// service resource endpoint using an API key.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For token-based authentication, including the use of managed identity, please use the alternate constructor:
+    /// <see cref="AzureOpenAIClient(Uri,TokenCredential,AzureOpenAIClientOptions)"/>
+    /// </para>
+    /// </remarks>
+    /// <param name="endpoint"> The Azure OpenAI resource endpoint to use. This should not include model deployment or operation information. For example: <c>https://my-resource.openai.azure.com</c>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    public AzureOpenAIClient(Uri endpoint, AzureKeyCredential credential, AzureOpenAIClientOptions options)
+        : this(CreatePipeline(credential?.Key, options), endpoint, options)
+    {
+    }
 
     /// <summary>
     /// Creates a new instance of <see cref="AzureOpenAIClient"/> that will connect to an Azure OpenAI service resource
@@ -128,15 +143,11 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// Example: <c>https://my-resource.openai.azure.com</c>
     /// </para>
     /// </param>
-    /// <param name="credential">
-    /// <para>
-    /// The API key to use when authenticating with the provided endpoint.
-    /// </para>
-    /// </param>
+    /// <param name="credential"> The API key to use when authenticating with the provided endpoint. </para>
     /// <param name="options"> The scenario-independent options to use. </param>
     public AzureOpenAIClient(Uri endpoint, TokenCredential credential, AzureOpenAIClientOptions options = null)
-        : this(CreatePipeline(credential, options), GetEndpoint(endpoint, requireExplicitEndpoint: true), options)
-    {}
+        : this(CreatePipeline(credential, options), endpoint, options)
+    { }
 
     /// <summary>
     /// Creates a new instance of <see cref="AzureOpenAIClient"/>.
@@ -145,8 +156,13 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// <param name="endpoint"> The endpoint to use. </param>
     /// <param name="options"> The additional client options to use. </param>
     protected AzureOpenAIClient(ClientPipeline pipeline, Uri endpoint, AzureOpenAIClientOptions options)
-        : base(pipeline, endpoint, options)
+        : base(pipeline, new OpenAIClientOptions() { Endpoint = endpoint })
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
+        options ??= new();
+
+        _endpoint = endpoint;
         _options = options;
     }
 
@@ -162,7 +178,7 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// <returns> A new <see cref="AssistantClient"/> instance. </returns>
     [Experimental("OPENAI001")]
     public override AssistantClient GetAssistantClient()
-        => new AzureAssistantClient(Pipeline, Endpoint, _options);
+        => new AzureAssistantClient(Pipeline, _endpoint, _options);
 
     /// <summary>
     /// Gets a new <see cref="AudioClient"/> instance configured for audio operation use with the Azure OpenAI service.
@@ -170,7 +186,7 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// <param name="deploymentName"> The model deployment name to use for the new client's audio operations. </param>
     /// <returns> A new <see cref="AudioClient"/> instance. </returns>
     public override AudioClient GetAudioClient(string deploymentName)
-        => new AzureAudioClient(Pipeline, deploymentName, Endpoint, _options);
+        => new AzureAudioClient(Pipeline, deploymentName, _endpoint, _options);
 
     /// <summary>
     /// Gets a new <see cref="BatchClient"/> instance configured for batch operation use with the Azure OpenAI service.
@@ -178,7 +194,7 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// <param name="deploymentName"> The model deployment name to use for the new client's audio operations. </param>
     /// <returns> A new <see cref="BatchClient"/> instance. </returns>
     public BatchClient GetBatchClient(string deploymentName)
-        => new AzureBatchClient(Pipeline, deploymentName, Endpoint, _options);
+        => new AzureBatchClient(Pipeline, deploymentName, _endpoint, _options);
 
     /// <remarks>
     /// This method is unsupported for Azure OpenAI. Please use the alternate <see cref="GetBatchClient(string)"/>
@@ -193,7 +209,7 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// <param name="deploymentName"> The model deployment name to use for the new client's chat completion operations. </param>
     /// <returns> A new <see cref="ChatClient"/> instance. </returns>
     public override ChatClient GetChatClient(string deploymentName)
-        => new AzureChatClient(Pipeline, deploymentName, Endpoint, _options);
+        => new AzureChatClient(Pipeline, deploymentName, _endpoint, _options);
 
     /// <summary>
     /// Gets a new <see cref="EmbeddingClient"/> instance configured for embedding operation use with the Azure OpenAI service.
@@ -201,21 +217,21 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// <param name="deploymentName"> The model deployment name to use for the new client's embedding operations. </param>
     /// <returns> A new <see cref="EmbeddingClient"/> instance. </returns>
     public override EmbeddingClient GetEmbeddingClient(string deploymentName)
-        => new AzureEmbeddingClient(Pipeline, deploymentName, Endpoint, _options);
+        => new AzureEmbeddingClient(Pipeline, deploymentName, _endpoint, _options);
 
     /// <summary>
     /// Gets a new <see cref="FileClient"/> instance configured for file operation use with the Azure OpenAI service.
     /// </summary>
     /// <returns> A new <see cref="FileClient"/> instance. </returns>
     public override FileClient GetFileClient()
-        => new AzureFileClient(Pipeline, Endpoint, _options);
+        => new AzureFileClient(Pipeline, _endpoint, _options);
 
     /// <summary>
     /// Gets a new <see cref="FineTuningClient"/> instance configured for fine-tuning operation use with the Azure OpenAI service.
     /// </summary>
     /// <returns> A new <see cref="FineTuningClient"/> instance. </returns>
     public override FineTuningClient GetFineTuningClient()
-        => new AzureFineTuningClient(Pipeline, Endpoint, _options);
+        => new AzureFineTuningClient(Pipeline, _endpoint, _options);
 
     /// <summary>
     /// Gets a new <see cref="ImageClient"/> instance configured for image operation use with the Azure OpenAI service.
@@ -223,7 +239,7 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// <param name="deploymentName"> The model deployment name to use for the new client's image operations. </param>
     /// <returns> A new <see cref="ImageClient"/> instance. </returns>
     public override ImageClient GetImageClient(string deploymentName)
-        => new AzureImageClient(Pipeline, deploymentName, Endpoint, _options);
+        => new AzureImageClient(Pipeline, deploymentName, _endpoint, _options);
 
     /// <remarks>
     /// Model management operations are not supported with Azure OpenAI.
@@ -249,18 +265,21 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// <returns> A new <see cref="VectorStoreClient"/> instance. </returns>
     [Experimental("OPENAI001")]
     public override VectorStoreClient GetVectorStoreClient()
-        => new AzureVectorStoreClient(Pipeline, Endpoint, _options);
+        => new AzureVectorStoreClient(Pipeline, _endpoint, _options);
 
     private static ClientPipeline CreatePipeline(PipelinePolicy authenticationPolicy, AzureOpenAIClientOptions options)
-        => ClientPipeline.Create(
+    {
+        return ClientPipeline.Create(
             options ?? new(),
-            perCallPolicies: [],
-            perTryPolicies:
-            [
+            perCallPolicies: [
+            ],
+            perTryPolicies: [
                 authenticationPolicy,
                 CreateAddUserAgentHeaderPolicy(options),
             ],
-            beforeTransportPolicies: []);
+            beforeTransportPolicies: [
+            ]);
+    }
 
     internal static ClientPipeline CreatePipeline(ApiKeyCredential credential, AzureOpenAIClientOptions options = null)
     {
@@ -272,60 +291,6 @@ public partial class AzureOpenAIClient : OpenAIClient
     {
         Argument.AssertNotNull(credential, nameof(credential));
         return CreatePipeline(new AzureTokenAuthenticationPolicy(credential), options);
-    }
-
-    internal static new ApiKeyCredential GetApiKey(ApiKeyCredential explicitCredential = null, bool requireExplicitCredential = false)
-    {
-        if (explicitCredential is not null)
-        {
-            return explicitCredential;
-        }
-        // To do: IConfiguration support
-        else if (requireExplicitCredential)
-        {
-            throw new ArgumentNullException(nameof(explicitCredential), $"A non-null credential value is required.");
-        }
-        else
-        {
-            string environmentApiKey = Environment.GetEnvironmentVariable(s_aoaiApiKeyEnvironmentVariable);
-            if (string.IsNullOrEmpty(environmentApiKey))
-            {
-                throw new InvalidOperationException(
-                    $"No environment variable value was found for AZURE_OPENAI_API_KEY. "
-                    + "Please either populate this environment variable or provide authentication information directly "
-                    + "to the client constructor.");
-            }
-            return new(environmentApiKey);
-        }
-    }
-
-    internal static Uri GetEndpoint(Uri explicitEndpoint = null, bool requireExplicitEndpoint = false, AzureOpenAIClientOptions options = null)
-    {
-        if (explicitEndpoint is not null)
-        {
-            return explicitEndpoint;
-        }
-        else if (options?.Endpoint is not null)
-        {
-            return options.Endpoint;
-        }
-        // To do: IConfiguration support
-        else if (requireExplicitEndpoint)
-        {
-            throw new ArgumentNullException(nameof(explicitEndpoint), $"A non-null endpoint value is required.");
-        }
-        else
-        {
-            string environmentApiKey = Environment.GetEnvironmentVariable(s_aoaiEndpointEnvironmentVariable);
-            if (string.IsNullOrEmpty(environmentApiKey))
-            {
-                throw new InvalidOperationException(
-                    $"No environment variable value was found for AZURE_OPENAI_ENDPOINT. "
-                    + "Please either populate this environment variable or provide endpoint information directly "
-                    + "to the client constructor.");
-            }
-            return new(environmentApiKey);
-        }
     }
 
     private static PipelinePolicy CreateAddUserAgentHeaderPolicy(AzureOpenAIClientOptions options = null)
@@ -341,8 +306,6 @@ public partial class AzureOpenAIClient : OpenAIClient
             });
     }
 
-    private static readonly string s_aoaiEndpointEnvironmentVariable = "AZURE_OPENAI_ENDPOINT";
-    private static readonly string s_aoaiApiKeyEnvironmentVariable = "AZURE_OPENAI_API_KEY";
     private static readonly string s_userAgentHeaderKey = "User-Agent";
     private static PipelineMessageClassifier _pipelineMessageClassifier;
     internal static PipelineMessageClassifier PipelineMessageClassifier

--- a/.dotnet.azure/src/Custom/Batch/AzureBatchClient.cs
+++ b/.dotnet.azure/src/Custom/Batch/AzureBatchClient.cs
@@ -18,20 +18,20 @@ internal partial class AzureBatchClient : BatchClient
     private readonly string _deploymentName;
     private readonly string _apiVersion;
 
-    internal AzureBatchClient(
-        ClientPipeline pipeline,
-        string deploymentName,
-        Uri endpoint,
-        AzureOpenAIClientOptions options)
-            : base(pipeline, endpoint, options)
+    internal AzureBatchClient(ClientPipeline pipeline, string deploymentName, Uri endpoint, AzureOpenAIClientOptions options)
+        : base(pipeline, new OpenAIClientOptions() { Endpoint = endpoint })
     {
-        options ??= new();
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
         Argument.AssertNotNullOrEmpty(deploymentName, nameof(deploymentName));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
+        options ??= new();
+
         _deploymentName = deploymentName;
         _endpoint = endpoint;
         _apiVersion = options.Version;
     }
 
     protected AzureBatchClient()
-    { }
+    {
+    }
 }

--- a/.dotnet.azure/src/Custom/Chat/AzureChatClient.cs
+++ b/.dotnet.azure/src/Custom/Chat/AzureChatClient.cs
@@ -21,21 +21,21 @@ internal partial class AzureChatClient : ChatClient
     private readonly Uri _endpoint;
     private readonly string _apiVersion;
 
-    internal AzureChatClient(
-        ClientPipeline pipeline,
-        string deploymentName,
-        Uri endpoint,
-        AzureOpenAIClientOptions options)
-            : base(pipeline, model: deploymentName, endpoint, options)
+    internal AzureChatClient(ClientPipeline pipeline, string deploymentName, Uri endpoint, AzureOpenAIClientOptions options)
+        : base(pipeline, model: deploymentName, new OpenAIClientOptions() { Endpoint = endpoint })
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(deploymentName, nameof(deploymentName));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
         options ??= new();
+
         _deploymentName = deploymentName;
-        _endpoint = endpoint;
         _apiVersion = options.Version;
     }
 
     protected AzureChatClient()
-    { }
+    {
+    }
 
     /// <inheritdoc/>
     public override AsyncCollectionResult<StreamingChatCompletionUpdate> CompleteChatStreamingAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)

--- a/.dotnet.azure/src/Custom/Embeddings/AzureEmbeddingClient.cs
+++ b/.dotnet.azure/src/Custom/Embeddings/AzureEmbeddingClient.cs
@@ -18,19 +18,20 @@ internal partial class AzureEmbeddingClient : EmbeddingClient
     private readonly Uri _endpoint;
     private readonly string _apiVersion;
 
-    internal AzureEmbeddingClient(
-        ClientPipeline pipeline,
-        string deploymentName,
-        Uri endpoint,
-        AzureOpenAIClientOptions options)
-            : base(pipeline, model: deploymentName, endpoint, options)
+    internal AzureEmbeddingClient(ClientPipeline pipeline, string deploymentName, Uri endpoint, AzureOpenAIClientOptions options)
+        : base(pipeline, model: deploymentName, new OpenAIClientOptions() { Endpoint = endpoint })
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(deploymentName, nameof(deploymentName));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
         options ??= new();
+
         _deploymentName = deploymentName;
         _endpoint = endpoint;
         _apiVersion = options.Version;
     }
 
     protected AzureEmbeddingClient()
-    { }
+    {
+    }
 }

--- a/.dotnet.azure/src/Custom/Files/AzureFileClient.cs
+++ b/.dotnet.azure/src/Custom/Files/AzureFileClient.cs
@@ -18,19 +18,20 @@ internal partial class AzureFileClient : FileClient
     private readonly Uri _endpoint;
     private readonly string _apiVersion;
 
-    internal AzureFileClient(
-        ClientPipeline pipeline,
-        Uri endpoint,
-        AzureOpenAIClientOptions options)
-            : base(pipeline, endpoint, options)
+    internal AzureFileClient(ClientPipeline pipeline, Uri endpoint, AzureOpenAIClientOptions options)
+        : base(pipeline, new OpenAIClientOptions() { Endpoint = endpoint })
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
         options ??= new();
+
         _endpoint = endpoint;
         _apiVersion = options.Version;
     }
 
     protected AzureFileClient()
-    { }
+    {
+    }
 
     /// <inheritdoc />
     public override ClientResult<OpenAIFileInfo> UploadFile(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default)

--- a/.dotnet.azure/src/Custom/FineTuning/AzureFineTuningClient.cs
+++ b/.dotnet.azure/src/Custom/FineTuning/AzureFineTuningClient.cs
@@ -17,17 +17,18 @@ internal partial class AzureFineTuningClient : FineTuningClient
     private readonly Uri _endpoint;
     private readonly string _apiVersion;
 
-    internal AzureFineTuningClient(
-        ClientPipeline pipeline,
-        Uri endpoint,
-        AzureOpenAIClientOptions options)
-            : base(pipeline, endpoint, options)
+    internal AzureFineTuningClient(ClientPipeline pipeline, Uri endpoint, AzureOpenAIClientOptions options)
+        : base(pipeline, new OpenAIClientOptions() { Endpoint = endpoint })
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
         options ??= new();
+
         _endpoint = endpoint;
         _apiVersion = options.Version;
     }
 
     protected AzureFineTuningClient()
-    { }
+    {
+    }
 }

--- a/.dotnet.azure/src/Custom/Images/AzureImageClient.cs
+++ b/.dotnet.azure/src/Custom/Images/AzureImageClient.cs
@@ -18,19 +18,20 @@ internal partial class AzureImageClient : ImageClient
     private readonly Uri _endpoint;
     private readonly string _apiVersion;
 
-    internal AzureImageClient(
-        ClientPipeline pipeline,
-        string deploymentName,
-        Uri endpoint,
-        AzureOpenAIClientOptions options)
-            : base(pipeline, model: deploymentName, endpoint, options)
+    internal AzureImageClient(ClientPipeline pipeline, string deploymentName, Uri endpoint, AzureOpenAIClientOptions options)
+        : base(pipeline, model: deploymentName, new OpenAIClientOptions() { Endpoint = endpoint })
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(deploymentName, nameof(deploymentName));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
         options ??= new();
+
         _deploymentName = deploymentName;
         _endpoint = endpoint;
         _apiVersion = options.Version;
     }
 
     protected AzureImageClient()
-    {}
+    {
+    }
 }

--- a/.dotnet.azure/src/Custom/VectorStores/AzureVectorStoreClient.cs
+++ b/.dotnet.azure/src/Custom/VectorStores/AzureVectorStoreClient.cs
@@ -19,17 +19,18 @@ internal partial class AzureVectorStoreClient : VectorStoreClient
     private readonly Uri _endpoint;
     private readonly string _apiVersion;
 
-    internal AzureVectorStoreClient(
-        ClientPipeline pipeline,
-        Uri endpoint,
-        AzureOpenAIClientOptions options)
-            : base(pipeline, endpoint, options)
+    internal AzureVectorStoreClient(ClientPipeline pipeline, Uri endpoint, AzureOpenAIClientOptions options)
+        : base(pipeline, new OpenAIClientOptions() { Endpoint = endpoint })
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNull(endpoint, nameof(endpoint));
         options ??= new();
+
         _endpoint = endpoint;
         _apiVersion = options.Version;
     }
 
     protected AzureVectorStoreClient()
-    { }
+    {
+    }
 }

--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -5,14 +5,19 @@
 ### Features Added
 
 - Added the following model factories (static classes that can be used to instantiate OpenAI models for mocking in non-live test scenarios):
-  - `OpenAIAudioModelFactory` in the `OpenAI.Audio` namespace
-  - `OpenAIEmbeddingsModelFactory` in the `OpenAI.Embeddings` namespace
-  - `OpenAIFilesModelFactory` in the `OpenAI.Files` namespace
-  - `OpenAIImagesModelFactory` in the `OpenAI.Images` namespace
-  - `OpenAIModelsModelFactory` in the `OpenAI.Models` namespace
-  - `OpenAIModerationsModelFactory` in the `OpenAI.Moderations` namespace
+  - `OpenAIAudioModelFactory` in the `OpenAI.Audio` namespace (commit_hash)
+  - `OpenAIEmbeddingsModelFactory` in the `OpenAI.Embeddings` namespace (commit_hash)
+  - `OpenAIFilesModelFactory` in the `OpenAI.Files` namespace (commit_hash)
+  - `OpenAIImagesModelFactory` in the `OpenAI.Images` namespace (commit_hash)
+  - `OpenAIModelsModelFactory` in the `OpenAI.Models` namespace (commit_hash)
+  - `OpenAIModerationsModelFactory` in the `OpenAI.Moderations` namespace (commit_hash)
 
 ### Breaking Changes
+
+- Removed client constructors that do not explicitly take an API key parameter or an endpoint via an `OpenAIClientOptions` parameter, making it clearer how to appropriately instantiate a client. (commit_hash)
+- Removed the endpoint parameter from all client constructors, making it clearer that an alternative endpoint must be specified via the `OpenAIClientOptions` parameter. (commit_hash)
+- Removed `OpenAIClient`'s `Endpoint` `protected` property. (commit_hash)
+- Made `OpenAIClient`'s constructor that takes a `ClientPipeline` parameter `protected internal` instead of just `protected`. (commit_hash)
 
 ### Bugs Fixed
 

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -17,10 +17,9 @@ namespace OpenAI {
     }
     public class OpenAIClient {
         protected OpenAIClient();
-        public OpenAIClient(OpenAIClientOptions options = null);
-        public OpenAIClient(ApiKeyCredential credential, OpenAIClientOptions options = null);
-        protected OpenAIClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options);
-        protected Uri Endpoint { get; }
+        public OpenAIClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public OpenAIClient(ApiKeyCredential credential);
+        protected internal OpenAIClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public virtual ClientPipeline Pipeline { get; }
         public virtual AssistantClient GetAssistantClient();
         public virtual AudioClient GetAudioClient(string model);
@@ -63,9 +62,9 @@ namespace OpenAI.Assistants {
     }
     public class AssistantClient {
         protected AssistantClient();
-        public AssistantClient(OpenAIClientOptions options = null);
-        public AssistantClient(ApiKeyCredential credential, OpenAIClientOptions options = null);
-        protected internal AssistantClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options);
+        public AssistantClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public AssistantClient(ApiKeyCredential credential);
+        protected internal AssistantClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public virtual ClientPipeline Pipeline { get; }
         public virtual ClientResult<ThreadRun> CancelRun(ThreadRun run);
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -982,9 +981,9 @@ namespace OpenAI.Assistants {
 namespace OpenAI.Audio {
     public class AudioClient {
         protected AudioClient();
-        protected internal AudioClient(ClientPipeline pipeline, string model, Uri endpoint, OpenAIClientOptions options);
-        public AudioClient(string model, OpenAIClientOptions options = null);
-        public AudioClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null);
+        protected internal AudioClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public AudioClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
+        public AudioClient(string model, ApiKeyCredential credential);
         public virtual ClientPipeline Pipeline { get; }
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions options = null);
@@ -1148,9 +1147,9 @@ namespace OpenAI.Audio {
 namespace OpenAI.Batch {
     public class BatchClient {
         protected BatchClient();
-        public BatchClient(OpenAIClientOptions options = null);
-        public BatchClient(ApiKeyCredential credential, OpenAIClientOptions options = null);
-        protected internal BatchClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options);
+        public BatchClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public BatchClient(ApiKeyCredential credential);
+        protected internal BatchClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public virtual ClientPipeline Pipeline { get; }
         public virtual ClientResult CancelBatch(string batchId, RequestOptions options);
         public virtual Task<ClientResult> CancelBatchAsync(string batchId, RequestOptions options);
@@ -1180,9 +1179,9 @@ namespace OpenAI.Chat {
     }
     public class ChatClient {
         protected ChatClient();
-        protected internal ChatClient(ClientPipeline pipeline, string model, Uri endpoint, OpenAIClientOptions options);
-        public ChatClient(string model, OpenAIClientOptions options = null);
-        public ChatClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null);
+        protected internal ChatClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public ChatClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
+        public ChatClient(string model, ApiKeyCredential credential);
         public virtual ClientPipeline Pipeline { get; }
         public virtual ClientResult<ChatCompletion> CompleteChat(params ChatMessage[] messages);
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -1557,9 +1556,9 @@ namespace OpenAI.Embeddings {
     }
     public class EmbeddingClient {
         protected EmbeddingClient();
-        protected internal EmbeddingClient(ClientPipeline pipeline, string model, Uri endpoint, OpenAIClientOptions options);
-        public EmbeddingClient(string model, OpenAIClientOptions options = null);
-        public EmbeddingClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null);
+        protected internal EmbeddingClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public EmbeddingClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
+        public EmbeddingClient(string model, ApiKeyCredential credential);
         public virtual ClientPipeline Pipeline { get; }
         public virtual ClientResult<Embedding> GenerateEmbedding(string input, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<Embedding>> GenerateEmbeddingAsync(string input, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default);
@@ -1608,23 +1607,19 @@ namespace OpenAI.Embeddings {
 namespace OpenAI.Files {
     public class FileClient {
         protected FileClient();
-        public FileClient(OpenAIClientOptions options = null);
-        public FileClient(ApiKeyCredential credential, OpenAIClientOptions options = null);
-        protected internal FileClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options);
+        public FileClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public FileClient(ApiKeyCredential credential);
+        protected internal FileClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public virtual ClientPipeline Pipeline { get; }
-        public virtual ClientResult<bool> DeleteFile(OpenAIFileInfo file);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult DeleteFile(string fileId, RequestOptions options);
         public virtual ClientResult<bool> DeleteFile(string fileId, CancellationToken cancellationToken = default);
-        public virtual Task<ClientResult<bool>> DeleteFileAsync(OpenAIFileInfo file);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<ClientResult> DeleteFileAsync(string fileId, RequestOptions options);
         public virtual Task<ClientResult<bool>> DeleteFileAsync(string fileId, CancellationToken cancellationToken = default);
-        public virtual ClientResult<BinaryData> DownloadFile(OpenAIFileInfo file);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult DownloadFile(string fileId, RequestOptions options);
         public virtual ClientResult<BinaryData> DownloadFile(string fileId, CancellationToken cancellationToken = default);
-        public virtual Task<ClientResult<BinaryData>> DownloadFileAsync(OpenAIFileInfo file);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<ClientResult> DownloadFileAsync(string fileId, RequestOptions options);
         public virtual Task<ClientResult<BinaryData>> DownloadFileAsync(string fileId, CancellationToken cancellationToken = default);
@@ -1736,9 +1731,9 @@ namespace OpenAI.Files {
 namespace OpenAI.FineTuning {
     public class FineTuningClient {
         protected FineTuningClient();
-        public FineTuningClient(OpenAIClientOptions options = null);
-        public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options = null);
-        protected internal FineTuningClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options);
+        public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public FineTuningClient(ApiKeyCredential credential);
+        protected internal FineTuningClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public virtual ClientPipeline Pipeline { get; }
         public virtual ClientResult CancelJob(string jobId, RequestOptions options);
         public virtual Task<ClientResult> CancelJobAsync(string jobId, RequestOptions options);
@@ -1806,9 +1801,9 @@ namespace OpenAI.Images {
     }
     public class ImageClient {
         protected ImageClient();
-        protected internal ImageClient(ClientPipeline pipeline, string model, Uri endpoint, OpenAIClientOptions options);
-        public ImageClient(string model, OpenAIClientOptions options = null);
-        public ImageClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null);
+        protected internal ImageClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public ImageClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
+        public ImageClient(string model, ApiKeyCredential credential);
         public virtual ClientPipeline Pipeline { get; }
         public virtual ClientResult<GeneratedImage> GenerateImage(string prompt, ImageGenerationOptions options = null, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<GeneratedImage>> GenerateImageAsync(string prompt, ImageGenerationOptions options = null, CancellationToken cancellationToken = default);
@@ -1891,9 +1886,9 @@ namespace OpenAI.Images {
 namespace OpenAI.Models {
     public class ModelClient {
         protected ModelClient();
-        public ModelClient(OpenAIClientOptions options = null);
-        public ModelClient(ApiKeyCredential credential, OpenAIClientOptions options = null);
-        protected internal ModelClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options);
+        public ModelClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public ModelClient(ApiKeyCredential credential);
+        protected internal ModelClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public virtual ClientPipeline Pipeline { get; }
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult DeleteModel(string model, RequestOptions options);
@@ -1975,9 +1970,9 @@ namespace OpenAI.Moderations {
     }
     public class ModerationClient {
         protected ModerationClient();
-        protected internal ModerationClient(ClientPipeline pipeline, string model, Uri endpoint, OpenAIClientOptions options);
-        public ModerationClient(string model, OpenAIClientOptions options = null);
-        public ModerationClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null);
+        protected internal ModerationClient(ClientPipeline pipeline, string model, OpenAIClientOptions options);
+        public ModerationClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
+        public ModerationClient(string model, ApiKeyCredential credential);
         public virtual ClientPipeline Pipeline { get; }
         public virtual ClientResult<ModerationResult> ClassifyTextInput(string input, CancellationToken cancellationToken = default);
         public virtual Task<ClientResult<ModerationResult>> ClassifyTextInputAsync(string input, CancellationToken cancellationToken = default);
@@ -2084,9 +2079,9 @@ namespace OpenAI.VectorStores {
     }
     public class VectorStoreClient {
         protected VectorStoreClient();
-        public VectorStoreClient(OpenAIClientOptions options = null);
-        public VectorStoreClient(ApiKeyCredential credential, OpenAIClientOptions options = null);
-        protected internal VectorStoreClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options);
+        public VectorStoreClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public VectorStoreClient(ApiKeyCredential credential);
+        protected internal VectorStoreClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public virtual ClientPipeline Pipeline { get; }
         public virtual ClientResult<VectorStoreFileAssociation> AddFileToVectorStore(VectorStore vectorStore, OpenAIFileInfo file);
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/.dotnet/examples/Assistants/Example01_RetrievalAugmentedGeneration.cs
+++ b/.dotnet/examples/Assistants/Example01_RetrievalAugmentedGeneration.cs
@@ -145,6 +145,6 @@ public partial class AssistantExamples
         // Optionally, delete any persistent resources you no longer need.
         _ = assistantClient.DeleteThread(threadRun.ThreadId);
         _ = assistantClient.DeleteAssistant(assistant);
-        _ = fileClient.DeleteFile(salesFile);
+        _ = fileClient.DeleteFile(salesFile.Id);
     }
 }

--- a/.dotnet/examples/Assistants/Example01_RetrievalAugmentedGenerationAsync.cs
+++ b/.dotnet/examples/Assistants/Example01_RetrievalAugmentedGenerationAsync.cs
@@ -146,6 +146,6 @@ public partial class AssistantExamples
         // Optionally, delete any persistent resources you no longer need.
         _ = await assistantClient.DeleteThreadAsync(threadRun.ThreadId);
         _ = await assistantClient.DeleteAssistantAsync(assistant);
-        _ = await fileClient.DeleteFileAsync(salesFile);
+        _ = await fileClient.DeleteFileAsync(salesFile.Id);
     }
 }

--- a/.dotnet/examples/Assistants/Example04_AllTheTools.cs
+++ b/.dotnet/examples/Assistants/Example04_AllTheTools.cs
@@ -45,7 +45,7 @@ public partial class AssistantExamples
         };
 
         #region Upload a mock file for use with file search
-        FileClient fileClient = new();
+        FileClient fileClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         OpenAIFileInfo favoriteNumberFile = fileClient.UploadFile(
             BinaryData.FromString("""
                 This file contains the favorite numbers for individuals.
@@ -59,7 +59,7 @@ public partial class AssistantExamples
         #endregion
 
         #region Create an assistant with functions, file search, and code interpreter all enabled
-        AssistantClient client = new();
+        AssistantClient client = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         Assistant assistant = client.CreateAssistant("gpt-4-turbo", new AssistantCreationOptions()
         {
             Instructions = "Use functions to resolve family relations into the names of people. Use file search to "

--- a/.dotnet/examples/Assistants/Example05_AssistantsWithVision.cs
+++ b/.dotnet/examples/Assistants/Example05_AssistantsWithVision.cs
@@ -65,7 +65,7 @@ public partial class AssistantExamples
         }
 
         // Delete temporary resources, if desired
-        _ = fileClient.DeleteFile(pictureOfAppleFile);
+        _ = fileClient.DeleteFile(pictureOfAppleFile.Id);
         _ = assistantClient.DeleteThread(thread);
         _ = assistantClient.DeleteAssistant(assistant);
     }

--- a/.dotnet/examples/Assistants/Example05_AssistantsWithVisionAsync.cs
+++ b/.dotnet/examples/Assistants/Example05_AssistantsWithVisionAsync.cs
@@ -65,7 +65,7 @@ public partial class AssistantExamples
             }
         }
 
-        _ = await fileClient.DeleteFileAsync(pictureOfAppleFile);
+        _ = await fileClient.DeleteFileAsync(pictureOfAppleFile.Id);
         _ = await assistantClient.DeleteThreadAsync(thread);
         _ = await assistantClient.DeleteAssistantAsync(assistant);
     }

--- a/.dotnet/examples/CombinationExamples.cs
+++ b/.dotnet/examples/CombinationExamples.cs
@@ -15,7 +15,7 @@ public partial class CombinationExamples
     public void AlpacaArtAssessor()
     {
         // First, we create an image using dall-e-3:
-        ImageClient imageClient = new("dall-e-3");
+        ImageClient imageClient = new("dall-e-3", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         ClientResult<GeneratedImage> imageResult = imageClient.GenerateImage(
             "a majestic alpaca on a mountain ridge, backed by an expansive blue sky accented with sparse clouds",
             new()
@@ -28,7 +28,7 @@ public partial class CombinationExamples
         Console.WriteLine($"Majestic alpaca available at:\n{imageGeneration.ImageUri.AbsoluteUri}");
 
         // Now, we'll ask a cranky art critic to evaluate the image using gpt-4-vision-preview:
-        ChatClient chatClient = new("gpt-4-vision-preview");
+        ChatClient chatClient = new("gpt-4o-mini", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         ChatCompletion chatCompletion = chatClient.CompleteChat(
             [
                 new SystemChatMessage("Assume the role of a cranky art critic. When asked to describe or "
@@ -47,7 +47,7 @@ public partial class CombinationExamples
         Console.WriteLine($"Art critique of majestic alpaca:\n{chatResponseText}");
 
         // Finally, we'll get some text-to-speech for that critical evaluation using tts-1-hd:
-        AudioClient audioClient = new("tts-1-hd");
+        AudioClient audioClient = new("tts-1-hd", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         ClientResult<BinaryData> ttsResult = audioClient.GenerateSpeechFromText(
             text: chatResponseText,
             GeneratedSpeechVoice.Fable,
@@ -69,7 +69,7 @@ public partial class CombinationExamples
     public async Task CuriousCreatureCreator()
     {
         // First, we'll use gpt-4 to have a creative helper imagine a twist on a household pet
-        ChatClient creativeWriterClient = new("gpt-4");
+        ChatClient creativeWriterClient = new("gpt-4o-mini", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         ClientResult<ChatCompletion> creativeWriterResult = creativeWriterClient.CompleteChat(
             [
                 new SystemChatMessage("You're a creative helper that specializes in brainstorming designs for concepts that fuse ordinary, mundane items with a fantastical touch. In particular, you can provide good one-paragraph descriptions of concept images."),
@@ -83,7 +83,7 @@ public partial class CombinationExamples
         Console.WriteLine($"Creative helper's creature description:\n{description}");
 
         // Asynchronously, in parallel to the next steps, we'll get the creative description in the voice of Onyx
-        AudioClient ttsClient = new("tts-1-hd");
+        AudioClient ttsClient = new("tts-1-hd", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         Task<ClientResult<BinaryData>> imageDescriptionAudioTask = ttsClient.GenerateSpeechFromTextAsync(
             description,
             GeneratedSpeechVoice.Onyx,
@@ -103,7 +103,7 @@ public partial class CombinationExamples
         });
 
         // Meanwhile, we'll use dall-e-3 to generate a rendition of our LLM artist's vision
-        ImageClient imageGenerationClient = new("dall-e-3");
+        ImageClient imageGenerationClient = new("dall-e-3", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         ClientResult<GeneratedImage> imageGenerationResult = await imageGenerationClient.GenerateImageAsync(
             description,
             new ImageGenerationOptions()
@@ -115,7 +115,7 @@ public partial class CombinationExamples
         Console.WriteLine($"Creature image available at:\n{imageLocation.AbsoluteUri}");
 
         // Now, we'll use gpt-4-vision-preview to get a hopelessly taken assessment from a usually exigent art connoisseur
-        ChatClient imageCriticClient = new("gpt-4-vision-preview");
+        ChatClient imageCriticClient = new("gpt-4o-mini", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         ClientResult<ChatCompletion> criticalAppraisalResult = await imageCriticClient.CompleteChatAsync(
             [
                 new SystemChatMessage("Assume the role of an art critic. Although usually cranky and occasionally even referred to as a 'curmudgeon', you're somehow entirely smitten with the subject presented to you and, despite your best efforts, can't help but lavish praise when you're asked to appraise a provided image."),

--- a/.dotnet/src/Custom/Assistants/Internal/InternalAssistantMessageClient.cs
+++ b/.dotnet/src/Custom/Assistants/Internal/InternalAssistantMessageClient.cs
@@ -18,42 +18,46 @@ namespace OpenAI.Assistants;
 [CodeGenSuppress("DeleteMessage", typeof(string), typeof(string))]
 internal partial class InternalAssistantMessageClient
 {
-    /// <summary>
-    /// Initializes a new instance of <see cref="InternalAssistantMessageClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public InternalAssistantMessageClient(ApiKeyCredential credential, OpenAIClientOptions options = default)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="InternalAssistantMessageClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="InternalAssistantMessageClient(ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public InternalAssistantMessageClient(OpenAIClientOptions options = default)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary> Initializes a new instance of <see cref="InternalAssistantMessageClient"/>. </summary>
-    /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
-    /// <param name="endpoint"> OpenAI Endpoint. </param>
-    protected internal InternalAssistantMessageClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="InternalAssistantMessageClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public InternalAssistantMessageClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="InternalAssistantMessageClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public InternalAssistantMessageClient(ApiKeyCredential credential, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="InternalAssistantMessageClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    protected internal InternalAssistantMessageClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIClientOptions();
+
         _pipeline = pipeline;
-        _endpoint = endpoint;
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 }

--- a/.dotnet/src/Custom/Assistants/Internal/InternalAssistantRunClient.cs
+++ b/.dotnet/src/Custom/Assistants/Internal/InternalAssistantRunClient.cs
@@ -26,43 +26,46 @@ namespace OpenAI.Assistants;
 [CodeGenSuppress("GetRunStep", typeof(string), typeof(string), typeof(string))]
 internal partial class InternalAssistantRunClient
 {
-    /// <summary>
-    /// Initializes a new instance of <see cref="InternalAssistantRunClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public InternalAssistantRunClient(ApiKeyCredential credential, OpenAIClientOptions options = default)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="InternalAssistantRunClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="InternalAssistantRunClient(ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public InternalAssistantRunClient(OpenAIClientOptions options = default)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary> Initializes a new instance of <see cref="InternalAssistantRunClient"/>. </summary>
-    /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
-    /// <param name="endpoint"> OpenAI Endpoint. </param>
-    /// <param name="options"> Client-wide options to propagate settings from. </param>
-    protected internal InternalAssistantRunClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="InternalAssistantRunClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public InternalAssistantRunClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="InternalAssistantRunClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public InternalAssistantRunClient(ApiKeyCredential credential, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="InternalAssistantRunClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    protected internal InternalAssistantRunClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIClientOptions();
+
         _pipeline = pipeline;
-        _endpoint = endpoint;
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 }

--- a/.dotnet/src/Custom/Assistants/Internal/InternalAssistantThreadClient.cs
+++ b/.dotnet/src/Custom/Assistants/Internal/InternalAssistantThreadClient.cs
@@ -16,43 +16,46 @@ namespace OpenAI.Assistants;
 [CodeGenSuppress("DeleteThread", typeof(string))]
 internal partial class InternalAssistantThreadClient
 {
-    /// <summary>
-    /// Initializes a new instance of <see cref="InternalAssistantThreadClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public InternalAssistantThreadClient(ApiKeyCredential credential, OpenAIClientOptions options = default)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="InternalAssistantThreadClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="InternalAssistantThreadClient(ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public InternalAssistantThreadClient(OpenAIClientOptions options = default)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary> Initializes a new instance of <see cref="InternalAssistantThreadClient"/>. </summary>
-    /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
-    /// <param name="endpoint"> OpenAI Endpoint. </param>
-    /// <param name="options"> Client-wide options to propagate settings from. </param>
-    protected internal InternalAssistantThreadClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="InternalAssistantThreadClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public InternalAssistantThreadClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="InternalAssistantThreadClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public InternalAssistantThreadClient(ApiKeyCredential credential, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="InternalAssistantThreadClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    protected internal InternalAssistantThreadClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIClientOptions();
+
         _pipeline = pipeline;
-        _endpoint = endpoint;
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 }

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -7,6 +7,10 @@ using System.Threading.Tasks;
 
 namespace OpenAI.Audio;
 
+// CUSTOM:
+// - Renamed.
+// - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
+// - Suppressed methods that only take the options parameter.
 /// <summary> The service client for OpenAI audio operations. </summary>
 [CodeGenClient("Audio")]
 [CodeGenSuppress("AudioClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
@@ -22,71 +26,72 @@ public partial class AudioClient
 
     // CUSTOM:
     // - Added `model` parameter.
-    // - Added support for retrieving credential and endpoint from environment variables.
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AudioClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="model"> The model name to use for audio operations. </param>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public AudioClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = default)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              model,
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="AudioClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="AudioClient(string,ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="model"> The model name to use for audio operations. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public AudioClient(string model, OpenAIClientOptions options = default)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              model,
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="AudioClient">. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    public AudioClient(string model, ApiKeyCredential credential) : this(model, credential, new OpenAIClientOptions())
+    {
+    }
 
     // CUSTOM:
     // - Added `model` parameter.
-
-    /// <summary> Initializes a new instance of EmbeddingClient. </summary>
-    /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
-    /// <param name="model"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
-    /// <param name="endpoint"> OpenAI Endpoint. </param>
-    protected internal AudioClient(ClientPipeline pipeline, string model, Uri endpoint, OpenAIClientOptions options)
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="AudioClient">. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    public AudioClient(string model, ApiKeyCredential credential, OpenAIClientOptions options)
     {
         Argument.AssertNotNullOrEmpty(model, nameof(model));
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
 
-        _pipeline = pipeline;
         _model = model;
-        _endpoint = endpoint;
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
+
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="AudioClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> or <paramref name="model"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    protected internal AudioClient(ClientPipeline pipeline, string model, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        options ??= new OpenAIClientOptions();
+
+        _model = model;
+        _pipeline = pipeline;
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
     #region GenerateSpeech
 
-    /// <summary>
-    /// Generates text-to-speech audio using the specified voice speaking the provided input text.
-    /// </summary>
+    /// <summary> Generates a life-like, spoken audio recording of the input text. </summary>
     /// <remarks>
-    /// The default format of the generated audio is <see cref="GeneratedSpeechFormat.Mp3"/> unless otherwise specified
-    /// via <see cref="SpeechGenerationOptions.ResponseFormat"/>.
+    ///     The default format of the generated audio is <see cref="GeneratedSpeechFormat.Mp3"/> unless otherwise specified
+    ///     via <see cref="SpeechGenerationOptions.ResponseFormat"/>.
     /// </remarks>
-    /// <param name="text"> The text for the voice to speak. </param>
-    /// <param name="voice"> The voice to use. </param>
-    /// <param name="options"> Additional options to tailor the text-to-speech request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="text"> The text to generate audio for. </param>
+    /// <param name="voice"> The voice to use in the generated audio. </param>
+    /// <param name="options"> The options to configure the audio generation. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="text"/> is null. </exception>
     /// <returns> The generated audio in the specified output format. </returns>
     public virtual async Task<ClientResult<BinaryData>> GenerateSpeechFromTextAsync(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default)
     {
@@ -100,17 +105,16 @@ public partial class AudioClient
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
     }
 
-    /// <summary>
-    /// Generates text-to-speech audio using the specified voice speaking the provided input text.
-    /// </summary>
+    /// <summary> Generates a life-like, spoken audio recording of the input text. </summary>
     /// <remarks>
-    /// The default format of the generated audio is <see cref="GeneratedSpeechFormat.Mp3"/> unless otherwise specified
-    /// via <see cref="SpeechGenerationOptions.ResponseFormat"/>.
+    ///     The default format of the generated audio is <see cref="GeneratedSpeechFormat.Mp3"/> unless otherwise specified
+    ///     via <see cref="SpeechGenerationOptions.ResponseFormat"/>.
     /// </remarks>
-    /// <param name="text"> The text for the voice to speak. </param>
-    /// <param name="voice"> The voice to use. </param>
-    /// <param name="options"> Additional options to tailor the text-to-speech request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="text"> The text to generate audio for. </param>
+    /// <param name="voice"> The voice to use in the generated audio. </param>
+    /// <param name="options"> The options to configure the audio generation. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="text"/> is null. </exception>
     /// <returns> The generated audio in the specified output format. </returns>
     public virtual ClientResult<BinaryData> GenerateSpeechFromText(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default)
     {
@@ -128,20 +132,17 @@ public partial class AudioClient
 
     #region TranscribeAudio
 
-    /// <summary>
-    /// Transcribes audio from a stream.
-    /// </summary>
-    /// <param name="audio"> The audio to transcribe. </param>
+    /// <summary> Transcribes the input audio. </summary>
+    /// <param name="audio"> The audio stream to transcribe. </param>
     /// <param name="audioFilename">
-    /// The filename associated with the audio stream. The filename's extension (for example: .mp3) will be used to
-    /// validate the format of the input audio. The request may fail if the file extension and input audio format do
-    /// not match.
+    ///     The filename associated with the audio stream. The filename's extension (for example: .mp3) will be used to
+    ///     validate the format of the input audio. The request may fail if the filename's extension and the actual
+    ///     format of the input audio do not match.
     /// </param>
-    /// <param name="options"> Additional options to tailor the audio transcription request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="options"> The options to configure the audio transcription. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="audio"/> or <paramref name="audioFilename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="audioFilename"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The audio transcription. </returns>
     public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(Stream audio, string audioFilename, AudioTranscriptionOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
@@ -155,20 +156,17 @@ public partial class AudioClient
         return ClientResult.FromValue(AudioTranscription.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary>
-    /// Transcribes audio from a stream.
-    /// </summary>
-    /// <param name="audio"> The audio to transcribe. </param>
+    /// <summary> Transcribes the input audio. </summary>
+    /// <param name="audio"> The audio stream to transcribe. </param>
     /// <param name="audioFilename">
-    /// The filename associated with the audio stream. The filename's extension (for example: .mp3) will be used to
-    /// validate the format of the input audio. The request may fail if the file extension and input audio format do
-    /// not match.
+    ///     The filename associated with the audio stream. The filename's extension (for example: .mp3) will be used to
+    ///     validate the format of the input audio. The request may fail if the filename's extension and the actual
+    ///     format of the input audio do not match.
     /// </param>
-    /// <param name="options"> Additional options to tailor the audio transcription request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="options"> The options to configure the audio transcription. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="audio"/> or <paramref name="audioFilename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="audioFilename"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The audio transcription. </returns>
     public virtual ClientResult<AudioTranscription> TranscribeAudio(Stream audio, string audioFilename, AudioTranscriptionOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
@@ -182,18 +180,15 @@ public partial class AudioClient
         return ClientResult.FromValue(AudioTranscription.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary>
-    /// Transcribes audio from a file with a known path.
-    /// </summary>
+    /// <summary> Transcribes the input audio. </summary>
     /// <param name="audioFilePath">
-    /// The path of the audio file to transcribe. The provided file path's extension (for example: .mp3) will be used
-    /// to validate the format of the input audio. The request may fail if the file extension and input audio format
-    /// do not match.
+    ///     The path of the audio file to transcribe. The provided file path's extension (for example: .mp3) will be
+    ///     used to validate the format of the input audio. The request may fail if the file path's extension and the
+    ///     actual format of the input audio do not match.
     /// </param>
-    /// <param name="options"> Additional options to tailor the audio transcription request. </param>
+    /// <param name="options"> The options to configure the audio transcription. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="audioFilePath"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="audioFilePath"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The audio transcription. </returns>
     public virtual async Task<ClientResult<AudioTranscription>> TranscribeAudioAsync(string audioFilePath, AudioTranscriptionOptions options = null)
     {
         Argument.AssertNotNullOrEmpty(audioFilePath, nameof(audioFilePath));
@@ -202,18 +197,15 @@ public partial class AudioClient
         return await TranscribeAudioAsync(audioStream, audioFilePath, options).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Transcribes audio from a file with a known path.
-    /// </summary>
+    /// <summary> Transcribes the input audio. </summary>
     /// <param name="audioFilePath">
-    /// The path of the audio file to transcribe. The provided file path's extension (for example: .mp3) will be used
-    /// to validate the format of the input audio. The request may fail if the file extension and input audio format
-    /// do not match.
+    ///     The path of the audio file to transcribe. The provided file path's extension (for example: .mp3) will be
+    ///     used to validate the format of the input audio. The request may fail if the file path's extension and the
+    ///     actual format of the input audio do not match.
     /// </param>
-    /// <param name="options"> Additional options to tailor the audio transcription request. </param>
+    /// <param name="options"> The options to configure the audio transcription. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="audioFilePath"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="audioFilePath"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The audio transcription. </returns>
     public virtual ClientResult<AudioTranscription> TranscribeAudio(string audioFilePath, AudioTranscriptionOptions options = null)
     {
         Argument.AssertNotNullOrEmpty(audioFilePath, nameof(audioFilePath));
@@ -226,18 +218,17 @@ public partial class AudioClient
 
     #region TranslateAudio
 
-    /// <summary> Translates audio from a stream into English. </summary>
-    /// <param name="audio"> The audio to translate. </param>
+    /// <summary> Translates the input audio into English. </summary>
+    /// <param name="audio"> The audio stream to translate. </param>
     /// <param name="audioFilename">
-    /// The filename associated with the audio stream. The filename's extension (for example: .mp3) will be used to
-    /// validate the format of the input audio. The request may fail if the file extension and input audio format do
-    /// not match.
+    ///     The filename associated with the audio stream. The filename's extension (for example: .mp3) will be used to
+    ///     validate the format of the input audio. The request may fail if the filename's extension and the actual
+    ///     format of the input audio do not match.
     /// </param>
-    /// <param name="options"> Additional options to tailor the audio translation request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="options"> The options to configure the audio translation. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="audio"/> or <paramref name="audioFilename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="audioFilename"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The audio translation. </returns>
     public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(Stream audio, string audioFilename, AudioTranslationOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
@@ -251,18 +242,17 @@ public partial class AudioClient
         return ClientResult.FromValue(AudioTranslation.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary> Translates audio from a stream into English. </summary>
-    /// <param name="audio"> The audio to translate. </param>
+    /// <summary> Translates the input audio into English. </summary>
+    /// <param name="audio"> The audio stream to translate. </param>
     /// <param name="audioFilename">
-    /// The filename associated with the audio stream. The filename's extension (for example: .mp3) will be used to
-    /// validate the format of the input audio. The request may fail if the file extension and input audio format do
-    /// not match.
+    ///     The filename associated with the audio stream. The filename's extension (for example: .mp3) will be used to
+    ///     validate the format of the input audio. The request may fail if the filename's extension and the actual
+    ///     format of the input audio do not match.
     /// </param>
-    /// <param name="options"> Additional options to tailor the audio translation request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="options"> The options to configure the audio translation. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="audio"/> or <paramref name="audioFilename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="audioFilename"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The audio translation. </returns>
     public virtual ClientResult<AudioTranslation> TranslateAudio(Stream audio, string audioFilename, AudioTranslationOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
@@ -276,18 +266,15 @@ public partial class AudioClient
         return ClientResult.FromValue(AudioTranslation.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary>
-    /// Translates audio from a file with a known path into English.
-    /// </summary>
+    /// <summary> Translates the input audio into English. </summary>
     /// <param name="audioFilePath">
-    /// The path of the audio file to translate. The provided file path's extension (for example: .mp3) will be used
-    /// to validate the format of the input audio. The request may fail if the file extension and input audio format
-    /// do not match.
+    ///     The path of the audio file to translate. The provided file path's extension (for example: .mp3) will be
+    ///     used to validate the format of the input audio. The request may fail if the file path's extension and the
+    ///     actual format of the input audio do not match.
     /// </param>
-    /// <param name="options"> Additional options to tailor the audio translation request. </param>
+    /// <param name="options"> The options to configure the audio translation. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="audioFilePath"/> was null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="audioFilePath"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The audio translation. </returns>
     public virtual ClientResult<AudioTranslation> TranslateAudio(string audioFilePath, AudioTranslationOptions options = null)
     {
         Argument.AssertNotNullOrEmpty(audioFilePath, nameof(audioFilePath));
@@ -296,18 +283,15 @@ public partial class AudioClient
         return TranslateAudio(audioStream, audioFilePath, options);
     }
 
-    /// <summary>
-    /// Translates audio from a file with a known path into English.
-    /// </summary>
+    /// <summary> Translates the input audio into English. </summary>
     /// <param name="audioFilePath">
-    /// The path of the audio file to translate. The provided file path's extension (for example: .mp3) will be used
-    /// to validate the format of the input audio. The request may fail if the file extension and input audio format
-    /// do not match.
+    ///     The path of the audio file to translate. The provided file path's extension (for example: .mp3) will be
+    ///     used to validate the format of the input audio. The request may fail if the file path's extension and the
+    ///     actual format of the input audio do not match.
     /// </param>
-    /// <param name="options"> Additional options to tailor the audio translation request. </param>
+    /// <param name="options"> The options to configure the audio translation. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="audioFilePath"/> was null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="audioFilePath"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The audio translation. </returns>
     public virtual async Task<ClientResult<AudioTranslation>> TranslateAudioAsync(string audioFilePath, AudioTranslationOptions options = null)
     {
         Argument.AssertNotNull(audioFilePath, nameof(audioFilePath));

--- a/.dotnet/src/Custom/Batch/BatchClient.Protocol.cs
+++ b/.dotnet/src/Custom/Batch/BatchClient.Protocol.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 namespace OpenAI.Batch;
 
+[CodeGenSuppress("RetrieveBatch", typeof(string), typeof(RequestOptions))]
+[CodeGenSuppress("RetrieveBatchAsync", typeof(string), typeof(RequestOptions))]
 public partial class BatchClient
 {
     /// <summary>

--- a/.dotnet/src/Custom/Batch/BatchClient.cs
+++ b/.dotnet/src/Custom/Batch/BatchClient.cs
@@ -2,62 +2,66 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace OpenAI.Batch;
 
+// CUSTOM:
+// - Renamed.
+// - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
+// - Suppressed convenience methods for now.
+/// <summary> The service client for OpenAI batch operations. </summary>
 [CodeGenClient("Batches")]
 [CodeGenSuppress("BatchClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateBatch", typeof(string), typeof(InternalCreateBatchRequestEndpoint), typeof(InternalBatchCompletionTimeframe), typeof(IDictionary<string, string>))]
 [CodeGenSuppress("CreateBatchAsync", typeof(string), typeof(InternalCreateBatchRequestEndpoint), typeof(InternalBatchCompletionTimeframe), typeof(IDictionary<string, string>))]
 [CodeGenSuppress("RetrieveBatch", typeof(string))]
 [CodeGenSuppress("RetrieveBatchAsync", typeof(string))]
-[CodeGenSuppress("RetrieveBatch", typeof(string), typeof(RequestOptions))]
-[CodeGenSuppress("RetrieveBatchAsync", typeof(string), typeof(RequestOptions))]
 [CodeGenSuppress("CancelBatch", typeof(string))]
 [CodeGenSuppress("CancelBatchAsync", typeof(string))]
 [CodeGenSuppress("GetBatches", typeof(string), typeof(int?))]
 [CodeGenSuppress("GetBatchesAsync", typeof(string), typeof(int?))]
 public partial class BatchClient
 {
-    /// <summary>
-    /// Initializes a new instance of <see cref="BatchClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public BatchClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              OpenAIClient.GetEndpoint(options),
-              options) 
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="BatchClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="BatchClient(ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public BatchClient(OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="BatchClient"/>.
-    /// </summary>
-    /// <param name="pipeline"> The client pipeline to use. </param>
-    /// <param name="endpoint"> The endpoint to use. </param>
-    protected internal BatchClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="BatchClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public BatchClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="BatchClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public BatchClient(ApiKeyCredential credential, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="BatchClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    protected internal BatchClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIClientOptions();
+
         _pipeline = pipeline;
-        _endpoint = endpoint;
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 }

--- a/.dotnet/src/Custom/Chat/ChatClient.cs
+++ b/.dotnet/src/Custom/Chat/ChatClient.cs
@@ -9,7 +9,13 @@ using System.Threading.Tasks;
 
 namespace OpenAI.Chat;
 
+// CUSTOM:
+// - Renamed.
+// - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
+// - Suppressed methods that only take the options parameter.
+/// <summary> The service client for OpenAI chat operations. </summary>
 [CodeGenClient("Chat")]
+[CodeGenSuppress("ChatClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateChatCompletionAsync", typeof(ChatCompletionOptions))]
 [CodeGenSuppress("CreateChatCompletion", typeof(ChatCompletionOptions))]
 public partial class ChatClient
@@ -17,63 +23,72 @@ public partial class ChatClient
     private readonly string _model;
     private readonly OpenTelemetrySource _telemetry;
 
-    /// <summary>
-    /// Initializes a new instance of <see cref="ChatClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="model"> The model name for chat completions that the client should use. </param>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public ChatClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              model,
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="ChatClient">. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    public ChatClient(string model, ApiKeyCredential credential) : this(model, credential, new OpenAIClientOptions())
+    {
+    }
 
-    /// <summary>
-    /// Initializes a new instance of <see cref="ChatClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="ChatClient(string,ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="model"> The model name for chat completions that the client should use. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public ChatClient(string model, OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              model,
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="ChatClient"/>.
-    /// </summary>
-    /// <param name="pipeline"> The <see cref="ClientPipeline"/> instance to use. </param>
-    /// <param name="model"> The model name to use. </param>
-    /// <param name="endpoint"> The endpoint to use. </param>
-    protected internal ChatClient(ClientPipeline pipeline, string model, Uri endpoint, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Added telemetry support.
+    /// <summary> Initializes a new instance of <see cref="ChatClient">. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    public ChatClient(string model, ApiKeyCredential credential, OpenAIClientOptions options)
     {
         Argument.AssertNotNullOrEmpty(model, nameof(model));
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _model = model;
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+        _telemetry = new OpenTelemetrySource(model, _endpoint);
+    }
+
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Added telemetry support.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="ChatClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> or <paramref name="model"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    protected internal ChatClient(ClientPipeline pipeline, string model, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        options ??= new OpenAIClientOptions();
 
         _model = model;
         _pipeline = pipeline;
-        _endpoint = endpoint;
-        _telemetry = new OpenTelemetrySource(model, endpoint);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+        _telemetry = new OpenTelemetrySource(model, _endpoint);
     }
 
-    /// <summary>
-    /// Generates a single chat completion result for a provided set of input chat messages.
-    /// </summary>
-    /// <param name="messages"> The messages to provide as input and history for chat completion. </param>
-    /// <param name="options"> Additional options for the chat completion request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
-    /// <returns> A result for a single chat completion. </returns>
+    /// <summary> Generates a completion for the given chat. </summary>
+    /// <param name="messages"> The messages comprising the chat so far. </param>
+    /// <param name="options"> The options to configure the chat completion. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="messages"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="messages"/> is an empty collection, and was expected to be non-empty. </exception>
     public virtual async Task<ClientResult<ChatCompletion>> CompleteChatAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(messages, nameof(messages));
@@ -98,21 +113,12 @@ public partial class ChatClient
         }
     }
 
-    /// <summary>
-    /// Generates a single chat completion result for a provided set of input chat messages.
-    /// </summary>
-    /// <param name="messages"> The messages to provide as input and history for chat completion. </param>
-    /// <returns> A result for a single chat completion. </returns>
-    public virtual async Task<ClientResult<ChatCompletion>> CompleteChatAsync(params ChatMessage[] messages)
-        => await CompleteChatAsync(messages, default(ChatCompletionOptions)).ConfigureAwait(false);
-
-    /// <summary>
-    /// Generates a single chat completion result for a provided set of input chat messages.
-    /// </summary>
-    /// <param name="messages"> The messages to provide as input and history for chat completion. </param>
-    /// <param name="options"> Additional options for the chat completion request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
-    /// <returns> A result for a single chat completion. </returns>
+    /// <summary> Generates a completion for the given chat. </summary>
+    /// <param name="messages"> The messages comprising the chat so far. </param>
+    /// <param name="options"> The options to configure the chat completion. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="messages"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="messages"/> is an empty collection, and was expected to be non-empty. </exception>
     public virtual ClientResult<ChatCompletion> CompleteChat(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(messages, nameof(messages));
@@ -137,26 +143,33 @@ public partial class ChatClient
         }
     }
 
-    /// <summary>
-    /// Generates a single chat completion result for a provided set of input chat messages.
-    /// </summary>
-    /// <param name="messages"> The messages to provide as input and history for chat completion. </param>
-    /// <returns> A result for a single chat completion. </returns>
+    /// <summary> Generates a completion for the given chat. </summary>
+    /// <param name="messages"> The messages comprising the chat so far. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="messages"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="messages"/> is an empty collection, and was expected to be non-empty. </exception>
+    public virtual async Task<ClientResult<ChatCompletion>> CompleteChatAsync(params ChatMessage[] messages)
+        => await CompleteChatAsync(messages, default(ChatCompletionOptions)).ConfigureAwait(false);
+
+    /// <summary> Generates a completion for the given chat. </summary>
+    /// <param name="messages"> The messages comprising the chat so far. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="messages"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="messages"/> is an empty collection, and was expected to be non-empty. </exception>
     public virtual ClientResult<ChatCompletion> CompleteChat(params ChatMessage[] messages)
         => CompleteChat(messages, default(ChatCompletionOptions));
 
     /// <summary>
-    /// Begins a streaming response for a chat completion request using the provided chat messages as input and
-    /// history.
+    ///     Generates a completion for the given chat. The completion is streamed back token by token as it is being
+    ///     generated by the model instead of waiting for it to be finished first.
     /// </summary>
     /// <remarks>
-    /// <see cref="AsyncCollectionResult{T}"/> can be enumerated over using the <c>await foreach</c> pattern using the
-    /// <see cref="IAsyncEnumerable{T}"/> interface.
+    ///     <see cref="AsyncCollectionResult{T}"/> implements the <see cref="IAsyncEnumerable{T}"/> interface and can be
+    ///     enumerated over using the <c>await foreach</c> pattern.
     /// </remarks>
-    /// <param name="messages"> The messages to provide as input for chat completion. </param>
-    /// <param name="options"> Additional options for the chat completion request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
-    /// <returns> A streaming result with incremental chat completion updates. </returns>
+    /// <param name="messages"> The messages comprising the chat so far. </param>
+    /// <param name="options"> The options to configure the chat completion. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="messages"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="messages"/> is an empty collection, and was expected to be non-empty. </exception>
     public virtual AsyncCollectionResult<StreamingChatCompletionUpdate> CompleteChatStreamingAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(messages, nameof(messages));
@@ -172,30 +185,18 @@ public partial class ChatClient
     }
 
     /// <summary>
-    /// Begins a streaming response for a chat completion request using the provided chat messages as input and
-    /// history.
+    ///     Generates a completion for the given chat. The completion is streamed back token by token as it is being
+    ///     generated by the model instead of waiting for it to be finished first.
     /// </summary>
     /// <remarks>
-    /// <see cref="AsyncCollectionResult{T}"/> can be enumerated over using the <c>await foreach</c> pattern using the
-    /// <see cref="IAsyncEnumerable{T}"/> interface.
+    ///     <see cref="AsyncCollectionResult{T}"/> implements the <see cref="IAsyncEnumerable{T}"/> interface and can be
+    ///     enumerated over using the <c>await foreach</c> pattern.
     /// </remarks>
-    /// <param name="messages"> The messages to provide as input for chat completion. </param>
-    /// <returns> A streaming result with incremental chat completion updates. </returns>
-    public virtual AsyncCollectionResult<StreamingChatCompletionUpdate> CompleteChatStreamingAsync(params ChatMessage[] messages)
-        => CompleteChatStreamingAsync(messages, default(ChatCompletionOptions));
-
-    /// <summary>
-    /// Begins a streaming response for a chat completion request using the provided chat messages as input and
-    /// history.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="CollectionResult{T}"/> can be enumerated over using the <c>foreach</c> pattern using the
-    /// <see cref="IEnumerable{T}"/> interface.
-    /// </remarks>
-    /// <param name="messages"> The messages to provide as input for chat completion. </param>
-    /// <param name="options"> Additional options for the chat completion request. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
-    /// <returns> A streaming result with incremental chat completion updates. </returns>
+    /// <param name="messages"> The messages comprising the chat so far. </param>
+    /// <param name="options"> The options to configure the chat completion. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="messages"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="messages"/> is an empty collection, and was expected to be non-empty. </exception>
     public virtual CollectionResult<StreamingChatCompletionUpdate> CompleteChatStreaming(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(messages, nameof(messages));
@@ -209,15 +210,30 @@ public partial class ChatClient
     }
 
     /// <summary>
-    /// Begins a streaming response for a chat completion request using the provided chat messages as input and
-    /// history.
+    ///     Generates a completion for the given chat. The completion is streamed back token by token as it is being
+    ///     generated by the model instead of waiting for it to be finished first.
     /// </summary>
     /// <remarks>
-    /// <see cref="CollectionResult{T}"/> can be enumerated over using the <c>foreach</c> pattern using the
-    /// <see cref="IEnumerable{T}"/> interface.
+    ///     <see cref="AsyncCollectionResult{T}"/> implements the <see cref="IAsyncEnumerable{T}"/> interface and can be
+    ///     enumerated over using the <c>await foreach</c> pattern.
     /// </remarks>
-    /// <param name="messages"> The messages to provide as input for chat completion. </param>
-    /// <returns> A streaming result with incremental chat completion updates. </returns>
+    /// <param name="messages"> The messages comprising the chat so far. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="messages"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="messages"/> is an empty collection, and was expected to be non-empty. </exception>
+    public virtual AsyncCollectionResult<StreamingChatCompletionUpdate> CompleteChatStreamingAsync(params ChatMessage[] messages)
+        => CompleteChatStreamingAsync(messages, default(ChatCompletionOptions));
+
+    /// <summary>
+    ///     Generates a completion for the given chat. The completion is streamed back token by token as it is being
+    ///     generated by the model instead of waiting for it to be finished first.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="AsyncCollectionResult{T}"/> implements the <see cref="IAsyncEnumerable{T}"/> interface and can be
+    ///     enumerated over using the <c>await foreach</c> pattern.
+    /// </remarks>
+    /// <param name="messages"> The messages comprising the chat so far. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="messages"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="messages"/> is an empty collection, and was expected to be non-empty. </exception>
     public virtual CollectionResult<StreamingChatCompletionUpdate> CompleteChatStreaming(params ChatMessage[] messages)
         => CompleteChatStreaming(messages, default(ChatCompletionOptions));
 

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -7,9 +7,10 @@ using System.Threading.Tasks;
 
 namespace OpenAI.Files;
 
-/// <summary>
-/// The service client for OpenAI file operations.
-/// </summary>
+// CUSTOM:
+// - Renamed.
+// - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
+/// <summary> The service client for OpenAI file operations. </summary>
 [CodeGenClient("Files")]
 [CodeGenSuppress("FileClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateFileAsync", typeof(InternalFileUploadOptions))]
@@ -24,70 +25,61 @@ namespace OpenAI.Files;
 [CodeGenSuppress("DownloadFile", typeof(string))]
 public partial class FileClient
 {
-    /// <summary>
-    /// Initializes a new instance of <see cref="FileClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public FileClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              OpenAIClient.GetEndpoint(options),
-              options) 
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="FileClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public FileClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
     }
 
-    /// <summary>
-    /// Initializes a new instance of <see cref="FileClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="FileClient(ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public FileClient(OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="FileClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public FileClient(ApiKeyCredential credential, OpenAIClientOptions options)
     {
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
-    /// <summary>
-    /// Initializes a new instance of <see cref="FileClient"/>.
-    /// </summary>
-    /// <param name="pipeline"> The client pipeline to use. </param>
-    /// <param name="endpoint"> The endpoint to use. </param>
-    protected internal FileClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="FileClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    protected internal FileClient(ClientPipeline pipeline, OpenAIClientOptions options)
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIClientOptions();
+
         _pipeline = pipeline;
-        _endpoint = endpoint;
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
-    /// <summary>
-    /// Upload a file that can be used across various endpoints. The size of all the files uploaded by
-    /// one organization can be up to 100 GB.
-    ///
-    /// The size of individual files can be a maximum of 512 MB or 2 million tokens for Assistants. See
-    /// the <see href="https://platform.openai.com/docs/assistants/tools">Assistants Tools guide</see> to
-    /// learn more about the types of files supported. The Fine-tuning API only supports `.jsonl` files.
-    ///
-    /// Please <see href="https://help.openai.com/">contact us</see> if you need to increase these
-    /// storage limits.
-    /// </summary>
-    /// <param name="file"> The file to upload. </param>
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file stream to upload. </param>
     /// <param name="filename">
-    /// The filename associated with the file stream. The filename's extension (for example: .json) will be used to
-    /// validate the file format. The request may fail if the file extension and file format do not match.
+    ///     The filename associated with the file stream. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> Information about the uploaded file. </returns>
     public virtual async Task<ClientResult<OpenAIFileInfo>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(file, nameof(file));
@@ -103,27 +95,18 @@ public partial class FileClient
         return ClientResult.FromValue(OpenAIFileInfo.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary>
-    /// Upload a file that can be used across various endpoints. The size of all the files uploaded by
-    /// one organization can be up to 100 GB.
-    ///
-    /// The size of individual files can be a maximum of 512 MB or 2 million tokens for Assistants. See
-    /// the <see href="https://platform.openai.com/docs/assistants/tools">Assistants Tools guide</see> to
-    /// learn more about the types of files supported. The Fine-tuning API only supports `.jsonl` files.
-    ///
-    /// Please <see href="https://help.openai.com/">contact us</see> if you need to increase these
-    /// storage limits.
-    /// </summary>
-    /// <param name="file"> The file to upload. </param>
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file stream to upload. </param>
     /// <param name="filename">
-    /// The filename associated with the file stream. The filename's extension (for example: .json) will be used to
-    /// validate the file format. The request may fail if the file extension and file format do not match.
+    ///     The filename associated with the file stream. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> Information about the uploaded file. </returns>
     public virtual ClientResult<OpenAIFileInfo> UploadFile(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(file, nameof(file));
@@ -139,26 +122,17 @@ public partial class FileClient
         return ClientResult.FromValue(OpenAIFileInfo.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary>
-    /// Upload a file that can be used across various endpoints. The size of all the files uploaded by
-    /// one organization can be up to 100 GB.
-    ///
-    /// The size of individual files can be a maximum of 512 MB or 2 million tokens for Assistants. See
-    /// the <see href="https://platform.openai.com/docs/assistants/tools">Assistants Tools guide</see> to
-    /// learn more about the types of files supported. The Fine-tuning API only supports `.jsonl` files.
-    ///
-    /// Please <see href="https://help.openai.com/">contact us</see> if you need to increase these
-    /// storage limits.
-    /// </summary>
-    /// <param name="file"> The file to upload. </param>
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file bytes to upload. </param>
     /// <param name="filename">
-    /// The filename associated with the file binary data. The filename's extension (for example: .json) will be used to
-    /// validate the file format. The request may fail if the file extension and file format do not match.
+    ///     The filename associated with the file bytes. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> Information about the uploaded file. </returns>
     public virtual Task<ClientResult<OpenAIFileInfo>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose)
     {
         Argument.AssertNotNull(file, nameof(file));
@@ -167,26 +141,17 @@ public partial class FileClient
         return UploadFileAsync(file?.ToStream(), filename, purpose);
     }
 
-    /// <summary>
-    /// Upload a file that can be used across various endpoints. The size of all the files uploaded by
-    /// one organization can be up to 100 GB.
-    ///
-    /// The size of individual files can be a maximum of 512 MB or 2 million tokens for Assistants. See
-    /// the <see href="https://platform.openai.com/docs/assistants/tools">Assistants Tools guide</see> to
-    /// learn more about the types of files supported. The Fine-tuning API only supports `.jsonl` files.
-    ///
-    /// Please <see href="https://help.openai.com/">contact us</see> if you need to increase these
-    /// storage limits.
-    /// </summary>
-    /// <param name="file"> The file to upload. </param>
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
+    /// <param name="file"> The file bytes to upload. </param>
     /// <param name="filename">
-    /// The filename associated with the file binary data. The filename's extension (for example: .json) will be used to
-    /// validate the file format. The request may fail if the file extension and file format do not match.
+    ///     The filename associated with the file bytes. The filename's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the filename's extension and the actual file format do
+    ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="file"/> or <paramref name="filename"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filename"/> is an empty string, and was expected to be non-empty. </exception>
-    ///
     public virtual ClientResult<OpenAIFileInfo> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose)
     {
         Argument.AssertNotNull(file, nameof(file));
@@ -195,25 +160,16 @@ public partial class FileClient
         return UploadFile(file?.ToStream(), filename, purpose);
     }
 
-    /// <summary>
-    /// Upload a file that can be used across various endpoints. The size of all the files uploaded by
-    /// one organization can be up to 100 GB.
-    ///
-    /// The size of individual files can be a maximum of 512 MB or 2 million tokens for Assistants. See
-    /// the <see href="https://platform.openai.com/docs/assistants/tools">Assistants Tools guide</see> to
-    /// learn more about the types of files supported. The Fine-tuning API only supports `.jsonl` files.
-    ///
-    /// Please <see href="https://help.openai.com/">contact us</see> if you need to increase these
-    /// storage limits.
-    /// </summary>
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
     /// <param name="filePath">
-    /// The path of the file to upload. The provided file path's extension (for example: .json) will be used
-    /// to validate the file format. The request may fail if the file extension and file format do not match.
+    ///     The path of the file to upload. The provided file path's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the file path's extension and the actual file format do
+    ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filePath"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> Information about the uploaded file. </returns>
     public virtual async Task<ClientResult<OpenAIFileInfo>> UploadFileAsync(string filePath, FileUploadPurpose purpose)
     {
         Argument.AssertNotNullOrEmpty(filePath, nameof(filePath));
@@ -222,25 +178,16 @@ public partial class FileClient
         return await UploadFileAsync(stream, filePath, purpose).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Upload a file that can be used across various endpoints. The size of all the files uploaded by
-    /// one organization can be up to 100 GB.
-    ///
-    /// The size of individual files can be a maximum of 512 MB or 2 million tokens for Assistants. See
-    /// the <see href="https://platform.openai.com/docs/assistants/tools">Assistants Tools guide</see> to
-    /// learn more about the types of files supported. The Fine-tuning API only supports `.jsonl` files.
-    ///
-    /// Please <see href="https://help.openai.com/">contact us</see> if you need to increase these
-    /// storage limits.
-    /// </summary>
+    /// <summary> Uploads a file that can be used across various operations. </summary>
+    /// <remarks> Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB. </remarks>
     /// <param name="filePath">
-    /// The path of the file to upload. The provided file path's extension (for example: .json) will be used
-    /// to validate the file format. The request may fail if the file extension and file format do not match.
+    ///     The path of the file to upload. The provided file path's extension (for example: .json) will be used to
+    ///     validate the file format. The request may fail if the file path's extension and the actual file format do
+    ///     not match.
     /// </param>
     /// <param name="purpose"> The intended purpose of the uploaded file. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="filePath"/> was null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="filePath"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> Information about the uploaded file. </returns>
     public virtual ClientResult<OpenAIFileInfo> UploadFile(string filePath, FileUploadPurpose purpose)
     {
         Argument.AssertNotNullOrEmpty(filePath, nameof(filePath));
@@ -249,32 +196,29 @@ public partial class FileClient
         return UploadFile(stream, filePath, purpose);
     }
 
-    /// <summary> Retrieves a list of files that belong to the user's organization. </summary>
+    /// <summary> Gets basic information about each of the files belonging to the user's organization. </summary>
     /// <param name="purpose"> Only return files with the given purpose. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
-    /// <returns> Information about the files in the user's organization. </returns>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     public virtual async Task<ClientResult<OpenAIFileInfoCollection>> GetFilesAsync(OpenAIFilePurpose? purpose = null, CancellationToken cancellationToken = default)
     {
         ClientResult result = await GetFilesAsync(purpose?.ToString(), cancellationToken.ToRequestOptions()).ConfigureAwait(false);
         return ClientResult.FromValue(OpenAIFileInfoCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary> Retrieves a list of files that belong to the user's organization. </summary>
+    /// <summary> Gets basic information about each of the files belonging to the user's organization. </summary>
     /// <param name="purpose"> Only return files with the given purpose. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
-    /// <returns> Information about the files in the user's organization. </returns>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     public virtual ClientResult<OpenAIFileInfoCollection> GetFiles(OpenAIFilePurpose? purpose = null, CancellationToken cancellationToken = default)
     {
         ClientResult result = GetFiles(purpose?.ToString(), cancellationToken.ToRequestOptions());
         return ClientResult.FromValue(OpenAIFileInfoCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary> Retrieves information about a specified file. </summary>
-    /// <param name="fileId"> The ID of the file to retrieve. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <summary> Gets basic information about the specified file. </summary>
+    /// <param name="fileId"> The ID of the desired file. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> Information about the specified file. </returns>
     public virtual async Task<ClientResult<OpenAIFileInfo>> GetFileAsync(string fileId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
@@ -283,12 +227,11 @@ public partial class FileClient
         return ClientResult.FromValue(OpenAIFileInfo.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary> Retrieves information about a specified file. </summary>
-    /// <param name="fileId"> The ID of the file to retrieve. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <summary> Gets basic information about the specified file. </summary>
+    /// <param name="fileId"> The ID of the desired file. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> Information about the specified file. </returns>
     public virtual ClientResult<OpenAIFileInfo> GetFile(string fileId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
@@ -297,12 +240,11 @@ public partial class FileClient
         return ClientResult.FromValue(OpenAIFileInfo.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary> Deletes a previously uploaded file. </summary>
+    /// <summary> Deletes the specified file. </summary>
     /// <param name="fileId"> The ID of the file to delete. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> A boolean value indicating whether the deletion request was successful. </returns>
     public virtual async Task<ClientResult<bool>> DeleteFileAsync(string fileId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
@@ -312,12 +254,11 @@ public partial class FileClient
         return ClientResult.FromValue(internalDeletion.Deleted, result.GetRawResponse());
     }
 
-    /// <summary> Deletes a previously uploaded file. </summary>
+    /// <summary> Deletes the specified file. </summary>
     /// <param name="fileId"> The ID of the file to delete. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> A boolean value indicating whether the deletion request was successful. </returns>
     public virtual ClientResult<bool> DeleteFile(string fileId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
@@ -327,32 +268,11 @@ public partial class FileClient
         return ClientResult.FromValue(internalDeletion.Deleted, result.GetRawResponse());
     }
 
-    /// <summary> Deletes a previously uploaded file. </summary>
-    /// <param name="file"> The file to delete. </param>
-    /// <exception cref="ArgumentNullException"> <paramref name="file"/> is null. </exception>
-    /// <returns> A boolean value indicating whether the deletion request was successful. </returns>
-    public virtual Task<ClientResult<bool>> DeleteFileAsync(OpenAIFileInfo file)
-    {
-        Argument.AssertNotNull(file, nameof(file));
-        return DeleteFileAsync(file.Id);
-    }
-
-    /// <summary> Deletes a previously uploaded file. </summary>
-    /// <param name="file"> The file to delete. </param>
-    /// <exception cref="ArgumentNullException"> <paramref name="file"/> is null. </exception>
-    /// <returns> A boolean value indicating whether the deletion request was successful. </returns>
-    public virtual ClientResult<bool> DeleteFile(OpenAIFileInfo file)
-    {
-        Argument.AssertNotNull(file.Id, nameof(file));
-        return DeleteFile(file.Id);
-    }
-
-    /// <summary> Downloads the binary content of the specified file. </summary>
+    /// <summary> Downloads the content of the specified file. </summary>
     /// <param name="fileId"> The ID of the file to download. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The contents of the specified file. </returns>
     public virtual async Task<ClientResult<BinaryData>> DownloadFileAsync(string fileId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
@@ -361,37 +281,16 @@ public partial class FileClient
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
     }
 
-    /// <summary> Downloads the binary content of the specified file. </summary>
+    /// <summary> Downloads the content of the specified file. </summary>
     /// <param name="fileId"> The ID of the file to download. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="fileId"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="fileId"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <returns> The bionary content of the specified file. </returns>
     public virtual ClientResult<BinaryData> DownloadFile(string fileId, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(fileId, nameof(fileId));
 
         ClientResult result = DownloadFile(fileId, cancellationToken.ToRequestOptions());
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
-    }
-
-    /// <summary> Downloads the binary content of the specified file. </summary>
-    /// <param name="file"> The file to download. </param>
-    /// <exception cref="ArgumentNullException"> <paramref name="file"/> is null. </exception>
-    /// <returns> The binary content of the uploaded file. </returns>
-    public virtual Task<ClientResult<BinaryData>> DownloadFileAsync(OpenAIFileInfo file)
-    {
-        Argument.AssertNotNull(file, nameof(file));
-        return DownloadFileAsync(file.Id);
-    }
-
-    /// <summary> Downloads the binary content of the specified file. </summary>
-    /// <param name="file"> The file to download. </param>
-    /// <exception cref="ArgumentNullException"> <paramref name="file"/> is null. </exception>
-    /// <returns> The binary content of the uploaded file. </returns>
-    public virtual ClientResult<BinaryData> DownloadFile(OpenAIFileInfo file)
-    {
-        Argument.AssertNotNull(file, nameof(file));
-        return DownloadFile(file.Id);
     }
 }

--- a/.dotnet/src/Custom/FineTuning/FineTuningClient.cs
+++ b/.dotnet/src/Custom/FineTuning/FineTuningClient.cs
@@ -4,10 +4,13 @@ using System.ClientModel.Primitives;
 
 namespace OpenAI.FineTuning;
 
-/// <summary>
-/// The service client for OpenAI fine-tuning operations.
-/// </summary>
+// CUSTOM:
+// - Renamed.
+// - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
+// - Suppressed convenience methods for now.
+/// <summary> The service client for OpenAI fine-tuning operations. </summary>
 [CodeGenClient("FineTuning")]
+[CodeGenSuppress("FineTuningClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateFineTuningJobAsync", typeof(InternalCreateFineTuningJobRequest))]
 [CodeGenSuppress("CreateFineTuningJob", typeof(InternalCreateFineTuningJobRequest))]
 [CodeGenSuppress("GetPaginatedFineTuningJobsAsync", typeof(string), typeof(int?))]
@@ -22,44 +25,46 @@ namespace OpenAI.FineTuning;
 [CodeGenSuppress("GetFineTuningJobCheckpoints", typeof(string), typeof(string), typeof(int?))]
 public partial class FineTuningClient
 {
-    // Customization: documented constructors, apply protected visibility
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="FineTuningClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="FineTuningClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="FineTuningClient(ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public FineTuningClient(OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    {}
-
-    /// <summary> Initializes a new instance of FineTuningClient. </summary>
-    /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
-    /// <param name="endpoint"> OpenAI Endpoint. </param>
-    protected internal FineTuningClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="FineTuningClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public FineTuningClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="FineTuningClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public FineTuningClient(ApiKeyCredential credential, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="FineTuningClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    protected internal FineTuningClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIClientOptions();
+
         _pipeline = pipeline;
-        _endpoint = endpoint;
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 }

--- a/.dotnet/src/Custom/LegacyCompletions/Internal/LegacyCompletionClient.cs
+++ b/.dotnet/src/Custom/LegacyCompletions/Internal/LegacyCompletionClient.cs
@@ -1,13 +1,73 @@
+using System;
+using System.ClientModel.Primitives;
+using System.ClientModel;
+
 namespace OpenAI.LegacyCompletions;
 
-/// <summary>
-///     The basic, protocol-level service client for OpenAI legacy completion operations.
-///     <para>
-///         <b>Note</b>: pre-chat completions are a legacy feature. New solutions should consider the use of chat
-///         completions or assistants, instead.
-///     </para>
-/// </summary>
+// CUSTOM:
+// - Renamed.
+// - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
+// - Suppressed methods that only take the options parameter.
+/// <summary> The service client for OpenAI legacy completion operations. </summary>
 [CodeGenClient("Completions")]
+[CodeGenSuppress("LegacyCompletionClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 internal partial class LegacyCompletionClient
 {
+    private readonly string _model;
+
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="LegacyCompletionClient">. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    public LegacyCompletionClient(string model, ApiKeyCredential credential) : this(model, credential, new OpenAIClientOptions())
+    {
+    }
+
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="LegacyCompletionClient">. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    public LegacyCompletionClient(string model, ApiKeyCredential credential, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _model = model;
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
+
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="LegacyCompletionClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> or <paramref name="model"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    protected internal LegacyCompletionClient(ClientPipeline pipeline, string model, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        options ??= new OpenAIClientOptions();
+
+        _model = model;
+        _pipeline = pipeline;
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
 }

--- a/.dotnet/src/Custom/Models/ModelClient.cs
+++ b/.dotnet/src/Custom/Models/ModelClient.cs
@@ -5,90 +5,80 @@ using System.Threading.Tasks;
 
 namespace OpenAI.Models;
 
-/// <summary>
-/// The service client for OpenAI model operations.
-/// </summary>
+// CUSTOM:
+// - Renamed.
+// - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
+// - Renamed convenience methods.
+/// <summary> The service client for OpenAI model operations. </summary>
 [CodeGenClient("ModelsOps")]
 [CodeGenSuppress("ModelClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
-[CodeGenSuppress("GetModelsAsync")]
-[CodeGenSuppress("GetModels")]
 [CodeGenSuppress("RetrieveAsync", typeof(string))]
 [CodeGenSuppress("Retrieve", typeof(string))]
 [CodeGenSuppress("DeleteAsync", typeof(string))]
 [CodeGenSuppress("Delete", typeof(string))]
 public partial class ModelClient
 {
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModelClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public ModelClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="ModelClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public ModelClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
     }
 
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModelClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="ModelClient(ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public ModelClient(OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="ModelClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public ModelClient(ApiKeyCredential credential, OpenAIClientOptions options)
     {
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
-    /// <summary> Initializes a new instance of <see cref="ModelClient"/>. </summary>
-    /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
-    /// <param name="endpoint"> OpenAI Endpoint. </param>
-    protected internal ModelClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="ModelClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    protected internal ModelClient(ClientPipeline pipeline, OpenAIClientOptions options)
     {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIClientOptions();
+
         _pipeline = pipeline;
-        _endpoint = endpoint;
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
-    /// <summary>
-    /// Lists the currently available models, and provides basic information about each one such as the
-    /// owner and availability.
-    /// </summary>
-    /// <remarks> List models. </remarks>
+    /// <summary> Gets basic information about each of the models that are currently available, such as their corresponding owner and availability. </summary>
     public virtual async Task<ClientResult<OpenAIModelInfoCollection>> GetModelsAsync()
     {
         ClientResult result = await GetModelsAsync(null).ConfigureAwait(false);
         return ClientResult.FromValue(OpenAIModelInfoCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary>
-    /// Lists the currently available models, and provides basic information about each one such as the
-    /// owner and availability.
-    /// </summary>
-    /// <remarks> List models. </remarks>
+    /// <summary> Gets basic information about each of the models that are currently available, such as their corresponding owner and availability. </summary>
     public virtual ClientResult<OpenAIModelInfoCollection> GetModels()
     {
         ClientResult result = GetModels(null);
         return ClientResult.FromValue(OpenAIModelInfoCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary>
-    /// Retrieves a model instance, providing basic information about the model such as the owner and
-    /// permissioning.
-    /// </summary>
-    /// <param name="model"> The ID of the model to use for this request. </param>
+    /// <summary> Gets basic information about the specified model, such as its owner and availability. </summary>
+    /// <param name="model"> The name of the desired model. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="model"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <remarks> Retrieve. </remarks>
     public virtual async Task<ClientResult<OpenAIModelInfo>> GetModelAsync(string model)
     {
         Argument.AssertNotNullOrEmpty(model, nameof(model));
@@ -97,14 +87,10 @@ public partial class ModelClient
         return ClientResult.FromValue(OpenAIModelInfo.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary>
-    /// Retrieves a model instance, providing basic information about the model such as the owner and
-    /// permissioning.
-    /// </summary>
-    /// <param name="model"> The ID of the model to use for this request. </param>
+    /// <summary> Gets basic information about the specified model, such as its owner and availability. </summary>
+    /// <param name="model"> The name of the desired model. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="model"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <remarks> Retrieve. </remarks>
     public virtual ClientResult<OpenAIModelInfo> GetModel(string model)
     {
         Argument.AssertNotNullOrEmpty(model, nameof(model));
@@ -113,11 +99,11 @@ public partial class ModelClient
         return ClientResult.FromValue(OpenAIModelInfo.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary> Delete a fine-tuned model. You must have the Owner role in your organization to delete a model. </summary>
-    /// <param name="model"> The model to delete. </param>
+    /// <summary> Deletes the specified fine-tuned model. </summary>
+    /// <remarks> You must have the role of "owner" within your organization in order to be able to delete a model. </remarks>
+    /// <param name="model"> The name of the model to delete. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="model"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <remarks> A value indicating whether the deletion operation was successful. </remarks>
     public virtual async Task<ClientResult<bool>> DeleteModelAsync(string model)
     {
         Argument.AssertNotNullOrEmpty(model, nameof(model));
@@ -128,11 +114,11 @@ public partial class ModelClient
         return ClientResult.FromValue(value.Deleted, response);
     }
 
-    /// <summary> Delete a fine-tuned model. You must have the Owner role in your organization to delete a model. </summary>
-    /// <param name="model"> The model to delete. </param>
+    /// <summary> Deletes the specified fine-tuned model. </summary>
+    /// <remarks> You must have the role of "owner" within your organization in order to be able to delete a model. </remarks>
+    /// <param name="model"> The name of the model to delete. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="model"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
-    /// <remarks> A value indicating whether the deletion operation was successful. </remarks>
     public virtual ClientResult<bool> DeleteModel(string model)
     {
         Argument.AssertNotNullOrEmpty(model, nameof(model));

--- a/.dotnet/src/Custom/Moderations/ModerationClient.cs
+++ b/.dotnet/src/Custom/Moderations/ModerationClient.cs
@@ -8,9 +8,11 @@ using System.Threading.Tasks;
 
 namespace OpenAI.Moderations;
 
-/// <summary>
-/// The service client for OpenAI moderation operations.
-/// </summary>
+// CUSTOM:
+// - Renamed.
+// - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
+// - Suppressed methods that only take the options parameter.
+/// <summary> The service client for OpenAI moderation operations. </summary>
 [CodeGenClient("Moderations")]
 [CodeGenSuppress("ModerationClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateModerationAsync", typeof(ModerationOptions))]
@@ -19,56 +21,65 @@ public partial class ModerationClient
 {
     private readonly string _model;
 
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModerationClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="model"> The model name to use for moderation operations. </param>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public ModerationClient(string model, ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              model,
-              OpenAIClient.GetEndpoint(options),
-              options)
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="ModerationClient">. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    public ModerationClient(string model, ApiKeyCredential credential) : this(model, credential, new OpenAIClientOptions())
     {
     }
 
-    /// <summary>
-    /// Initializes a new instance of <see cref="ModerationClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="ModerationClient(string, ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="model"> The model name to use for moderation operations. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public ModerationClient(string model, OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              model,
-              OpenAIClient.GetEndpoint(options),
-              options)
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="ModerationClient">. </summary>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="credential"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    public ModerationClient(string model, ApiKeyCredential credential, OpenAIClientOptions options)
     {
-    }
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
 
-    /// <summary> Initializes a new instance of <see cref="ModerationClient"/>. </summary>
-    /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
-    /// <param name="model"> The model name to use for moderation operations. </param>
-    /// <param name="endpoint"> OpenAI Endpoint. </param>
-    protected internal ModerationClient(ClientPipeline pipeline, string model, Uri endpoint, OpenAIClientOptions options)
-    {
-        _pipeline = pipeline;
         _model = model;
-        _endpoint = endpoint;
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
-    /// <summary> Classifies if text is potentially harmful. </summary>
-    /// <param name="input"> The text to classify. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    // CUSTOM:
+    // - Added `model` parameter.
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="ModerationClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> or <paramref name="model"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
+    protected internal ModerationClient(ClientPipeline pipeline, string model, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        Argument.AssertNotNullOrEmpty(model, nameof(model));
+        options ??= new OpenAIClientOptions();
+
+        _model = model;
+        _pipeline = pipeline;
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
+
+    /// <summary> Classifies if the text input is potentially harmful across several categories. </summary>
+    /// <param name="input"> The text input to classify. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="input"/> is an empty string, and was expected to be non-empty. </exception>
     public virtual async Task<ClientResult<ModerationResult>> ClassifyTextInputAsync(string input, CancellationToken cancellationToken = default)
@@ -83,9 +94,9 @@ public partial class ModerationClient
         return ClientResult.FromValue(ModerationCollection.FromResponse(result.GetRawResponse()).FirstOrDefault(), result.GetRawResponse());
     }
 
-    /// <summary> Classifies if text is potentially harmful. </summary>
-    /// <param name="input"> The text to classify. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <summary> Classifies if the text input is potentially harmful across several categories. </summary>
+    /// <param name="input"> The text input to classify. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="input"/> is an empty string, and was expected to be non-empty. </exception>
     public virtual ClientResult<ModerationResult> ClassifyTextInput(string input, CancellationToken cancellationToken = default)
@@ -100,10 +111,9 @@ public partial class ModerationClient
         return ClientResult.FromValue(ModerationCollection.FromResponse(result.GetRawResponse()).FirstOrDefault(), result.GetRawResponse());
     }
 
-
-    /// <summary> Classifies if text is potentially harmful. </summary>
-    /// <param name="inputs"> The text to classify. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <summary> Classifies if the text inputs are potentially harmful across several categories. </summary>
+    /// <param name="inputs"> The text inputs to classify. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="inputs"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="inputs"/> is an empty collection, and was expected to be non-empty. </exception>
     public virtual async Task<ClientResult<ModerationCollection>> ClassifyTextInputsAsync(IEnumerable<string> inputs, CancellationToken cancellationToken = default)
@@ -118,9 +128,9 @@ public partial class ModerationClient
         return ClientResult.FromValue(ModerationCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
-    /// <summary> Classifies if text is potentially harmful. </summary>
-    /// <param name="inputs"> The text to classify. </param>
-    /// <param name="cancellationToken">A token that can be used to cancel this method call.</param>
+    /// <summary> Classifies if the text inputs are potentially harmful across several categories. </summary>
+    /// <param name="inputs"> The text inputs to classify. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="inputs"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="inputs"/> is an empty collection, and was expected to be non-empty. </exception>
     public virtual ClientResult<ModerationCollection> ClassifyTextInputs(IEnumerable<string> inputs, CancellationToken cancellationToken = default)

--- a/.dotnet/src/Custom/VectorStores/VectorStoreClient.cs
+++ b/.dotnet/src/Custom/VectorStores/VectorStoreClient.cs
@@ -13,6 +13,7 @@ namespace OpenAI.VectorStores;
 /// The service client for OpenAI vector store operations.
 /// </summary>
 [CodeGenClient("VectorStores")]
+[CodeGenSuppress("VectorStoreClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateVectorStoreAsync", typeof(VectorStoreCreationOptions))]
 [CodeGenSuppress("CreateVectorStore", typeof(VectorStoreCreationOptions))]
 [CodeGenSuppress("GetVectorStoreAsync", typeof(string))]
@@ -42,43 +43,47 @@ namespace OpenAI.VectorStores;
 [Experimental("OPENAI001")]
 public partial class VectorStoreClient
 {
-    /// <summary>
-    /// Initializes a new instance of <see cref="VectorStoreClient"/> that will use an API key when authenticating.
-    /// </summary>
-    /// <param name="credential"> The API key used to authenticate with the service endpoint. </param>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="ArgumentNullException"> The provided <paramref name="credential"/> was null. </exception>
-    public VectorStoreClient(ApiKeyCredential credential, OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(credential, requireExplicitCredential: true), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="VectorStoreClient"/> that will use an API key from the OPENAI_API_KEY
-    /// environment variable when authenticating.
-    /// </summary>
-    /// <remarks>
-    /// To provide an explicit credential instead of using the environment variable, use an alternate constructor like
-    /// <see cref="VectorStoreClient(ApiKeyCredential,OpenAIClientOptions)"/>.
-    /// </remarks>
-    /// <param name="options"> Additional options to customize the client. </param>
-    /// <exception cref="InvalidOperationException"> The OPENAI_API_KEY environment variable was not found. </exception>
-    public VectorStoreClient(OpenAIClientOptions options = null)
-        : this(
-              OpenAIClient.CreatePipeline(OpenAIClient.GetApiKey(), options),
-              OpenAIClient.GetEndpoint(options),
-              options)
-    { }
-
-    /// <summary> Initializes a new instance of VectorStoreClient. </summary>
-    /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
-    /// <param name="endpoint"> OpenAI Endpoint. </param>
-    protected internal VectorStoreClient(ClientPipeline pipeline, Uri endpoint, OpenAIClientOptions options)
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="VectorStoreClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public VectorStoreClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    /// <summary> Initializes a new instance of <see cref="VectorStoreClient">. </summary>
+    /// <param name="credential"> The API key to authenticate with the service. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
+    public VectorStoreClient(ApiKeyCredential credential, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(credential, nameof(credential));
+        options ??= new OpenAIClientOptions();
+
+        _pipeline = OpenAIClient.CreatePipeline(credential, options);
+        _endpoint = OpenAIClient.GetEndpoint(options);
+    }
+
+    // CUSTOM:
+    // - Used a custom pipeline.
+    // - Demoted the endpoint parameter to be a property in the options class.
+    // - Made protected.
+    /// <summary> Initializes a new instance of <see cref="VectorStoreClient">. </summary>
+    /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
+    /// <param name="options"> The options to configure the client. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
+    protected internal VectorStoreClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    {
+        Argument.AssertNotNull(pipeline, nameof(pipeline));
+        options ??= new OpenAIClientOptions();
+
         _pipeline = pipeline;
-        _endpoint = endpoint;
+        _endpoint = OpenAIClient.GetEndpoint(options);
     }
 
     /// <summary> Creates a vector store. </summary>

--- a/.dotnet/src/Generated/ChatClient.cs
+++ b/.dotnet/src/Generated/ChatClient.cs
@@ -24,13 +24,6 @@ namespace OpenAI.Chat
         {
         }
 
-        internal ChatClient(ClientPipeline pipeline, ApiKeyCredential keyCredential, Uri endpoint)
-        {
-            _pipeline = pipeline;
-            _keyCredential = keyCredential;
-            _endpoint = endpoint;
-        }
-
         internal PipelineMessage CreateCreateChatCompletionRequest(BinaryContent content, RequestOptions options)
         {
             var message = _pipeline.CreateMessage();

--- a/.dotnet/src/Generated/FineTuningClient.cs
+++ b/.dotnet/src/Generated/FineTuningClient.cs
@@ -24,13 +24,6 @@ namespace OpenAI.FineTuning
         {
         }
 
-        internal FineTuningClient(ClientPipeline pipeline, ApiKeyCredential keyCredential, Uri endpoint)
-        {
-            _pipeline = pipeline;
-            _keyCredential = keyCredential;
-            _endpoint = endpoint;
-        }
-
         internal PipelineMessage CreateCreateFineTuningJobRequest(BinaryContent content, RequestOptions options)
         {
             var message = _pipeline.CreateMessage();

--- a/.dotnet/src/Generated/LegacyCompletionClient.cs
+++ b/.dotnet/src/Generated/LegacyCompletionClient.cs
@@ -24,13 +24,6 @@ namespace OpenAI.LegacyCompletions
         {
         }
 
-        internal LegacyCompletionClient(ClientPipeline pipeline, ApiKeyCredential keyCredential, Uri endpoint)
-        {
-            _pipeline = pipeline;
-            _keyCredential = keyCredential;
-            _endpoint = endpoint;
-        }
-
         public virtual async Task<ClientResult<InternalCreateCompletionResponse>> CreateCompletionAsync(InternalCreateCompletionRequest requestBody)
         {
             Argument.AssertNotNull(requestBody, nameof(requestBody));

--- a/.dotnet/src/Generated/VectorStoreClient.cs
+++ b/.dotnet/src/Generated/VectorStoreClient.cs
@@ -24,13 +24,6 @@ namespace OpenAI.VectorStores
         {
         }
 
-        internal VectorStoreClient(ClientPipeline pipeline, ApiKeyCredential keyCredential, Uri endpoint)
-        {
-            _pipeline = pipeline;
-            _keyCredential = keyCredential;
-            _endpoint = endpoint;
-        }
-
         internal PipelineMessage CreateGetVectorStoresRequest(int? limit, string order, string after, string before, RequestOptions options)
         {
             var message = _pipeline.CreateMessage();

--- a/.dotnet/tests/Assistants/AssistantTests.cs
+++ b/.dotnet/tests/Assistants/AssistantTests.cs
@@ -29,9 +29,9 @@ public partial class AssistantTests
             return;
         }
 
-        AssistantClient client = new();
-        FileClient fileClient = new();
-        VectorStoreClient vectorStoreClient = new();
+        AssistantClient client = GetTestClient<AssistantClient>(TestScenario.Assistants);
+        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        VectorStoreClient vectorStoreClient = GetTestClient<VectorStoreClient>(TestScenario.VectorStores);
         RequestOptions requestOptions = new()
         {
             ErrorOptions = ClientErrorBehaviors.NoThrow,
@@ -273,7 +273,7 @@ public partial class AssistantTests
         });
         Validate(assistant);
 
-        FileClient fileClient = new();
+        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
         OpenAIFileInfo equationFile = fileClient.UploadFile(
             BinaryData.FromString("""
             x,y
@@ -450,7 +450,7 @@ public partial class AssistantTests
     [Test]
     public async Task StreamingRunWorks()
     {
-        AssistantClient client = new();
+        AssistantClient client = GetTestClient();
         Assistant assistant = await client.CreateAssistantAsync("gpt-4o-mini");
         Validate(assistant);
 
@@ -557,7 +557,7 @@ public partial class AssistantTests
     public void BasicFileSearchWorks()
     {
         // First, we need to upload a simple test file.
-        FileClient fileClient = new();
+        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
         OpenAIFileInfo testFile = fileClient.UploadFile(
             BinaryData.FromString("""
             This file describes the favorite foods of several people.
@@ -944,7 +944,7 @@ public partial class AssistantTests
         });
         Validate(assistant);
 
-        FileClient fileClient = new();
+        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
         OpenAIFileInfo equationFile = fileClient.UploadFile(
             BinaryData.FromString("""
             x,y

--- a/.dotnet/tests/Assistants/VectorStoreTests.cs
+++ b/.dotnet/tests/Assistants/VectorStoreTests.cs
@@ -359,7 +359,7 @@ public partial class VectorStoreTests
     {
         List<OpenAIFileInfo> files = [];
 
-        FileClient client = new();
+        FileClient client = GetTestClient<FileClient>(TestScenario.Files);
         for (int i = 0; i < count; i++)
         {
             OpenAIFileInfo file = client.UploadFile(
@@ -376,8 +376,8 @@ public partial class VectorStoreTests
     [TearDown]
     protected void Cleanup()
     {
-        FileClient fileClient = new();
-        VectorStoreClient vectorStoreClient = new();
+        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        VectorStoreClient vectorStoreClient = GetTestClient<VectorStoreClient>(TestScenario.VectorStores);
         RequestOptions requestOptions = new()
         {
             ErrorOptions = ClientErrorBehaviors.NoThrow,

--- a/.dotnet/tests/Batch/BatchTests.cs
+++ b/.dotnet/tests/Batch/BatchTests.cs
@@ -60,7 +60,7 @@ public partial class BatchTests : SyncAsyncTestBase
         streamWriter.Flush();
         testFileStream.Position = 0;
 
-        FileClient fileClient = new();
+        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
         OpenAIFileInfo inputFile = await fileClient.UploadFileAsync(testFileStream, "test-batch-file", FileUploadPurpose.Batch);
         Assert.That(inputFile.Id, Is.Not.Null.And.Not.Empty);
 

--- a/.dotnet/tests/Embeddings/EmbeddingTests.cs
+++ b/.dotnet/tests/Embeddings/EmbeddingTests.cs
@@ -28,7 +28,7 @@ public partial class EmbeddingTests : SyncAsyncTestBase
     [Test]
     public async Task GenerateSingleEmbedding()
     {
-        EmbeddingClient client = new("text-embedding-3-small");
+        EmbeddingClient client = new("text-embedding-3-small", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
 
         string input = "Hello, world!";
 
@@ -49,7 +49,7 @@ public partial class EmbeddingTests : SyncAsyncTestBase
     [TestCase(EmbeddingsInputKind.UsingIntegers)]
     public async Task GenerateMultipleEmbeddings(EmbeddingsInputKind embeddingsInputKind)
     {
-        EmbeddingClient client = new("text-embedding-3-small");
+        EmbeddingClient client = new("text-embedding-3-small", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
 
         const int Dimensions = 456;
 

--- a/.dotnet/tests/Models/ModelTests.cs
+++ b/.dotnet/tests/Models/ModelTests.cs
@@ -4,6 +4,7 @@ using OpenAI.Tests.Utility;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using static OpenAI.Tests.TestHelpers;
 
 namespace OpenAI.Tests.Models;
 
@@ -20,7 +21,7 @@ public partial class ModelTests : SyncAsyncTestBase
     [Test]
     public async Task ListModels()
     {
-        ModelClient client = new();
+        ModelClient client = GetTestClient<ModelClient>(TestScenario.Models);
 
         OpenAIModelInfoCollection allModels = IsAsync
             ? await client.GetModelsAsync()
@@ -33,7 +34,7 @@ public partial class ModelTests : SyncAsyncTestBase
     [Test]
     public async Task GetModelInfo()
     {
-        ModelClient client = new();
+        ModelClient client = GetTestClient<ModelClient>(TestScenario.Models);
 
         string modelName = "gpt-4o-mini";
 

--- a/.dotnet/tests/Moderations/ModerationTests.cs
+++ b/.dotnet/tests/Moderations/ModerationTests.cs
@@ -3,6 +3,7 @@ using OpenAI.Moderations;
 using OpenAI.Tests.Utility;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using static OpenAI.Tests.TestHelpers;
 
 namespace OpenAI.Tests.Moderations;
 
@@ -19,7 +20,7 @@ public partial class ModerationTests : SyncAsyncTestBase
     [Test]
     public async Task ClassifySingleInput()
     {
-        ModerationClient client = new("text-moderation-stable");
+        ModerationClient client = GetTestClient<ModerationClient>(TestScenario.Moderations);
 
         const string input = "I am killing all my houseplants!";
 
@@ -35,7 +36,7 @@ public partial class ModerationTests : SyncAsyncTestBase
     [Test]
     public async Task ClassifyMultipleInputs()
     {
-        ModerationClient client = new("text-moderation-stable");
+        ModerationClient client = GetTestClient<ModerationClient>(TestScenario.Moderations);
 
         List<string> inputs =
             [

--- a/.dotnet/tests/UserAgentTests.cs
+++ b/.dotnet/tests/UserAgentTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using OpenAI.Chat;
+using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.IO;
@@ -29,7 +30,7 @@ public partial class UserAgentTests
         } : new();
         options.AddPolicy(policy, PipelinePosition.BeforeTransport);
 
-        ChatClient client = new("no-real-model-needed", options);
+        ChatClient client = new("no-real-model-needed", Environment.GetEnvironmentVariable("OPENAI_API_KEY"), options);
         RequestOptions noThrowOptions = new() { ErrorOptions = ClientErrorBehaviors.NoThrow, };
         using BinaryContent emptyContent = BinaryContent.Create(new MemoryStream());
         _ = client.CompleteChat(emptyContent, noThrowOptions);

--- a/.dotnet/tests/Utility/TestHelpers.cs
+++ b/.dotnet/tests/Utility/TestHelpers.cs
@@ -6,8 +6,11 @@ using OpenAI.Chat;
 using OpenAI.Embeddings;
 using OpenAI.Files;
 using OpenAI.Images;
+using OpenAI.Models;
+using OpenAI.Moderations;
 using OpenAI.VectorStores;
 using System;
+using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
@@ -42,23 +45,26 @@ internal static class TestHelpers
     public static T GetTestClient<T>(TestScenario scenario, string overrideModel = null)
     {
         OpenAIClientOptions options = new();
+        ApiKeyCredential credential = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
         options.AddPolicy(GetDumpPolicy(), PipelinePosition.PerTry);
         object clientObject = scenario switch
         {
 #pragma warning disable OPENAI001
-            TestScenario.Assistants => new AssistantClient(options),
+            TestScenario.Assistants => new AssistantClient(credential, options),
 #pragma warning restore OPENAI001
-            TestScenario.Audio_TTS => new AudioClient(overrideModel ?? "tts-1", options),
-            TestScenario.Audio_Whisper => new AudioClient(overrideModel ?? "whisper-1", options),
-            TestScenario.Batch => new BatchClient(options),
-            TestScenario.Chat => new ChatClient(overrideModel ?? "gpt-4o-mini", options),
-            TestScenario.Embeddings => new EmbeddingClient(overrideModel ?? "text-embedding-3-small", options),
-            TestScenario.Files => new FileClient(options),
-            TestScenario.Images => new ImageClient(overrideModel ?? "dall-e-3", options),
+            TestScenario.Audio_TTS => new AudioClient(overrideModel ?? "tts-1", credential, options),
+            TestScenario.Audio_Whisper => new AudioClient(overrideModel ?? "whisper-1", credential, options),
+            TestScenario.Batch => new BatchClient(credential, options),
+            TestScenario.Chat => new ChatClient(overrideModel ?? "gpt-4o-mini", credential, options),
+            TestScenario.Embeddings => new EmbeddingClient(overrideModel ?? "text-embedding-3-small", credential, options),
+            TestScenario.Files => new FileClient(credential,options),
+            TestScenario.Images => new ImageClient(overrideModel ?? "dall-e-3", credential, options),
+            TestScenario.Models => new ModelClient(credential, options),
+            TestScenario.Moderations => new ModerationClient(overrideModel ?? "text-moderation-stable", credential, options),
 #pragma warning disable OPENAI001
-            TestScenario.VectorStores => new VectorStoreClient(options),
+            TestScenario.VectorStores => new VectorStoreClient(credential, options),
 #pragma warning restore OPENAI001
-            TestScenario.TopLevel => new OpenAIClient(options),
+            TestScenario.TopLevel => new OpenAIClient(credential, options),
             _ => throw new NotImplementedException(),
         };
         return (T)clientObject;


### PR DESCRIPTION
* Remove constructors that do not explicitly take a credential and endpoint
* Remove endpoint parameter from the protected constructors
* Remove OpenAIClient's Endpoint protected property
* Make OpenAIClient's constructor that takes ClientPipeline `protected internal` instead of just `protected`



























































