### PR TITLE
Add support for automatic re-recording on test failures.

### DIFF
--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/FineTuningTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/FineTuningTests.cs
@@ -193,7 +193,7 @@ public class FineTuningTests : AoaiTestBase<FineTuningClient>
         Assert.That(job.Status, Is.EqualTo("cancelled"));
     }
 
-    [RecordedTest]
+    [RecordedTest(AutomaticRecord = false)]
     [Category("LongRunning")] // CAUTION: This test can take up 30 *minutes* to run in live mode
     public async Task CreateAndDeleteFineTuning()
     {
@@ -229,7 +229,7 @@ public class FineTuningTests : AoaiTestBase<FineTuningClient>
         Assert.True(deleted, "Failed to delete fine tuning model: {0}", job.FineTunedModel);
     }
 
-    [RecordedTest]
+    [RecordedTest(AutomaticRecord = false)]
     [Category("LongRunning")] // CAUTION: This test can take around 10 to 15 *minutes* in live mode to run
     public async Task DeployAndChatWithModel()
     {

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Utils/AoaiTestBase.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Utils/AoaiTestBase.cs
@@ -58,7 +58,7 @@ public class AoaiTestBase<TClient> : RecordedClientTestBase where TClient : clas
     protected AoaiTestBase(bool isAsync, RecordedTestMode? mode = null)
         : base(isAsync, mode)
     {
-        TestConfig = new TestConfig(Mode);
+        TestConfig = new TestConfig(() => Mode);
         Assets = new Assets();
         TestEnvironment = new AzureTestEnvironment(Mode);
 
@@ -235,6 +235,10 @@ public class AoaiTestBase<TClient> : RecordedClientTestBase where TClient : clas
     /// <inheritdoc />
     protected override RecordedTestMode GetDefaultRecordedTestMode()
         => AzureTestEnvironment.DefaultRecordMode;
+
+    /// <inheritdoc />
+    protected override bool GetDefaultAutomaticRecordEnabled()
+        => AzureTestEnvironment.DefaultAutomaticRecordEnabled;
 
     /// <inheritdoc />
     protected override ProxyServiceOptions CreateProxyServiceOptions()

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Utils/AzureTestEnvironment.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Utils/AzureTestEnvironment.cs
@@ -131,7 +131,7 @@ public class AzureTestEnvironment
         get
         {
             string? modeString = TestContext.Parameters["TestMode"]
-                    ?? Environment.GetEnvironmentVariable("AZURE_TEST_MODE");
+                ?? Environment.GetEnvironmentVariable("AZURE_TEST_MODE");
 
             if (Enum.TryParse(modeString, true, out RecordedTestMode mode))
             {
@@ -139,6 +139,25 @@ public class AzureTestEnvironment
             }
 
             return RecordedTestMode.Playback;
+        }
+    }
+
+    /// <summary>
+    /// Gets whether or not we should automatically record tests.
+    /// </summary>
+    public static bool DefaultAutomaticRecordEnabled
+    {
+        get
+        {
+            string? enabledString = TestContext.Parameters["DisableAutoRecording"]
+                ?? Environment.GetEnvironmentVariable("AZURE_DISABLE_AUTO_RECORDING");
+
+            if (bool.TryParse(enabledString, out bool enabled))
+            {
+                return !enabled;
+            }
+
+            return true;
         }
     }
 

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Utils/TestConfig.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Utils/TestConfig.cs
@@ -18,50 +18,50 @@ internal class TestConfig
 {
     private const string AZURE_OPENAI_ENV_KEY_PREFIX = "AZURE_OPENAI";
 
-    private readonly bool _isPlayback;
-    private readonly IReadOnlyDictionary<string, JsonConfig> _jsonConfig;
+    private readonly Func<RecordedTestMode> _getRecordedMode;
     private SortedDictionary<string, SanitizedJsonConfig> _recordedConfig;
+    private readonly IReadOnlyDictionary<string, JsonConfig> _liveConfig;
+    private readonly IReadOnlyDictionary<string, JsonConfig> _playbackConfig;
 
     public virtual string AssetsSubFolder => "Assets";
     public virtual string AssetsJson => "test_config.json";
     public virtual string PlaybackAssetsJson => $"playback_{AssetsJson}";
 
-    public TestConfig(RecordedTestMode? mode)
+    protected bool IsPlayback => _getRecordedMode() == RecordedTestMode.Playback;
+
+    // When in playback mode, we always use the playback configuration. This ensures that we run in the same way in CI/CD
+    // as we do locally.
+    protected IReadOnlyDictionary<string, JsonConfig> CurrentConfig => IsPlayback ? _playbackConfig : _liveConfig;
+
+    public TestConfig(Func<RecordedTestMode> getRecordedMode)
     {
-        _isPlayback = mode == RecordedTestMode.Playback;
+        _getRecordedMode = getRecordedMode ?? throw new ArgumentNullException(nameof(getRecordedMode));
         _recordedConfig = new(new DefaultFirstStringComparer());
 
         // Load the previous playback configuration and use that to initialize the recorded config
         string playbackConfigJson = Path.Combine(AssetsSubFolder, PlaybackAssetsJson);
-        var playbackConfig = ReadJsonConfig(playbackConfigJson);
-        if (playbackConfig != null)
+        _playbackConfig = ReadJsonConfig(playbackConfigJson)!;
+        if (_playbackConfig == null)
         {
-            foreach (var kvp in playbackConfig)
-            {
-                _recordedConfig.Add(kvp.Key, new SanitizedJsonConfig(kvp.Value));
-            }
+            throw new InvalidOperationException($"The playback config file was not found: {playbackConfigJson}");
         }
 
-        // When in playback mode, we always use the playback configuration. This ensures that we run in the same way in CI/CD
-        // as we do locally.
-        if (_isPlayback)
+        foreach (var kvp in _playbackConfig)
         {
-            _jsonConfig = playbackConfig
-                ?? throw new InvalidOperationException($"The playback config file was not found: {playbackConfigJson}");
+            _recordedConfig.Add(kvp.Key, new SanitizedJsonConfig(kvp.Value));
         }
-        else
-        {
-            _jsonConfig = new[]
-                {
-                    AssetsJson,
-                    Path.Combine(AssetsSubFolder, AssetsJson),
-                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".azure", AssetsSubFolder, AssetsJson),
-                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".azure", AssetsSubFolder, AssetsJson),
-                }
-                .Select(f => ReadJsonConfig(f))
-                .FirstOrDefault(c => c != null)
-                ?? new Dictionary<string, JsonConfig>();
-        }
+
+        // Try to load the configuration to use against the real service (e.g. recording or live mode)
+        _liveConfig = new[]
+            {
+                AssetsJson,
+                Path.Combine(AssetsSubFolder, AssetsJson),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".azure", AssetsSubFolder, AssetsJson),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".azure", AssetsSubFolder, AssetsJson),
+            }
+            .Select(f => ReadJsonConfig(f))
+            .FirstOrDefault(c => c != null)
+            ?? new Dictionary<string, JsonConfig>();
     }
 
     public virtual IConfiguration? GetConfig<TClient>()
