### PR TITLE
Restore clean run-checks and make it run with CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,11 @@ jobs:
           SECRET_VALUE: ${{ secrets.OPENAI_TOKEN }}
         working-directory: .dotnet
 
+      - name: Run additional code checks
+        shell: pwsh
+        run: Run-Checks.ps1
+        working-directory: .scripts
+
       - name: Pack
         run: dotnet pack
           --no-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run additional code checks
         shell: pwsh
-        run: Run-Checks.ps1
+        run: ./Run-Checks.ps1
         working-directory: .scripts
 
       - name: Pack

--- a/.scripts/Run-Checks.ps1
+++ b/.scripts/Run-Checks.ps1
@@ -18,7 +18,8 @@ function Run-ModelsSubnamespaceCheck {
         "OpenAIModelInfo.cs",
         "OpenAIModelInfo.Serialization.cs",
         "OpenAIModelInfoCollection.cs",
-        "OpenAIModelInfoCollection.Serialization.cs"
+        "OpenAIModelInfoCollection.Serialization.cs",
+        "OpenAIModelsModelFactory.cs"
     )
 
     $failures = @()


### PR DESCRIPTION
Follow-up to:
#198

This PR didn't run the `Run-Checks.ps1` script (and why would it? there was no reason to) and thus missed that it tripped the exclusion-list-based "accidental things in `Models` namespace" check.

This change adds that new type and *also* makes `Run-Checks.ps1` run as part of the CI pipeline here on the dev mirror.