### PR TITLE
Rename `GenerateSpeechFromText` to `GenerateSpeech`

### DIFF
--- a/.dotnet.azure/src/Custom/Audio/AzureAudioClient.Protocol.cs
+++ b/.dotnet.azure/src/Custom/Audio/AzureAudioClient.Protocol.cs
@@ -41,14 +41,14 @@ internal partial class AzureAudioClient : AudioClient
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public override ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions options = null)
+    public override ClientResult GenerateSpeech(BinaryContent content, RequestOptions options = null)
     {
         using PipelineMessage message = CreateGenerateSpeechFromTextRequestMessage(content, options);
         return ClientResult.FromResponse(Pipeline.ProcessMessage(message, options));
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public override async Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions options = null)
+    public override async Task<ClientResult> GenerateSpeechAsync(BinaryContent content, RequestOptions options = null)
     {
         using PipelineMessage message = CreateGenerateSpeechFromTextRequestMessage(content, options);
         PipelineResponse response = await Pipeline.ProcessMessageAsync(message, options).ConfigureAwait(false);

--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 2.0.0-beta.10 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+- Renamed `AudioClient`'s `GenerateSpeechFromText` methods to simply `GenerateSpeech`. (commit_hash)
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0-beta.9 (2024-08-23)
 
 ### Features Added

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -999,11 +999,11 @@ namespace OpenAI.Audio {
         public AudioClient(string model, ApiKeyCredential credential);
         public virtual ClientPipeline Pipeline { get; }
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions options = null);
-        public virtual ClientResult<BinaryData> GenerateSpeechFromText(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default);
+        public virtual ClientResult GenerateSpeech(BinaryContent content, RequestOptions options = null);
+        public virtual ClientResult<BinaryData> GenerateSpeech(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions options = null);
-        public virtual Task<ClientResult<BinaryData>> GenerateSpeechFromTextAsync(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default);
+        public virtual Task<ClientResult> GenerateSpeechAsync(BinaryContent content, RequestOptions options = null);
+        public virtual Task<ClientResult<BinaryData>> GenerateSpeechAsync(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult TranscribeAudio(BinaryContent content, string contentType, RequestOptions options = null);
         public virtual ClientResult<AudioTranscription> TranscribeAudio(Stream audio, string audioFilename, AudioTranscriptionOptions options = null, CancellationToken cancellationToken = default);

--- a/.dotnet/examples/Audio/Example01_SimpleTextToSpeech.cs
+++ b/.dotnet/examples/Audio/Example01_SimpleTextToSpeech.cs
@@ -18,7 +18,7 @@ public partial class AudioExamples
             + " moisture, it is wise to postpone watering for a couple more days. When in doubt, it is often safer"
             + " to water sparingly and maintain a less-is-more approach.";
 
-        BinaryData speech = client.GenerateSpeechFromText(input, GeneratedSpeechVoice.Alloy);
+        BinaryData speech = client.GenerateSpeech(input, GeneratedSpeechVoice.Alloy);
 
         using FileStream stream = File.OpenWrite($"{Guid.NewGuid()}.mp3");
         speech.ToStream().CopyTo(stream);

--- a/.dotnet/examples/Audio/Example01_SimpleTextToSpeechAsync.cs
+++ b/.dotnet/examples/Audio/Example01_SimpleTextToSpeechAsync.cs
@@ -19,7 +19,7 @@ public partial class AudioExamples
             + " moisture, it is wise to postpone watering for a couple more days. When in doubt, it is often safer"
             + " to water sparingly and maintain a less-is-more approach.";
 
-        BinaryData speech = await client.GenerateSpeechFromTextAsync(input, GeneratedSpeechVoice.Alloy);
+        BinaryData speech = await client.GenerateSpeechAsync(input, GeneratedSpeechVoice.Alloy);
 
         using FileStream stream = File.OpenWrite($"{Guid.NewGuid()}.mp3");
         speech.ToStream().CopyTo(stream);

--- a/.dotnet/examples/CombinationExamples.cs
+++ b/.dotnet/examples/CombinationExamples.cs
@@ -48,7 +48,7 @@ public partial class CombinationExamples
 
         // Finally, we'll get some text-to-speech for that critical evaluation using tts-1-hd:
         AudioClient audioClient = new("tts-1-hd", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-        ClientResult<BinaryData> ttsResult = audioClient.GenerateSpeechFromText(
+        ClientResult<BinaryData> ttsResult = audioClient.GenerateSpeech(
             text: chatResponseText,
             GeneratedSpeechVoice.Fable,
             new SpeechGenerationOptions()
@@ -84,7 +84,7 @@ public partial class CombinationExamples
 
         // Asynchronously, in parallel to the next steps, we'll get the creative description in the voice of Onyx
         AudioClient ttsClient = new("tts-1-hd", Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-        Task<ClientResult<BinaryData>> imageDescriptionAudioTask = ttsClient.GenerateSpeechFromTextAsync(
+        Task<ClientResult<BinaryData>> imageDescriptionAudioTask = ttsClient.GenerateSpeechAsync(
             description,
             GeneratedSpeechVoice.Onyx,
             new SpeechGenerationOptions()
@@ -131,7 +131,7 @@ public partial class CombinationExamples
         Console.WriteLine($"Critic's appraisal:\n{appraisal}");
 
         // Finally, we'll get that art expert's laudations in the voice of Fable
-        ClientResult<BinaryData> appraisalAudioResult = await ttsClient.GenerateSpeechFromTextAsync(
+        ClientResult<BinaryData> appraisalAudioResult = await ttsClient.GenerateSpeechAsync(
             appraisal,
             GeneratedSpeechVoice.Fable,
             new SpeechGenerationOptions()

--- a/.dotnet/src/Custom/Audio/AudioClient.Protocol.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.Protocol.cs
@@ -27,7 +27,7 @@ public partial class AudioClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> GenerateSpeechFromTextAsync(BinaryContent content, RequestOptions options = null)
+    public virtual async Task<ClientResult> GenerateSpeechAsync(BinaryContent content, RequestOptions options = null)
     {
         Argument.AssertNotNull(content, nameof(content));
 
@@ -48,7 +48,7 @@ public partial class AudioClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult GenerateSpeechFromText(BinaryContent content, RequestOptions options = null)
+    public virtual ClientResult GenerateSpeech(BinaryContent content, RequestOptions options = null)
     {
         Argument.AssertNotNull(content, nameof(content));
 

--- a/.dotnet/src/Custom/Audio/AudioClient.cs
+++ b/.dotnet/src/Custom/Audio/AudioClient.cs
@@ -93,7 +93,7 @@ public partial class AudioClient
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="text"/> is null. </exception>
     /// <returns> The generated audio in the specified output format. </returns>
-    public virtual async Task<ClientResult<BinaryData>> GenerateSpeechFromTextAsync(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default)
+    public virtual async Task<ClientResult<BinaryData>> GenerateSpeechAsync(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(text, nameof(text));
 
@@ -101,7 +101,7 @@ public partial class AudioClient
         CreateSpeechGenerationOptions(text, voice, ref options);
 
         using BinaryContent content = options.ToBinaryContent();
-        ClientResult result = await GenerateSpeechFromTextAsync(content, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        ClientResult result = await GenerateSpeechAsync(content, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
     }
 
@@ -116,7 +116,7 @@ public partial class AudioClient
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="text"/> is null. </exception>
     /// <returns> The generated audio in the specified output format. </returns>
-    public virtual ClientResult<BinaryData> GenerateSpeechFromText(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default)
+    public virtual ClientResult<BinaryData> GenerateSpeech(string text, GeneratedSpeechVoice voice, SpeechGenerationOptions options = null, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(text, nameof(text));
 
@@ -124,7 +124,7 @@ public partial class AudioClient
         CreateSpeechGenerationOptions(text, voice, ref options);
 
         using BinaryContent content = options.ToBinaryContent();
-        ClientResult result = GenerateSpeechFromText(content, cancellationToken.ToRequestOptions()); ;
+        ClientResult result = GenerateSpeech(content, cancellationToken.ToRequestOptions()); ;
         return ClientResult.FromValue(result.GetRawResponse().Content, result.GetRawResponse());
     }
 

--- a/.dotnet/tests/Audio/TextToSpeechTests.cs
+++ b/.dotnet/tests/Audio/TextToSpeechTests.cs
@@ -23,8 +23,8 @@ public partial class TextToSpeechTests : SyncAsyncTestBase
         AudioClient client = GetTestClient<AudioClient>(TestScenario.Audio_TTS);
 
         BinaryData audio = IsAsync
-            ? await client.GenerateSpeechFromTextAsync("Hello, world! This is a test.", GeneratedSpeechVoice.Shimmer)
-            : client.GenerateSpeechFromText("Hello, world! This is a test.", GeneratedSpeechVoice.Shimmer);
+            ? await client.GenerateSpeechAsync("Hello, world! This is a test.", GeneratedSpeechVoice.Shimmer)
+            : client.GenerateSpeech("Hello, world! This is a test.", GeneratedSpeechVoice.Shimmer);
 
         Assert.That(audio, Is.Not.Null);
         ValidateGeneratedAudio(audio, "hello");
@@ -47,8 +47,8 @@ public partial class TextToSpeechTests : SyncAsyncTestBase
             : new() { ResponseFormat = responseFormat };
 
         BinaryData audio = IsAsync
-            ? await client.GenerateSpeechFromTextAsync("Hello, world!", GeneratedSpeechVoice.Alloy, options)
-            : client.GenerateSpeechFromText("Hello, world!", GeneratedSpeechVoice.Alloy, options);
+            ? await client.GenerateSpeechAsync("Hello, world!", GeneratedSpeechVoice.Alloy, options)
+            : client.GenerateSpeech("Hello, world!", GeneratedSpeechVoice.Alloy, options);
 
         Assert.That(audio, Is.Not.Null);
     }


### PR DESCRIPTION
Simplify the name of the `AudioClient`'s method.