@@ -78,10 +78,10 @@ internal class TestConfig
 
         return new FlattenedConfig(
             [
-                new NamedConfig(_jsonConfig.GetValueOrDefault(name), name),
-                new NamedConfig(_jsonConfig.GetValueOrDefault(JsonConfig.DEFAULT_CONFIG_NAME), null),
-                _isPlayback ? null : new EnvironmentValuesConfig(AZURE_OPENAI_ENV_KEY_PREFIX, name),
-                _isPlayback ? null : new EnvironmentValuesConfig(AZURE_OPENAI_ENV_KEY_PREFIX)
+                new NamedConfig(CurrentConfig.GetValueOrDefault(name), name),
+                new NamedConfig(CurrentConfig.GetValueOrDefault(JsonConfig.DEFAULT_CONFIG_NAME), null),
+                IsPlayback ? null : new EnvironmentValuesConfig(AZURE_OPENAI_ENV_KEY_PREFIX, name),
+                IsPlayback ? null : new EnvironmentValuesConfig(AZURE_OPENAI_ENV_KEY_PREFIX)
             ], _recordedConfig);
     }
 

--- a/.dotnet.azure/sdk/openai/tools/TestFramework/src/RecordedTestAttribute.cs
+++ b/.dotnet.azure/sdk/openai/tools/TestFramework/src/RecordedTestAttribute.cs
@@ -1,7 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal.Commands;
+using NUnit.Framework.Internal;
+using OpenAI.TestFramework.Recording;
 
 namespace OpenAI.TestFramework;
 
@@ -10,9 +15,118 @@ namespace OpenAI.TestFramework;
 /// <see cref="RecordedClientTestBase"/> in your test class, and add this attribute to your test function, and then
 /// make sure to call <see cref="RecordedClientTestBase.ConfigureClientOptions{TClientOptions}(TClientOptions)"/>
 /// on the client options you use to configure a client, this should automatically enable the recording/playback
