### PR TITLE
Making the Uploads API public

### DIFF
--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Added support for the Uploads API in `FileClient`. This `Experimental` feature allows uploading large files in multiple parts.
+  - The feature is supported by the `CreateUpload`, `AddUploadPart`, `CompleteUpload`, and `CancelUpload` protocol methods.
+
 ### Breaking Changes
 
 - Renamed `ChatMessageContentPart`'s `CreateTextMessageContentPart` factory method to `CreateTextPart`.

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -1668,6 +1668,14 @@ namespace OpenAI.Files {
         public FileClient(ApiKeyCredential credential);
         protected internal FileClient(ClientPipeline pipeline, OpenAIClientOptions options);
         public virtual ClientPipeline Pipeline { get; }
+        public virtual ClientResult AddUploadPart(string uploadId, BinaryContent content, string contentType, RequestOptions options = null);
+        public virtual Task<ClientResult> AddUploadPartAsync(string uploadId, BinaryContent content, string contentType, RequestOptions options = null);
+        public virtual ClientResult CancelUpload(string uploadId, RequestOptions options = null);
+        public virtual Task<ClientResult> CancelUploadAsync(string uploadId, RequestOptions options = null);
+        public virtual ClientResult CompleteUpload(string uploadId, BinaryContent content, RequestOptions options = null);
+        public virtual Task<ClientResult> CompleteUploadAsync(string uploadId, BinaryContent content, RequestOptions options = null);
+        public virtual ClientResult CreateUpload(BinaryContent content, RequestOptions options = null);
+        public virtual Task<ClientResult> CreateUploadAsync(BinaryContent content, RequestOptions options = null);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult DeleteFile(string fileId, RequestOptions options);
         public virtual ClientResult<bool> DeleteFile(string fileId, CancellationToken cancellationToken = default);

--- a/.dotnet/src/Custom/Files/FileClient.Protocol.cs
+++ b/.dotnet/src/Custom/Files/FileClient.Protocol.cs
@@ -2,6 +2,7 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace OpenAI.Files;
@@ -208,5 +209,53 @@ public partial class FileClient
 
         using PipelineMessage message = CreateDownloadFileRequest(fileId, options);
         return ClientResult.FromResponse(_pipeline.ProcessMessage(message, options));
+    }
+
+    [Experimental("OPENAI001")]
+    public virtual async Task<ClientResult> CreateUploadAsync(BinaryContent content, RequestOptions options = null)
+    {
+        return await _internalUploadsClient.CreateUploadAsync(content, options).ConfigureAwait(false);
+    }
+
+    [Experimental("OPENAI001")]
+    public virtual ClientResult CreateUpload(BinaryContent content, RequestOptions options = null)
+    {
+        return _internalUploadsClient.CreateUpload(content, options);
+    }
+
+    [Experimental("OPENAI001")]
+    public virtual async Task<ClientResult> AddUploadPartAsync(string uploadId, BinaryContent content, string contentType, RequestOptions options = null)
+    {
+        return await _internalUploadsClient.AddUploadPartAsync(uploadId, content, contentType, options).ConfigureAwait(false);
+    }
+
+    [Experimental("OPENAI001")]
+    public virtual ClientResult AddUploadPart(string uploadId, BinaryContent content, string contentType, RequestOptions options = null)
+    {
+        return _internalUploadsClient.AddUploadPart(uploadId, content, contentType, options);
+    }
+
+    [Experimental("OPENAI001")]
+    public virtual async Task<ClientResult> CompleteUploadAsync(string uploadId, BinaryContent content, RequestOptions options = null)
+    {
+        return await _internalUploadsClient.CompleteUploadAsync(uploadId, content, options).ConfigureAwait(false);
+    }
+
+    [Experimental("OPENAI001")]
+    public virtual ClientResult CompleteUpload(string uploadId, BinaryContent content, RequestOptions options = null)
+    {
+        return _internalUploadsClient.CompleteUpload(uploadId, content, options);
+    }
+
+    [Experimental("OPENAI001")]
+    public virtual async Task<ClientResult> CancelUploadAsync(string uploadId, RequestOptions options = null)
+    {
+        return await _internalUploadsClient.CancelUploadAsync(uploadId, options).ConfigureAwait(false);
+    }
+
+    [Experimental("OPENAI001")]
+    public virtual ClientResult CancelUpload(string uploadId, RequestOptions options = null)
+    {
+        return _internalUploadsClient.CancelUpload(uploadId, options);
     }
 }

