### PR TITLE
Suppress extra `Created` property in favor of `CreatedAt`

### DIFF
--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Removed the optional parameter from the constructors of `VectorStoreCreationHelper`, `AssistantChatMessage`, and `ChatFunction`. (commit_hash)
 - Removed the optional `purpose` parameter from `FileClient.GetFilesAsync` and `FileClient.GetFiles` methods, and added overloads where `purpose` is required. (commit_hash)
 - Renamed `ModerationClient`'s `ClassifyTextInput` methods to `ClassifyText`. (commit_hash)
+- Removed duplicated `Created` property from `GeneratedImageCollection`. (commit_hash)
 
 ### Bugs Fixed
 

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -1939,7 +1939,6 @@ namespace OpenAI.Images {
         BinaryData IPersistableModel<GeneratedImage>.Write(ModelReaderWriterOptions options);
     }
     public class GeneratedImageCollection : ObjectModel.ReadOnlyCollection<GeneratedImage>, IJsonModel<GeneratedImageCollection>, IPersistableModel<GeneratedImageCollection> {
-        public DateTimeOffset Created { get; }
         public DateTimeOffset CreatedAt { get; }
         GeneratedImageCollection IJsonModel<GeneratedImageCollection>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<GeneratedImageCollection>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);

--- a/.dotnet/src/Custom/Images/GeneratedImageCollection.cs
+++ b/.dotnet/src/Custom/Images/GeneratedImageCollection.cs
@@ -9,6 +9,7 @@ namespace OpenAI.Images;
 /// </summary>
 [CodeGenModel("ImagesResponse")]
 [CodeGenSuppress("Data")]
+[CodeGenSuppress("Created")]
 [CodeGenSuppress(nameof(GeneratedImageCollection))]
 [CodeGenSuppress(nameof(GeneratedImageCollection), typeof(DateTimeOffset), typeof(IReadOnlyList<GeneratedImage>))]
 public partial class GeneratedImageCollection : ReadOnlyCollection<GeneratedImage>

--- a/.dotnet/src/Generated/Models/GeneratedImageCollection.cs
+++ b/.dotnet/src/Generated/Models/GeneratedImageCollection.cs
@@ -11,6 +11,5 @@ namespace OpenAI.Images
 {
     public partial class GeneratedImageCollection : ReadOnlyCollection<GeneratedImage>
     {
-        public DateTimeOffset Created { get; }
     }
 }


### PR DESCRIPTION
CodeGen refuses to rename the `Created` property of `GeneratedImageCollection` to "CreatedAt", so we ended up with two properties. To fix this, I'm directly suppressing the `Created` property, which CodeGen appears to be okay with.