### PR TITLE
Use Record<unknown> for non-metadata "object" extension maps (like file_search)

### DIFF
--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Bugs Fixed
 
+- Corrected an internal deserialization issue that caused recent updates to Assistants `file_search` to fail when streaming a run. Strongly typed support for `ranking_options` is not included but will arrive soon. (commit_hash)
+
 ### Other Changes
 
 - Reverted the removal of the version path parameter "v1" from the default endpoint URL. (commit_hash)

--- a/.dotnet/src/Generated/Models/InternalBatchRequestOutputResponse.cs
+++ b/.dotnet/src/Generated/Models/InternalBatchRequestOutputResponse.cs
@@ -12,10 +12,10 @@ namespace OpenAI.Batch
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
         internal InternalBatchRequestOutputResponse()
         {
-            Body = new ChangeTrackingDictionary<string, string>();
+            Body = new ChangeTrackingDictionary<string, BinaryData>();
         }
 
-        internal InternalBatchRequestOutputResponse(int? statusCode, string requestId, IReadOnlyDictionary<string, string> body, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal InternalBatchRequestOutputResponse(int? statusCode, string requestId, IReadOnlyDictionary<string, BinaryData> body, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             StatusCode = statusCode;
             RequestId = requestId;
@@ -25,6 +25,6 @@ namespace OpenAI.Batch
 
         public int? StatusCode { get; }
         public string RequestId { get; }
-        public IReadOnlyDictionary<string, string> Body { get; }
+        public IReadOnlyDictionary<string, BinaryData> Body { get; }
     }
 }

--- a/.dotnet/src/Generated/Models/InternalRunStepDeltaStepDetailsToolCallsFileSearchObject.Serialization.cs
+++ b/.dotnet/src/Generated/Models/InternalRunStepDeltaStepDetailsToolCallsFileSearchObject.Serialization.cs
@@ -38,7 +38,19 @@ namespace OpenAI.Assistants
                 foreach (var item in FileSearch)
                 {
                     writer.WritePropertyName(item.Key);
-                    writer.WriteStringValue(item.Value);
+                    if (item.Value == null)
+                    {
+                        writer.WriteNullValue();
+                        continue;
+                    }
+#if NET6_0_OR_GREATER
+				writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
                 }
                 writer.WriteEndObject();
             }
@@ -91,7 +103,7 @@ namespace OpenAI.Assistants
             }
             int index = default;
             string id = default;
-            IReadOnlyDictionary<string, string> fileSearch = default;
+            IReadOnlyDictionary<string, BinaryData> fileSearch = default;
             string type = default;
             IDictionary<string, BinaryData> serializedAdditionalRawData = default;
             Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
@@ -109,10 +121,17 @@ namespace OpenAI.Assistants
                 }
                 if (property.NameEquals("file_search"u8))
                 {
-                    Dictionary<string, string> dictionary = new Dictionary<string, string>();
+                    Dictionary<string, BinaryData> dictionary = new Dictionary<string, BinaryData>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        dictionary.Add(property0.Name, property0.Value.GetString());
+                        if (property0.Value.ValueKind == JsonValueKind.Null)
+                        {
+                            dictionary.Add(property0.Name, null);
+                        }
+                        else
+                        {
+                            dictionary.Add(property0.Name, BinaryData.FromString(property0.Value.GetRawText()));
+                        }
                     }
                     fileSearch = dictionary;
                     continue;