-/// functionality.
+/// functionality. By default. this will also automatically try to re-record the test if it fails during playback.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
-public class RecordedTestAttribute : TestAttribute
+public class RecordedTestAttribute : TestAttribute, IRepeatTest
 {
+    /// <summary>
+    /// Whether or not to automatically try to record the test again in the case of a recording mismatch, or missing
+    /// test recording.
+    /// </summary>
+    public bool AutomaticRecord { get; set; } = true;
+
+    public TestCommand Wrap(TestCommand command)
+    {
+        // For some reason, the test fixture may be set on the parent of the current test, and not the current test
+        // itself. Let's handle this
+        ITest? test = command.Test;
+        while (test.Fixture == null && test.Parent != null)
+        {
+            test = test.Parent;
+        }
+
+        // If the test fixture extends RecordedClientTestBase, we are in playback mode, and auto-rerecord
+        // is enabled, wrap the command to enable the retry in Record mode
+        if (AutomaticRecord
+            && test?.Fixture is RecordedClientTestBase testBase
+            && testBase.AutomaticRecord
+            && testBase.Mode == RecordedTestMode.Playback)
+        {
+            return new AutoRerecordCommand(command, testBase);
+        }
+
+        return command;
+    }
+
+    private class AutoRerecordCommand(TestCommand inner, RecordedClientTestBase testBase) : DelegatingTestCommand(inner)
+    {
+        private readonly RecordedClientTestBase _testBase = testBase ?? throw new ArgumentNullException(nameof(testBase));
+
+        public override TestResult Execute(TestExecutionContext context)
+        {
+            context.CurrentResult = innerCommand.Execute(context);
+            if (IsRecordingPlaybackFailure(context.CurrentResult))
+            {
+                try
+                {
+                    _testBase.Mode = RecordedTestMode.Record;
+                    TestResult originalResult = context.CurrentResult;
+
+                    context.CurrentResult = context.CurrentTest.MakeTestResult();
+                    context.CurrentResult = innerCommand.Execute(context);
+
+                    // If the recording succeeded, update the original message to reflect this
+                    ResultState state;
+                    string? stackTrace;
+                    StringBuilder builder = new();
+                    if (context.CurrentResult.ResultState?.Status == TestStatus.Passed)
+                    {
+                        state = originalResult.ResultState;
+                        stackTrace = originalResult.StackTrace;
+                        builder.AppendLine("Test failed playback, but was successfully re-recorded. It should pass if re-run.");
+                    }
+                    else
+                    {
+                        state = context.CurrentResult.ResultState ?? ResultState.Error;
+                        stackTrace = context.CurrentResult.StackTrace;
+                        builder.AppendLine("Re-recording attempt failed. Error: ");
+                        builder.AppendLine();
+                        builder.AppendLine(context.CurrentResult.Message);
+                        builder.AppendLine();
+                        builder.AppendLine("Original message:");
+                    }
+
+                    builder.AppendLine();
+                    builder.Append(originalResult.Message);
+                    context.CurrentResult.SetResult(state, builder.ToString(), stackTrace);
+                }
+                finally
+                {
+                    _testBase.Mode = RecordedTestMode.Playback;
+                }
+            }
+
+            return context.CurrentResult;
+        }
+
+        private static bool IsRecordingPlaybackFailure(TestResult result)
+        {
+            string exceptionName = typeof(TestRecordingMismatchException).FullName
+                ?? nameof(TestRecordingMismatchException);
+
+            // 1. Check if the test passed
+            bool testPassed = result.ResultState?.Status switch
+            {
+                TestStatus.Passed => true,
+                TestStatus.Inconclusive => true,
+                TestStatus.Skipped => true,
+                _ => false
+            };
+
+            if (testPassed)
+            {
+                return false;
+            }
+
+            // 2. Check if the failure message indicates a recording playback exception. This sadly requires us to check test failure
+            //    messages which can be a little fragile but there does not seem to be a way to get the exception directly
+            if (result.Message?.Contains(exceptionName) == true)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
- By default, automatic recording will be disabled if running in CI/CD (supports GitHub workflows and Azure DevOps detection right now)
- Allows you to customize when autoamtic recording is disabled globally, at the test suite level, or for individual tests
- Fixes a bug in the Azure OpenAI tests that was preventing automatic re-recording from working