### PR TITLE
Fine Tuning: pagination fixes from AOAI

### DIFF
--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.0.0-beta.12 (Unreleased)
+
+### Bugs Fixed
+
+- Addressed an issue that caused multi-page queries of fine-tuning jobs, checkpoints, and events to fail. (commit_hash)
+
 ## 2.0.0-beta.11 (2024-09-03)
 
 ### Features Added

--- a/.dotnet/src/Custom/FineTuning/Internal/Pagination/FineTuningJobCheckpointsPageEnumerator.cs
+++ b/.dotnet/src/Custom/FineTuning/Internal/Pagination/FineTuningJobCheckpointsPageEnumerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -17,7 +18,7 @@ internal partial class FineTuningJobCheckpointsPageEnumerator : PageResultEnumer
     private readonly int? _limit;
     private readonly RequestOptions _options;
 
-    private string _after;
+    private string? _after;
 
     public FineTuningJobCheckpointsPageEnumerator(
         ClientPipeline pipeline,
@@ -35,29 +36,39 @@ internal partial class FineTuningJobCheckpointsPageEnumerator : PageResultEnumer
     }
 
     public override async Task<ClientResult> GetFirstAsync()
-        => await GetJobCheckpointsAsync(_jobId, _after, _limit, _options).ConfigureAwait(false);
+        => await GetJobCheckpointsAsync(_jobId, _after!, _limit, _options).ConfigureAwait(false);
 
     public override ClientResult GetFirst()
-        => GetJobCheckpoints(_jobId, _after, _limit, _options);
+        => GetJobCheckpoints(_jobId, _after!, _limit, _options);
 
     public override async Task<ClientResult> GetNextAsync(ClientResult result)
     {
         PipelineResponse response = result.GetRawResponse();
 
-        using JsonDocument doc = JsonDocument.Parse(response.Content);
-        _after = doc.RootElement.GetProperty("last_id"u8).GetString()!;
+        using JsonDocument doc = JsonDocument.Parse(response?.Content);
 
-        return await GetJobCheckpointsAsync(_jobId, _after, _limit, _options).ConfigureAwait(false);
+        if (doc?.RootElement.TryGetProperty("data", out JsonElement dataElement) == true
+            && dataElement.EnumerateArray().LastOrDefault().TryGetProperty("id", out JsonElement idElement) == true)
+        {
+            _after = idElement.GetString();
+        }
+
+        return await GetJobCheckpointsAsync(_jobId, _after!, _limit, _options).ConfigureAwait(false);
     }
 
     public override ClientResult GetNext(ClientResult result)
     {
         PipelineResponse response = result.GetRawResponse();
 
-        using JsonDocument doc = JsonDocument.Parse(response.Content);
-        _after = doc.RootElement.GetProperty("last_id"u8).GetString()!;
+        using JsonDocument doc = JsonDocument.Parse(response?.Content);
 
-        return GetJobCheckpoints(_jobId, _after, _limit, _options);
+        if (doc?.RootElement.TryGetProperty("data", out JsonElement dataElement) == true
+            && dataElement.EnumerateArray().LastOrDefault().TryGetProperty("id", out JsonElement idElement) == true)
+        {
+            _after = idElement.GetString();
+        }
+
+        return GetJobCheckpoints(_jobId, _after!, _limit, _options);
     }
 
     public override bool HasNext(ClientResult result)


### PR DESCRIPTION
Fine Tuning APIs do not return the same parent pagination cursor information that newer APIs do; there's no `last_id` on the list response.

[Example recorded test traffic (AOAI) for reference](https://github.com/Azure/azure-sdk-assets/blob/23ae923738880b66ae7350f9e6afcfa13f594184/net/sdk/openai/Azure.AI.OpenAI/tests/SessionRecords/FineTuningTests/JobsFineTuning.json#L25)

Instead, the "last ID" must be manually retrieved from the last element of the `data` array, using the `id` property of that element.

This PR introduces that fix.