--- a/.dotnet/src/Generated/Models/InternalRunStepDeltaStepDetailsToolCallsFileSearchObject.cs
+++ b/.dotnet/src/Generated/Models/InternalRunStepDeltaStepDetailsToolCallsFileSearchObject.cs
@@ -9,7 +9,7 @@ namespace OpenAI.Assistants
 {
     internal partial class InternalRunStepDeltaStepDetailsToolCallsFileSearchObject : InternalRunStepDeltaStepDetailsToolCallsObjectToolCallsObject
     {
-        internal InternalRunStepDeltaStepDetailsToolCallsFileSearchObject(int index, IReadOnlyDictionary<string, string> fileSearch)
+        internal InternalRunStepDeltaStepDetailsToolCallsFileSearchObject(int index, IReadOnlyDictionary<string, BinaryData> fileSearch)
         {
             Argument.AssertNotNull(fileSearch, nameof(fileSearch));
 
@@ -18,7 +18,7 @@ namespace OpenAI.Assistants
             FileSearch = fileSearch;
         }
 
-        internal InternalRunStepDeltaStepDetailsToolCallsFileSearchObject(string type, IDictionary<string, BinaryData> serializedAdditionalRawData, int index, string id, IReadOnlyDictionary<string, string> fileSearch) : base(type, serializedAdditionalRawData)
+        internal InternalRunStepDeltaStepDetailsToolCallsFileSearchObject(string type, IDictionary<string, BinaryData> serializedAdditionalRawData, int index, string id, IReadOnlyDictionary<string, BinaryData> fileSearch) : base(type, serializedAdditionalRawData)
         {
             Index = index;
             Id = id;
@@ -31,6 +31,6 @@ namespace OpenAI.Assistants
 
         public int Index { get; }
         public string Id { get; }
-        public IReadOnlyDictionary<string, string> FileSearch { get; }
+        public IReadOnlyDictionary<string, BinaryData> FileSearch { get; }
     }
 }

--- a/.dotnet/src/Generated/Models/InternalRunStepFileSearchToolCallDetails.cs
+++ b/.dotnet/src/Generated/Models/InternalRunStepFileSearchToolCallDetails.cs
@@ -9,7 +9,7 @@ namespace OpenAI.Assistants
 {
     internal partial class InternalRunStepFileSearchToolCallDetails : RunStepToolCall
     {
-        internal InternalRunStepFileSearchToolCallDetails(string id, IReadOnlyDictionary<string, string> fileSearch)
+        internal InternalRunStepFileSearchToolCallDetails(string id, IReadOnlyDictionary<string, BinaryData> fileSearch)
         {
             Argument.AssertNotNull(id, nameof(id));
             Argument.AssertNotNull(fileSearch, nameof(fileSearch));
@@ -19,7 +19,7 @@ namespace OpenAI.Assistants
             FileSearch = fileSearch;
         }
 
-        internal InternalRunStepFileSearchToolCallDetails(string type, IDictionary<string, BinaryData> serializedAdditionalRawData, string id, IReadOnlyDictionary<string, string> fileSearch) : base(type, serializedAdditionalRawData)
+        internal InternalRunStepFileSearchToolCallDetails(string type, IDictionary<string, BinaryData> serializedAdditionalRawData, string id, IReadOnlyDictionary<string, BinaryData> fileSearch) : base(type, serializedAdditionalRawData)
         {
             Id = id;
             FileSearch = fileSearch;
@@ -30,6 +30,6 @@ namespace OpenAI.Assistants
         }
 
         public string Id { get; }
-        public IReadOnlyDictionary<string, string> FileSearch { get; }
+        public IReadOnlyDictionary<string, BinaryData> FileSearch { get; }
     }
 }

--- a/.openapi3/openapi3-openai.yaml
+++ b/.openapi3/openapi3-openai.yaml
@@ -2879,8 +2879,7 @@ components:
               description: An unique identifier for the OpenAI API request. Please include this request ID when contacting support.
             body:
               type: object
-              additionalProperties:
-                type: string
+              additionalProperties: {}
               description: The JSON body of the response
               x-oaiTypeLabel: map
           nullable: true
@@ -8261,8 +8260,7 @@ components:
           description: The type of tool call. This is always going to be `file_search` for this type of tool call.
         file_search:
           type: object
-          additionalProperties:
-            type: string
+          additionalProperties: {}
           description: For now, this is always going to be an empty object.
           x-oaiTypeLabel: map
       allOf:
@@ -8460,8 +8458,7 @@ components:
           description: The type of tool call. This is always going to be `file_search` for this type of tool call.
         file_search:
           type: object
-          additionalProperties:
-            type: string
+          additionalProperties: {}
           description: For now, this is always going to be an empty object.
           x-oaiTypeLabel: map
       allOf:

--- a/.typespec/assistants/models.tsp
+++ b/.typespec/assistants/models.tsp
@@ -92,6 +92,7 @@ model CreateAssistantRequest {
     file_search?: ToolResourcesFileSearch;
   } | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -153,6 +154,7 @@ model ModifyAssistantRequest {
     file_search?: ToolResourcesFileSearchIdsOnly;
   } | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -291,6 +293,7 @@ model AssistantObject {
     file_search?: ToolResourcesFileSearchIdsOnly;
   } | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata: Record<string> | null;

--- a/.typespec/batch/models.tsp
+++ b/.typespec/batch/models.tsp
@@ -120,6 +120,7 @@ model Batch {
     failed: int32;
   };
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -158,7 +159,7 @@ model BatchRequestOutput {
 
     /** The JSON body of the response */
     @extension("x-oaiTypeLabel", "map")
-    body?: Record<string>;
+    body?: Record<unknown>;
   } | null;
 
   /** For requests that failed with a non-HTTP error, this will contain more information on the cause of the failure. */

--- a/.typespec/messages/models.tsp
+++ b/.typespec/messages/models.tsp
@@ -47,12 +47,14 @@ model CreateMessageRequest {
   /** A list of files attached to the message, and the tools they should be added to. */
   attachments?: CreateMessageRequestAttachments | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
 }
 
 model ModifyMessageRequest {
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -139,6 +141,7 @@ model MessageObject {
   /** A list of files attached to the message, and the tools they were added to. */
   attachments: MessageObjectAttachments | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata: Record<string> | null;

--- a/.typespec/runs/models.tsp
+++ b/.typespec/runs/models.tsp
@@ -71,6 +71,7 @@ model CreateRunRequest {
   /** Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis. */
   tools?: CreateRunRequestTools | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -113,6 +114,7 @@ model CreateRunRequest {
 }
 
 model ModifyRunRequest {
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -177,6 +179,7 @@ model CreateThreadAndRunRequest {
     file_search?: ToolResourcesFileSearchIdsOnly;
   } | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -352,7 +355,7 @@ model RunStepDetailsToolCallsFileSearchObject
 
   /** For now, this is always going to be an empty object. */
   @extension("x-oaiTypeLabel", "map")
-  file_search: Record<string>;
+  file_search: Record<unknown>;
 }
 
 // Tool customization: apply custom, common base type to union items
@@ -518,6 +521,7 @@ model RunObject {
   @extension("x-oaiExpandable", true)
   tools: AssistantToolDefinition[] = #[];
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata: Record<string> | null;
@@ -616,6 +620,7 @@ model RunStepObject {
   @encode("unixTimestamp", int32)
   completed_at: utcDateTime | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata: Record<string> | null;
@@ -771,7 +776,7 @@ model RunStepDeltaStepDetailsToolCallsFileSearchObject
 
   /** For now, this is always going to be an empty object. */
   @extension("x-oaiTypeLabel", "map")
-  file_search: Record<string>;
+  file_search: Record<unknown>;
 }
 
 // Tool customization: apply custom, common base type to union items

--- a/.typespec/threads/models.tsp
+++ b/.typespec/threads/models.tsp
@@ -30,6 +30,7 @@ model CreateThreadRequest {
     file_search?: ToolResourcesFileSearch;
   } | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -52,6 +53,7 @@ model ModifyThreadRequest {
     file_search?: ToolResourcesFileSearchIdsOnly;
   } | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -96,6 +98,7 @@ model ThreadObject {
     };
   } | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata: Record<string> | null;

--- a/.typespec/vector-stores/models.tsp
+++ b/.typespec/vector-stores/models.tsp
@@ -79,6 +79,7 @@ model VectorStoreObject {
   @encode("unixTimestamp", int32)
   last_active_at: utcDateTime | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata: Record<string> | null;
@@ -102,6 +103,7 @@ model CreateVectorStoreRequest {
   @extension("x-oaiExpandable", true)
   chunking_strategy?: AutoChunkingStrategyRequestParam | StaticChunkingStrategyRequestParam;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;
@@ -113,6 +115,7 @@ model UpdateVectorStoreRequest {
 
   expires_after?: VectorStoreExpirationAfter | null;
 
+  // Tool customization: specialize known metadata string maps
   /** Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long. */
   @extension("x-oaiTypeLabel", "map")
   metadata?: Record<string> | null;


### PR DESCRIPTION
Changes were made via the ingestion tool.
- The application of the `x-oaiTypeLabel = map` attribute now results in otherwise unspecified types being `Record<unknown>` instead of `Record<object>`.
- `metadata`, a known `Record<string>` and the reason why the rule was the way it was, is special-cased with a straightforward, pattern-checked replacement
- Repro test case included for before/after with `file_search`