### PR TITLE
Update pagination method URIs for fine-tuning and batching

### DIFF
--- a/.dotnet/src/Custom/Batch/Internal/Pagination/BatchesPageEnumerator.cs
+++ b/.dotnet/src/Custom/Batch/Internal/Pagination/BatchesPageEnumerator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -89,7 +88,7 @@ internal partial class BatchesPageEnumerator : PageResultEnumerator
         request.Method = "GET";
         var uri = new ClientUriBuilder();
         uri.Reset(_endpoint);
-        uri.AppendPath("/batches", false);
+        uri.AppendPath("/v1/batches", false);
         if (after != null)
         {
             uri.AppendQuery("after", after, true);

--- a/.dotnet/src/Custom/FineTuning/Internal/Pagination/FineTuningJobCheckpointsPageEnumerator.cs
+++ b/.dotnet/src/Custom/FineTuning/Internal/Pagination/FineTuningJobCheckpointsPageEnumerator.cs
@@ -94,7 +94,7 @@ internal partial class FineTuningJobCheckpointsPageEnumerator : PageResultEnumer
         request.Method = "GET";
         var uri = new ClientUriBuilder();
         uri.Reset(_endpoint);
-        uri.AppendPath("/fine_tuning/jobs/", false);
+        uri.AppendPath("/v1/fine_tuning/jobs/", false);
         uri.AppendPath(fineTuningJobId, true);
         uri.AppendPath("/checkpoints", false);
         if (after != null)

--- a/.dotnet/src/Custom/FineTuning/Internal/Pagination/FineTuningJobEventsPageEnumerator.cs
+++ b/.dotnet/src/Custom/FineTuning/Internal/Pagination/FineTuningJobEventsPageEnumerator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -95,7 +94,7 @@ internal partial class FineTuningJobEventsPageEnumerator : PageResultEnumerator
         request.Method = "GET";
         var uri = new ClientUriBuilder();
         uri.Reset(_endpoint);
-        uri.AppendPath("/fine_tuning/jobs/", false);
+        uri.AppendPath("/v1/fine_tuning/jobs/", false);
         uri.AppendPath(fineTuningJobId, true);
         uri.AppendPath("/events", false);
         if (after != null)

--- a/.dotnet/src/Custom/FineTuning/Internal/Pagination/FineTuningJobsPageEnumerator.cs
+++ b/.dotnet/src/Custom/FineTuning/Internal/Pagination/FineTuningJobsPageEnumerator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -89,7 +88,7 @@ internal partial class FineTuningJobsPageEnumerator : PageResultEnumerator
         request.Method = "GET";
         var uri = new ClientUriBuilder();
         uri.Reset(_endpoint);
-        uri.AppendPath("/fine_tuning/jobs", false);
+        uri.AppendPath("/v1/fine_tuning/jobs", false);
         if (after != null)
         {
             uri.AppendQuery("after", after, true);


### PR DESCRIPTION
A change was made last week that removed the "v1" version path parameter from the default endpoint. This PR adds the "v1" parameter to the URI in fine-tuning and batching pagination operations.