--- a/.dotnet/src/Custom/Files/FileClient.Protocol.cs
+++ b/.dotnet/src/Custom/Files/FileClient.Protocol.cs
@@ -211,48 +211,126 @@ public partial class FileClient
         return ClientResult.FromResponse(_pipeline.ProcessMessage(message, options));
     }
 
+    /// <summary>
+    /// [Protocol Method] Creates an intermediate upload to which data can be added in chunks of bytes. An upload
+    /// can accept at most 8 GB in total and expires an hour after it is created.
+    /// </summary>
+    /// <param name="content"> The content to send as the body of the request. </param>
+    /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The response returned from the service. </returns>
     [Experimental("OPENAI001")]
     public virtual async Task<ClientResult> CreateUploadAsync(BinaryContent content, RequestOptions options = null)
     {
         return await _internalUploadsClient.CreateUploadAsync(content, options).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// [Protocol Method] Creates an intermediate upload to which data can be added in chunks of bytes. An upload
+    /// can accept at most 8 GB in total and expires an hour after it is created.
+    /// </summary>
+    /// <param name="content"> The content to send as the body of the request. </param>
+    /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The response returned from the service. </returns>
     [Experimental("OPENAI001")]
     public virtual ClientResult CreateUpload(BinaryContent content, RequestOptions options = null)
     {
         return _internalUploadsClient.CreateUpload(content, options);
     }
 
+    /// <summary>
+    /// [Protocol Method] Adds a chunk of bytes to an existing upload. Each part can contain at most 64 MB, while the
+    /// upload can accept at most 8 GB in total.
+    /// </summary>
+    /// <param name="uploadId"> The ID of the upload. </param>
+    /// <param name="content"> The content to send as the body of the request. </param>
+    /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="uploadId"> or <paramref name="content"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="uploadId"/> is an empty string, and was expected to be non-empty. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The response returned from the service. </returns>
     [Experimental("OPENAI001")]
     public virtual async Task<ClientResult> AddUploadPartAsync(string uploadId, BinaryContent content, string contentType, RequestOptions options = null)
     {
         return await _internalUploadsClient.AddUploadPartAsync(uploadId, content, contentType, options).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// [Protocol Method] Adds a chunk of bytes to an existing upload. Each part can contain at most 64 MB, while the
+    /// upload can accept at most 8 GB in total.
+    /// </summary>
+    /// <param name="uploadId"> The ID of the upload. </param>
+    /// <param name="content"> The content to send as the body of the request. </param>
+    /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="uploadId"> or <paramref name="content"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="uploadId"/> is an empty string, and was expected to be non-empty. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The response returned from the service. </returns>
     [Experimental("OPENAI001")]
     public virtual ClientResult AddUploadPart(string uploadId, BinaryContent content, string contentType, RequestOptions options = null)
     {
         return _internalUploadsClient.AddUploadPart(uploadId, content, contentType, options);
     }
 
+    /// <summary>
+    /// [Protocol Method] Completes an existing upload, creating a file ready to use.
+    /// </summary>
+    /// <param name="uploadId"> The ID of the upload. </param>
+    /// <param name="content"> The content to send as the body of the request. </param>
+    /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="uploadId"> or <paramref name="content"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="uploadId"/> is an empty string, and was expected to be non-empty. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The response returned from the service. </returns>
     [Experimental("OPENAI001")]
     public virtual async Task<ClientResult> CompleteUploadAsync(string uploadId, BinaryContent content, RequestOptions options = null)
     {
         return await _internalUploadsClient.CompleteUploadAsync(uploadId, content, options).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// [Protocol Method] Completes an existing upload, creating a file ready to use.
+    /// </summary>
+    /// <param name="uploadId"> The ID of the upload. </param>
+    /// <param name="content"> The content to send as the body of the request. </param>
+    /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="uploadId"> or <paramref name="content"/> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="uploadId"/> is an empty string, and was expected to be non-empty. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The response returned from the service. </returns>
     [Experimental("OPENAI001")]
     public virtual ClientResult CompleteUpload(string uploadId, BinaryContent content, RequestOptions options = null)
     {
         return _internalUploadsClient.CompleteUpload(uploadId, content, options);
     }
 
+    /// <summary>
+    /// [Protocol Method] Cancels an existing upload.
+    /// </summary>
+    /// <param name="uploadId"> The ID of the upload. </param>
+    /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="uploadId"> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="uploadId"/> is an empty string, and was expected to be non-empty. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The response returned from the service. </returns>
     [Experimental("OPENAI001")]
     public virtual async Task<ClientResult> CancelUploadAsync(string uploadId, RequestOptions options = null)
     {
         return await _internalUploadsClient.CancelUploadAsync(uploadId, options).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// [Protocol Method] Cancels an existing upload.
+    /// </summary>
+    /// <param name="uploadId"> The ID of the upload. </param>
+    /// <param name="options"> The request options, which can override default behaviors of the client pipeline on a per-call basis. </param>
+    /// <exception cref="ArgumentNullException"> <paramref name="uploadId"> is null. </exception>
+    /// <exception cref="ArgumentException"> <paramref name="uploadId"/> is an empty string, and was expected to be non-empty. </exception>
+    /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
+    /// <returns> The response returned from the service. </returns>
     [Experimental("OPENAI001")]
     public virtual ClientResult CancelUpload(string uploadId, RequestOptions options = null)
     {

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -51,6 +51,7 @@ public partial class FileClient
 
         _pipeline = OpenAIClient.CreatePipeline(credential, options);
         _endpoint = OpenAIClient.GetEndpoint(options);
+        _internalUploadsClient = new(_pipeline, options);
     }
 
     // CUSTOM:

--- a/.dotnet/tests/Files/FileTests.Uploads.cs
+++ b/.dotnet/tests/Files/FileTests.Uploads.cs
@@ -1,0 +1,242 @@
+﻿using System;
+using System.ClientModel;
+using System.Text.Json;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OpenAI.Files;
+using OpenAI.Tests.Utility;
+
+namespace OpenAI.Tests.Files;
+
+public partial class FileTests : SyncAsyncTestBase
+{
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task CreateUploadWorks(bool useTopLevelClient)
+    {
+        // Test with the top-level client as well to validate that both FileClient constructors
+        // are setting the internal Uploads client correctly.
+
+        FileClient fileClient = useTopLevelClient
+            ? TestHelpers.GetTestTopLevelClient().GetFileClient()
+            : GetTestClient();
+        BinaryContent content = BinaryContent.Create(BinaryData.FromObjectAsJson(new
+        {
+            purpose = "fine-tune",
+            filename = "uploads_test_file.jsonl",
+            bytes = 8,
+            mime_type = "text/jsonl"
+        }));
+
+        ClientResult result = IsAsync
+            ? await fileClient.CreateUploadAsync(content)
+            : fileClient.CreateUpload(content);
+
+        BinaryData response = result.GetRawResponse().Content;
+        using JsonDocument jsonDocument = JsonDocument.Parse(response);
+        UploadDetails uploadDetails = GetUploadDetails(jsonDocument);
+
+        long unixTime2024 = (new DateTimeOffset(2024, 01, 01, 0, 0, 0, TimeSpan.Zero)).ToUnixTimeSeconds();
+
+        Assert.That(uploadDetails.Id, Does.StartWith("upload_"));
+        Assert.That(uploadDetails.Object, Is.EqualTo("upload"));
+        Assert.That(uploadDetails.Bytes, Is.EqualTo(8));
+        Assert.That(uploadDetails.CreatedAt, Is.GreaterThan(unixTime2024));
+        Assert.That(uploadDetails.Filename, Is.EqualTo("uploads_test_file.jsonl"));
+        Assert.That(uploadDetails.Purpose, Is.EqualTo("fine-tune"));
+        Assert.That(uploadDetails.Status, Is.EqualTo("pending"));
+        Assert.That(uploadDetails.ExpiresAt, Is.GreaterThan(uploadDetails.CreatedAt));
+    }
+
+    [Test]
+    public async Task AddUploadPartWorks()
+    {
+        FileClient fileClient = GetTestClient();
+        UploadDetails uploadDetails = await CreateTestUploadAsync(fileClient);
+        using MultipartFormDataBinaryContent content = new();
+
+        content.Add([1, 2, 3, 4], "data", "data", "application/octet-stream");
+
+        ClientResult result = IsAsync
+            ? await fileClient.AddUploadPartAsync(uploadDetails.Id, content, content.ContentType)
+            : fileClient.AddUploadPart(uploadDetails.Id, content, content.ContentType);
+
+        BinaryData response = result.GetRawResponse().Content;
+        using JsonDocument jsonDocument = JsonDocument.Parse(response);
+        UploadPartDetails uploadPartDetails = GetUploadPartDetails(jsonDocument);
+
+        Assert.That(uploadPartDetails.Id, Does.StartWith("part_"));
+        Assert.That(uploadPartDetails.Object, Is.EqualTo("upload.part"));
+        Assert.That(uploadPartDetails.CreatedAt, Is.GreaterThanOrEqualTo(uploadDetails.CreatedAt));
+        Assert.That(uploadPartDetails.UploadId, Is.EqualTo(uploadDetails.Id));
+    }
+
+    [Test]
+    public async Task CompleteUploadWorks()
+    {
+        FileClient fileClient = GetTestClient();
+        UploadDetails createdUploadDetails = await CreateTestUploadAsync(fileClient);
+        using MultipartFormDataBinaryContent firstPartContent = new();
+        using MultipartFormDataBinaryContent secondPartContent = new();
+
+        firstPartContent.Add([1, 2, 3, 4], "data", "data", "application/octet-stream");
+        secondPartContent.Add([5, 6, 7, 8], "data", "data", "application/octet-stream");
+
+        UploadPartDetails firstPartDetails = await AddTestUploadPartAsync(fileClient, createdUploadDetails.Id, firstPartContent);
+        UploadPartDetails secondPartDetails = await AddTestUploadPartAsync(fileClient, createdUploadDetails.Id, secondPartContent);
+
+        BinaryContent content = BinaryContent.Create(BinaryData.FromObjectAsJson(new
+        {
+            part_ids = new[] {
+                firstPartDetails.Id,
+                secondPartDetails.Id
+            }
+        }));
+
+        ClientResult result = IsAsync
+            ? await fileClient.CompleteUploadAsync(createdUploadDetails.Id, content)
+            : fileClient.CompleteUpload(createdUploadDetails.Id, content);
+
+        BinaryData response = result.GetRawResponse().Content;
+        using JsonDocument jsonDocument = JsonDocument.Parse(response);
+        JsonElement fileElement = jsonDocument.RootElement.GetProperty("file");
+        string fileId = fileElement.GetProperty("id").GetString();
+
+        await fileClient.DeleteFileAsync(fileId);
+
+        UploadDetails completedUploadDetails = GetUploadDetails(jsonDocument);
+
+        Assert.That(completedUploadDetails.Id, Is.EqualTo(createdUploadDetails.Id));
+        Assert.That(completedUploadDetails.Object, Is.EqualTo(createdUploadDetails.Object));
+        Assert.That(completedUploadDetails.Bytes, Is.EqualTo(createdUploadDetails.Bytes));
+        Assert.That(completedUploadDetails.CreatedAt, Is.EqualTo(createdUploadDetails.CreatedAt));
+        Assert.That(completedUploadDetails.Filename, Is.EqualTo(createdUploadDetails.Filename));
+        Assert.That(completedUploadDetails.Purpose, Is.EqualTo(createdUploadDetails.Purpose));
+        Assert.That(completedUploadDetails.Status, Is.EqualTo("completed"));
+        Assert.That(completedUploadDetails.ExpiresAt, Is.EqualTo(createdUploadDetails.ExpiresAt));
+
+        string fileObject = fileElement.GetProperty("object").GetString();
+        int fileBytes = fileElement.GetProperty("bytes").GetInt32();
+        long fileCreatedAt = fileElement.GetProperty("created_at").GetInt64();
+        string filename = fileElement.GetProperty("filename").GetString();
+        string filePurpose = fileElement.GetProperty("purpose").GetString();
+
+        Assert.That(fileId, Does.StartWith("file-"));
+        Assert.That(fileObject, Is.EqualTo("file"));
+        Assert.That(fileBytes, Is.EqualTo(createdUploadDetails.Bytes));
+        Assert.That(fileCreatedAt, Is.GreaterThanOrEqualTo(createdUploadDetails.CreatedAt));
+        Assert.That(filename, Is.EqualTo(createdUploadDetails.Filename));
+        Assert.That(filePurpose, Is.EqualTo(createdUploadDetails.Purpose));
+    }
+
+    [Test]
+    public async Task CancelUploadWorks()
+    {
+        FileClient fileClient = GetTestClient();
+        UploadDetails createdUploadDetails = await CreateTestUploadAsync(fileClient);
+
+        ClientResult result = IsAsync
+            ? await fileClient.CancelUploadAsync(createdUploadDetails.Id)
+            : fileClient.CancelUpload(createdUploadDetails.Id);
+
+        BinaryData response = result.GetRawResponse().Content;
+        using JsonDocument jsonDocument = JsonDocument.Parse(response);
+        UploadDetails canceledUploadDetails = GetUploadDetails(jsonDocument);
+
+        Assert.That(canceledUploadDetails.Id, Is.EqualTo(createdUploadDetails.Id));
+        Assert.That(canceledUploadDetails.Object, Is.EqualTo(createdUploadDetails.Object));
+        Assert.That(canceledUploadDetails.Bytes, Is.EqualTo(createdUploadDetails.Bytes));
+        Assert.That(canceledUploadDetails.CreatedAt, Is.EqualTo(createdUploadDetails.CreatedAt));
+        Assert.That(canceledUploadDetails.Filename, Is.EqualTo(createdUploadDetails.Filename));
+        Assert.That(canceledUploadDetails.Purpose, Is.EqualTo(createdUploadDetails.Purpose));
+        Assert.That(canceledUploadDetails.Status, Is.EqualTo("cancelled"));
+        Assert.That(canceledUploadDetails.ExpiresAt, Is.EqualTo(createdUploadDetails.ExpiresAt));
+    }
+
+    private async Task<UploadDetails> CreateTestUploadAsync(FileClient fileClient)
+    {
+        BinaryContent content = BinaryContent.Create(BinaryData.FromObjectAsJson(new
+        {
+            purpose = "fine-tune",
+            filename = "uploads_test_file" + Guid.NewGuid() + ".jsonl",
+            bytes = 8,
+            mime_type = "text/jsonl"
+        }));
+
+        ClientResult result = await fileClient.CreateUploadAsync(content);
+        BinaryData response = result.GetRawResponse().Content;
+        using JsonDocument jsonDocument = JsonDocument.Parse(response);
+
+        return GetUploadDetails(jsonDocument);
+    }
+
+    private async Task<UploadPartDetails> AddTestUploadPartAsync(FileClient fileClient, string uploadId, MultipartFormDataBinaryContent content)
+    {
+        ClientResult result = await fileClient.AddUploadPartAsync(uploadId, content, content.ContentType);
+        BinaryData response = result.GetRawResponse().Content;
+        using JsonDocument jsonDocument = JsonDocument.Parse(response);
+
+        return GetUploadPartDetails(jsonDocument);
+    }
+
+    private UploadDetails GetUploadDetails(JsonDocument jsonDocument)
+    {
+        string id = jsonDocument.RootElement.GetProperty("id").GetString();
+        string @object = jsonDocument.RootElement.GetProperty("object").GetString();
+        int bytes = jsonDocument.RootElement.GetProperty("bytes").GetInt32();
+        long createdAt = jsonDocument.RootElement.GetProperty("created_at").GetInt64();
+        string filename = jsonDocument.RootElement.GetProperty("filename").GetString();
+        string purpose = jsonDocument.RootElement.GetProperty("purpose").GetString();
+        string status = jsonDocument.RootElement.GetProperty("status").GetString();
+        long expiresAt = jsonDocument.RootElement.GetProperty("expires_at").GetInt64();
+
+        return new UploadDetails()
+        {
+            Id = id,
+            Object = @object,
+            Bytes = bytes,
+            CreatedAt = createdAt,
+            Filename = filename,
+            Purpose = purpose,
+            Status = status,
+            ExpiresAt = expiresAt
+        };
+    }
+
+    private UploadPartDetails GetUploadPartDetails(JsonDocument jsonDocument)
+    {
+        string id = jsonDocument.RootElement.GetProperty("id").GetString();
+        string @object = jsonDocument.RootElement.GetProperty("object").GetString();
+        long createdAt = jsonDocument.RootElement.GetProperty("created_at").GetInt64();
+        string uploadId = jsonDocument.RootElement.GetProperty("upload_id").GetString();
+
+        return new UploadPartDetails()
+        {
+            Id = id,
+            Object = @object,
+            CreatedAt = createdAt,
+            UploadId = uploadId
+        };
+    }
+
+    private readonly struct UploadDetails
+    {
+        public string Id { get; init; }
+        public string Object { get; init; }
+        public int Bytes { get; init; }
+        public long CreatedAt { get; init; }
+        public string Filename { get; init; }
+        public string Purpose { get; init; }
+        public string Status { get; init; }
+        public long ExpiresAt { get; init; }
+    }
+
+    private readonly struct UploadPartDetails
+    {
+        public string Id { get; init; }
+        public string Object { get; init; }
+        public long CreatedAt { get; init; }
+        public string UploadId { get; init; }
+    }
+}

--- a/.dotnet/tests/Utility/MultipartFormDataBinaryContent.cs
+++ b/.dotnet/tests/Utility/MultipartFormDataBinaryContent.cs
@@ -22,9 +22,9 @@ internal class MultipartFormDataBinaryContent : BinaryContent
 
     public string ContentType => _multipartContent.Headers.ContentType.ToString();
 
-    public void Add(byte[] stream, string name, string fileName, string contentType = null)
+    public void Add(byte[] bytes, string name, string fileName, string contentType = null)
     {
-        ByteArrayContent content = new(stream);
+        ByteArrayContent content = new(bytes);
         if (contentType is not null)
         {
             content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);

--- a/.dotnet/tests/Utility/MultipartFormDataBinaryContent.cs
+++ b/.dotnet/tests/Utility/MultipartFormDataBinaryContent.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.ClientModel;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI.Tests;
+
+internal class MultipartFormDataBinaryContent : BinaryContent
+{
+    private readonly MultipartFormDataContent _multipartContent;
+
+    private const int BoundaryLength = 70;
+    private const string BoundaryValues = "0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
+
+    public MultipartFormDataBinaryContent()
+    {
+        _multipartContent = new MultipartFormDataContent(CreateBoundary());
+    }
+
+    public string ContentType => _multipartContent.Headers.ContentType.ToString();
+
+    public void Add(byte[] stream, string name, string fileName, string contentType = null)
+    {
+        ByteArrayContent content = new(stream);
+        if (contentType is not null)
+        {
+            content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
+        }
+        _multipartContent.Add(content, name, fileName);
+    }
+
+#if NET6_0_OR_GREATER
+    private static string CreateBoundary() =>
+        string.Create(BoundaryLength, 0, (chars, _) =>
+        {
+            Span<byte> random = stackalloc byte[BoundaryLength];
+            Random.Shared.NextBytes(random);
+
+            for (int i = 0; i < chars.Length; i++)
+            {
+                chars[i] = BoundaryValues[random[i] % BoundaryValues.Length];
+            }
+        });
+#else
+    private static readonly Random _random = new();
+
+    private static string CreateBoundary()
+    {
+        Span<char> chars = stackalloc char[BoundaryLength];
+
+        byte[] random = new byte[BoundaryLength];
+        lock (_random)
+        {
+            _random.NextBytes(random);
+        }
+
+        // Instead of `% BoundaryValues.Length` as is used above, use a mask to achieve the same result.
+        // `% BoundaryValues.Length` is optimized to the equivalent on .NET Core but not on .NET Framework.
+        const int Mask = 255 >> 2;
+        Debug.Assert(BoundaryValues.Length - 1 == Mask);
+
+        for (int i = 0; i < chars.Length; i++)
+        {
+            chars[i] = BoundaryValues[random[i] & Mask];
+        }
+
+        return chars.ToString();
+    }
+#endif
+
+    public override bool TryComputeLength(out long length)
+    {
+        // We can't call the protected method on HttpContent
+
+        if (_multipartContent.Headers.ContentLength is long contentLength)
+        {
+            length = contentLength;
+            return true;
+        }
+
+        length = 0;
+        return false;
+    }
+
+    public override void WriteTo(Stream stream, CancellationToken cancellationToken = default)
+    {
+#if NET5_0_OR_GREATER
+        _multipartContent.CopyTo(stream, default, cancellationToken);
+#else
+        // TODO: polyfill sync-over-async for netstandard2.0 for Azure clients.
+        // Tracked by https://github.com/Azure/azure-sdk-for-net/issues/42674
+        _multipartContent.CopyToAsync(stream).GetAwaiter().GetResult();
+#endif
+    }
+
+    public override async Task WriteToAsync(Stream stream, CancellationToken cancellationToken = default)
+    {
+#if NET5_0_OR_GREATER
+        await _multipartContent.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+#else
+        await _multipartContent.CopyToAsync(stream).ConfigureAwait(false);
+#endif
+    }
+
+    public override void Dispose()
+    {
+        _multipartContent.Dispose();
+    }
+}


### PR DESCRIPTION
Exposing the Uploads API as `Experimental` protocol methods, and adding tests to them.