### PR TITLE
Rename `User` property in applicable Options classes to `EndUserId`

### DIFF
--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Removed the endpoint parameter from all client constructors, making it clearer that an alternative endpoint must be specified via the `OpenAIClientOptions` parameter. (commit_hash)
 - Removed `OpenAIClient`'s `Endpoint` `protected` property. (commit_hash)
 - Made `OpenAIClient`'s constructor that takes a `ClientPipeline` parameter `protected internal` instead of just `protected`. (commit_hash)
+- Renamed the `User` property in applicable Options classes to `EndUserId`, making its purpose clearer. (commit_hash)
 
 ### Bugs Fixed
 

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -1216,6 +1216,7 @@ namespace OpenAI.Chat {
         public override string ToString();
     }
     public class ChatCompletionOptions : IJsonModel<ChatCompletionOptions>, IPersistableModel<ChatCompletionOptions> {
+        public string EndUserId { get; set; }
         public float? FrequencyPenalty { get; set; }
         public ChatFunctionChoice FunctionChoice { get; set; }
         public IList<ChatFunction> Functions { get; }
@@ -1232,7 +1233,6 @@ namespace OpenAI.Chat {
         public IList<ChatTool> Tools { get; }
         public int? TopLogProbabilityCount { get; set; }
         public float? TopP { get; set; }
-        public string User { get; set; }
         ChatCompletionOptions IJsonModel<ChatCompletionOptions>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<ChatCompletionOptions>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         ChatCompletionOptions IPersistableModel<ChatCompletionOptions>.Create(BinaryData data, ModelReaderWriterOptions options);
@@ -1582,7 +1582,7 @@ namespace OpenAI.Embeddings {
     }
     public class EmbeddingGenerationOptions : IJsonModel<EmbeddingGenerationOptions>, IPersistableModel<EmbeddingGenerationOptions> {
         public int? Dimensions { get; set; }
-        public string User { get; set; }
+        public string EndUserId { get; set; }
         EmbeddingGenerationOptions IJsonModel<EmbeddingGenerationOptions>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<EmbeddingGenerationOptions>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         EmbeddingGenerationOptions IPersistableModel<EmbeddingGenerationOptions>.Create(BinaryData data, ModelReaderWriterOptions options);
@@ -1847,9 +1847,9 @@ namespace OpenAI.Images {
         public virtual Task<ClientResult<GeneratedImageCollection>> GenerateImageVariationsAsync(string imageFilePath, int imageCount, ImageVariationOptions options = null);
     }
     public class ImageEditOptions : IJsonModel<ImageEditOptions>, IPersistableModel<ImageEditOptions> {
+        public string EndUserId { get; set; }
         public GeneratedImageFormat? ResponseFormat { get; set; }
         public GeneratedImageSize? Size { get; set; }
-        public string User { get; set; }
         ImageEditOptions IJsonModel<ImageEditOptions>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<ImageEditOptions>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         ImageEditOptions IPersistableModel<ImageEditOptions>.Create(BinaryData data, ModelReaderWriterOptions options);
@@ -1857,11 +1857,11 @@ namespace OpenAI.Images {
         BinaryData IPersistableModel<ImageEditOptions>.Write(ModelReaderWriterOptions options);
     }
     public class ImageGenerationOptions : IJsonModel<ImageGenerationOptions>, IPersistableModel<ImageGenerationOptions> {
+        public string EndUserId { get; set; }
         public GeneratedImageQuality? Quality { get; set; }
         public GeneratedImageFormat? ResponseFormat { get; set; }
         public GeneratedImageSize? Size { get; set; }
         public GeneratedImageStyle? Style { get; set; }
-        public string User { get; set; }
         ImageGenerationOptions IJsonModel<ImageGenerationOptions>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<ImageGenerationOptions>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         ImageGenerationOptions IPersistableModel<ImageGenerationOptions>.Create(BinaryData data, ModelReaderWriterOptions options);
@@ -1869,9 +1869,9 @@ namespace OpenAI.Images {
         BinaryData IPersistableModel<ImageGenerationOptions>.Write(ModelReaderWriterOptions options);
     }
     public class ImageVariationOptions : IJsonModel<ImageVariationOptions>, IPersistableModel<ImageVariationOptions> {
+        public string EndUserId { get; set; }
         public GeneratedImageFormat? ResponseFormat { get; set; }
         public GeneratedImageSize? Size { get; set; }
-        public string User { get; set; }
         ImageVariationOptions IJsonModel<ImageVariationOptions>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<ImageVariationOptions>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         ImageVariationOptions IPersistableModel<ImageVariationOptions>.Create(BinaryData data, ModelReaderWriterOptions options);

--- a/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
+++ b/.dotnet/src/Custom/Chat/ChatCompletionOptions.cs
@@ -102,6 +102,7 @@ public partial class ChatCompletionOptions
     [CodeGenMember("FunctionCall")]
     public ChatFunctionChoice FunctionChoice { get; set; }
 
+    // CUSTOM: Renamed.
     /// <summary>
     /// Whether to enable parallel function calling during tool use. 
     /// </summary>
@@ -110,4 +111,12 @@ public partial class ChatCompletionOptions
     /// </remarks>
     [CodeGenMember("ParallelToolCalls")]
     public bool? ParallelToolCallsEnabled { get; set; }
+
+    // CUSTOM: Renamed.
+    /// <summary>
+    ///     A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    ///     <see href="https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids">Learn more</see>.
+    /// </summary>
+    [CodeGenMember("User")]
+    public string EndUserId { get; set; }
 }

--- a/.dotnet/src/Custom/Embeddings/EmbeddingGenerationOptions.cs
+++ b/.dotnet/src/Custom/Embeddings/EmbeddingGenerationOptions.cs
@@ -86,4 +86,12 @@ public partial class EmbeddingGenerationOptions
     public EmbeddingGenerationOptions()
     {
     }
+
+    // CUSTOM: Renamed.
+    /// <summary>
+    ///     A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    ///     <see href="https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids">Learn more</see>.
+    /// </summary>
+    [CodeGenMember("User")]
+    public string EndUserId { get; set; }
 }

--- a/.dotnet/src/Custom/Images/ImageEditOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageEditOptions.cs
@@ -75,11 +75,21 @@ public partial class ImageEditOptions
 
     // CUSTOM: Changed property type.
     /// <summary> The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`. </summary>
+    [CodeGenMember("Size")]
     public GeneratedImageSize? Size { get; set; }
 
     // CUSTOM: Changed property type.
     /// <summary> The format in which the generated images are returned. Must be one of `url` or `b64_json`. </summary>
+    [CodeGenMember("ResponseFormat")]
     public GeneratedImageFormat? ResponseFormat { get; set; }
+
+    // CUSTOM: Renamed.
+    /// <summary>
+    ///     A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    ///     <see href="https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids">Learn more</see>.
+    /// </summary>
+    [CodeGenMember("User")]
+    public string EndUserId { get; set; }
 
     internal MultipartFormDataBinaryContent ToMultipartContent(Stream image, string imageFilename, Stream mask, string maskFilename)
     {
@@ -116,9 +126,9 @@ public partial class ImageEditOptions
             content.Add(Size.ToString(), "size");
         }
 
-        if (User is not null)
+        if (EndUserId is not null)
         {
-            content.Add(User, "user");
+            content.Add(EndUserId, "user");
         }
 
         return content;

--- a/.dotnet/src/Custom/Images/ImageGenerationOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageGenerationOptions.cs
@@ -32,4 +32,12 @@ public partial class ImageGenerationOptions
     public ImageGenerationOptions()
     {
     }
+
+    // CUSTOM: Renamed.
+    /// <summary>
+    ///     A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    ///     <see href="https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids">Learn more</see>.
+    /// </summary>
+    [CodeGenMember("User")]
+    public string EndUserId { get; set; }
 }

--- a/.dotnet/src/Custom/Images/ImageVariationOptions.cs
+++ b/.dotnet/src/Custom/Images/ImageVariationOptions.cs
@@ -48,11 +48,21 @@ public partial class ImageVariationOptions
 
     // CUSTOM: Changed property type.
     /// <summary> The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`. </summary>
+    [CodeGenMember("Size")]
     public GeneratedImageSize? Size { get; set; }
 
     // CUSTOM: Changed property type.
     /// <summary> The format in which the generated images are returned. Must be one of `url` or `b64_json`. </summary>
+    [CodeGenMember("ResponseFormat")]
     public GeneratedImageFormat? ResponseFormat { get; set; }
+
+    // CUSTOM: Renamed.
+    /// <summary>
+    ///     A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    ///     <see href="https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids">Learn more</see>.
+    /// </summary>
+    [CodeGenMember("User")]
+    public string EndUserId { get; set; }
 
     internal MultipartFormDataBinaryContent ToMultipartContent(Stream image, string imageFilename)
     {
@@ -83,9 +93,9 @@ public partial class ImageVariationOptions
             content.Add(Size.ToString(), "size");
         }
 
-        if (User is not null)
+        if (EndUserId is not null)
         {
-            content.Add(User, "user");
+            content.Add(EndUserId, "user");
         }
 
         return content;

--- a/.dotnet/src/Generated/Models/ChatCompletionOptions.Serialization.cs
+++ b/.dotnet/src/Generated/Models/ChatCompletionOptions.Serialization.cs
@@ -217,10 +217,10 @@ namespace OpenAI.Chat
                 writer.WritePropertyName("parallel_tool_calls"u8);
                 writer.WriteBooleanValue(ParallelToolCallsEnabled.Value);
             }
-            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(User))
+            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(EndUserId))
             {
                 writer.WritePropertyName("user"u8);
-                writer.WriteStringValue(User);
+                writer.WriteStringValue(EndUserId);
             }
             if (SerializedAdditionalRawData?.ContainsKey("function_call") != true && Optional.IsDefined(FunctionChoice))
             {

--- a/.dotnet/src/Generated/Models/ChatCompletionOptions.cs
+++ b/.dotnet/src/Generated/Models/ChatCompletionOptions.cs
@@ -12,7 +12,7 @@ namespace OpenAI.Chat
     {
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
 
-        internal ChatCompletionOptions(IList<ChatMessage> messages, InternalCreateChatCompletionRequestModel model, float? frequencyPenalty, IDictionary<int, int> logitBiases, bool? includeLogProbabilities, int? topLogProbabilityCount, int? maxTokens, int? n, float? presencePenalty, ChatResponseFormat responseFormat, long? seed, IList<string> stopSequences, bool? stream, InternalChatCompletionStreamOptions streamOptions, float? temperature, float? topP, IList<ChatTool> tools, ChatToolChoice toolChoice, bool? parallelToolCallsEnabled, string user, ChatFunctionChoice functionChoice, IList<ChatFunction> functions, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal ChatCompletionOptions(IList<ChatMessage> messages, InternalCreateChatCompletionRequestModel model, float? frequencyPenalty, IDictionary<int, int> logitBiases, bool? includeLogProbabilities, int? topLogProbabilityCount, int? maxTokens, int? n, float? presencePenalty, ChatResponseFormat responseFormat, long? seed, IList<string> stopSequences, bool? stream, InternalChatCompletionStreamOptions streamOptions, float? temperature, float? topP, IList<ChatTool> tools, ChatToolChoice toolChoice, bool? parallelToolCallsEnabled, string endUserId, ChatFunctionChoice functionChoice, IList<ChatFunction> functions, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             Messages = messages;
             Model = model;
@@ -33,7 +33,7 @@ namespace OpenAI.Chat
             Tools = tools;
             ToolChoice = toolChoice;
             ParallelToolCallsEnabled = parallelToolCallsEnabled;
-            User = user;
+            EndUserId = endUserId;
             FunctionChoice = functionChoice;
             Functions = functions;
             SerializedAdditionalRawData = serializedAdditionalRawData;
@@ -46,7 +46,6 @@ namespace OpenAI.Chat
         public float? Temperature { get; set; }
         public float? TopP { get; set; }
         public IList<ChatTool> Tools { get; }
-        public string User { get; set; }
         public IList<ChatFunction> Functions { get; }
     }
 }

--- a/.dotnet/src/Generated/Models/EmbeddingGenerationOptions.Serialization.cs
+++ b/.dotnet/src/Generated/Models/EmbeddingGenerationOptions.Serialization.cs
@@ -48,10 +48,10 @@ namespace OpenAI.Embeddings
                 writer.WritePropertyName("dimensions"u8);
                 writer.WriteNumberValue(Dimensions.Value);
             }
-            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(User))
+            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(EndUserId))
             {
                 writer.WritePropertyName("user"u8);
-                writer.WriteStringValue(User);
+                writer.WriteStringValue(EndUserId);
             }
             if (SerializedAdditionalRawData != null)
             {

--- a/.dotnet/src/Generated/Models/EmbeddingGenerationOptions.cs
+++ b/.dotnet/src/Generated/Models/EmbeddingGenerationOptions.cs
@@ -11,16 +11,15 @@ namespace OpenAI.Embeddings
     {
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
 
-        internal EmbeddingGenerationOptions(BinaryData input, InternalCreateEmbeddingRequestModel model, InternalCreateEmbeddingRequestEncodingFormat? encodingFormat, int? dimensions, string user, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal EmbeddingGenerationOptions(BinaryData input, InternalCreateEmbeddingRequestModel model, InternalCreateEmbeddingRequestEncodingFormat? encodingFormat, int? dimensions, string endUserId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             Input = input;
             Model = model;
             EncodingFormat = encodingFormat;
             Dimensions = dimensions;
-            User = user;
+            EndUserId = endUserId;
             SerializedAdditionalRawData = serializedAdditionalRawData;
         }
         public int? Dimensions { get; set; }
-        public string User { get; set; }
     }
 }

--- a/.dotnet/src/Generated/Models/ImageEditOptions.Serialization.cs
+++ b/.dotnet/src/Generated/Models/ImageEditOptions.Serialization.cs
@@ -99,10 +99,10 @@ namespace OpenAI.Images
                     writer.WriteNull("response_format");
                 }
             }
