### PR TITLE
Remove the usage of required modifier

### DIFF
--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -374,7 +374,7 @@ namespace OpenAI.Assistants {
         public FunctionToolDefinition();
         public FunctionToolDefinition(string name);
         public string Description { get; set; }
-        public required string FunctionName { get; set; }
+        public string FunctionName { get; set; }
         public BinaryData Parameters { get; set; }
         public bool? StrictParameterSchemaEnabled { get; set; }
         FunctionToolDefinition IJsonModel<FunctionToolDefinition>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
@@ -2299,8 +2299,8 @@ namespace OpenAI.VectorStores {
     public class VectorStoreExpirationPolicy : IJsonModel<VectorStoreExpirationPolicy>, IPersistableModel<VectorStoreExpirationPolicy> {
         public VectorStoreExpirationPolicy();
         public VectorStoreExpirationPolicy(VectorStoreExpirationAnchor anchor, int days);
-        public required VectorStoreExpirationAnchor Anchor { get; set; }
-        public required int Days { get; set; }
+        public VectorStoreExpirationAnchor Anchor { get; set; }
+        public int Days { get; set; }
         VectorStoreExpirationPolicy IJsonModel<VectorStoreExpirationPolicy>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<VectorStoreExpirationPolicy>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         VectorStoreExpirationPolicy IPersistableModel<VectorStoreExpirationPolicy>.Create(BinaryData data, ModelReaderWriterOptions options);

--- a/.dotnet/src/Custom/Assistants/FunctionToolDefinition.cs
+++ b/.dotnet/src/Custom/Assistants/FunctionToolDefinition.cs
@@ -15,7 +15,7 @@ public partial class FunctionToolDefinition : ToolDefinition
     private readonly InternalFunctionDefinition _internalFunction;
 
     /// <inheritdoc cref="InternalFunctionDefinition.Name"/>
-    public required string FunctionName
+    public string FunctionName
     {
         get => _internalFunction.Name;
         set => _internalFunction.Name = value;

--- a/.dotnet/src/Custom/VectorStores/VectorStoreExpirationPolicy.cs
+++ b/.dotnet/src/Custom/VectorStores/VectorStoreExpirationPolicy.cs
@@ -22,14 +22,14 @@ public partial class VectorStoreExpirationPolicy
     private int _days;
 
     /// <summary> Anchor timestamp after which the expiration policy applies. Supported anchors: `last_active_at`. </summary>
-    public required VectorStoreExpirationAnchor Anchor
+    public VectorStoreExpirationAnchor Anchor
     {
         get => _anchor;
         set => _anchor = value;
     }
 
     /// <summary> The number of days after the anchor time that the vector store will expire. </summary>
-    public required int Days
+    public int Days
     {
         get => _days;
         set => _days = value;


### PR DESCRIPTION
This PR removes the use of the `required` modifier as it is not necessary. According to the guidelines, the constructor should take the required parameters.