-            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(User))
+            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(EndUserId))
             {
                 writer.WritePropertyName("user"u8);
-                writer.WriteStringValue(User);
+                writer.WriteStringValue(EndUserId);
             }
             if (SerializedAdditionalRawData != null)
             {
@@ -293,9 +293,9 @@ namespace OpenAI.Images
                     content.Add(ResponseFormat.Value.ToSerialString(), "response_format");
                 }
             }
-            if (Optional.IsDefined(User))
+            if (Optional.IsDefined(EndUserId))
             {
-                content.Add(User, "user");
+                content.Add(EndUserId, "user");
             }
             return content;
         }

--- a/.dotnet/src/Generated/Models/ImageEditOptions.cs
+++ b/.dotnet/src/Generated/Models/ImageEditOptions.cs
@@ -11,7 +11,7 @@ namespace OpenAI.Images
     {
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
 
-        internal ImageEditOptions(BinaryData image, string prompt, BinaryData mask, InternalCreateImageEditRequestModel? model, long? n, GeneratedImageSize? size, GeneratedImageFormat? responseFormat, string user, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal ImageEditOptions(BinaryData image, string prompt, BinaryData mask, InternalCreateImageEditRequestModel? model, long? n, GeneratedImageSize? size, GeneratedImageFormat? responseFormat, string endUserId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             Image = image;
             Prompt = prompt;
@@ -20,9 +20,8 @@ namespace OpenAI.Images
             N = n;
             Size = size;
             ResponseFormat = responseFormat;
-            User = user;
+            EndUserId = endUserId;
             SerializedAdditionalRawData = serializedAdditionalRawData;
         }
-        public string User { get; set; }
     }
 }

--- a/.dotnet/src/Generated/Models/ImageGenerationOptions.Serialization.cs
+++ b/.dotnet/src/Generated/Models/ImageGenerationOptions.Serialization.cs
@@ -91,10 +91,10 @@ namespace OpenAI.Images
                     writer.WriteNull("style");
                 }
             }
-            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(User))
+            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(EndUserId))
             {
                 writer.WritePropertyName("user"u8);
-                writer.WriteStringValue(User);
+                writer.WriteStringValue(EndUserId);
             }
             if (SerializedAdditionalRawData != null)
             {

--- a/.dotnet/src/Generated/Models/ImageGenerationOptions.cs
+++ b/.dotnet/src/Generated/Models/ImageGenerationOptions.cs
@@ -11,7 +11,7 @@ namespace OpenAI.Images
     {
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
 
-        internal ImageGenerationOptions(string prompt, InternalCreateImageRequestModel? model, long? n, GeneratedImageQuality? quality, GeneratedImageFormat? responseFormat, GeneratedImageSize? size, GeneratedImageStyle? style, string user, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal ImageGenerationOptions(string prompt, InternalCreateImageRequestModel? model, long? n, GeneratedImageQuality? quality, GeneratedImageFormat? responseFormat, GeneratedImageSize? size, GeneratedImageStyle? style, string endUserId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             Prompt = prompt;
             Model = model;
@@ -20,13 +20,12 @@ namespace OpenAI.Images
             ResponseFormat = responseFormat;
             Size = size;
             Style = style;
-            User = user;
+            EndUserId = endUserId;
             SerializedAdditionalRawData = serializedAdditionalRawData;
         }
         public GeneratedImageQuality? Quality { get; set; }
         public GeneratedImageFormat? ResponseFormat { get; set; }
         public GeneratedImageSize? Size { get; set; }
         public GeneratedImageStyle? Style { get; set; }
-        public string User { get; set; }
     }
 }

--- a/.dotnet/src/Generated/Models/ImageVariationOptions.Serialization.cs
+++ b/.dotnet/src/Generated/Models/ImageVariationOptions.Serialization.cs
@@ -82,10 +82,10 @@ namespace OpenAI.Images
                     writer.WriteNull("size");
                 }
             }
-            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(User))
+            if (SerializedAdditionalRawData?.ContainsKey("user") != true && Optional.IsDefined(EndUserId))
             {
                 writer.WritePropertyName("user"u8);
-                writer.WriteStringValue(User);
+                writer.WriteStringValue(EndUserId);
             }
             if (SerializedAdditionalRawData != null)
             {
@@ -253,9 +253,9 @@ namespace OpenAI.Images
                     content.Add(Size.Value.ToString(), "size");
                 }
             }
-            if (Optional.IsDefined(User))
+            if (Optional.IsDefined(EndUserId))
             {
-                content.Add(User, "user");
+                content.Add(EndUserId, "user");
             }
             return content;
         }

--- a/.dotnet/src/Generated/Models/ImageVariationOptions.cs
+++ b/.dotnet/src/Generated/Models/ImageVariationOptions.cs
@@ -11,16 +11,15 @@ namespace OpenAI.Images
     {
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
 
-        internal ImageVariationOptions(BinaryData image, InternalCreateImageVariationRequestModel? model, long? n, GeneratedImageFormat? responseFormat, GeneratedImageSize? size, string user, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal ImageVariationOptions(BinaryData image, InternalCreateImageVariationRequestModel? model, long? n, GeneratedImageFormat? responseFormat, GeneratedImageSize? size, string endUserId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             Image = image;
             Model = model;
             N = n;
             ResponseFormat = responseFormat;
             Size = size;
-            User = user;
+            EndUserId = endUserId;
             SerializedAdditionalRawData = serializedAdditionalRawData;
         }
-        public string User { get; set; }
     }
 }


### PR DESCRIPTION
Renamed the `User` property in applicable Options classes to `EndUserId`, making its purpose clearer.