### PR TITLE
Rename `ModerationClient`'s `ClassifyTextInput` methods to `ClassifyText`

### DIFF
--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Updated the `Embedding.Vector` property to the `Embedding.ToFloats()` method. (commit_hash)
 - Removed the optional parameter from the constructors of `VectorStoreCreationHelper`, `AssistantChatMessage`, and `ChatFunction`. (commit_hash)
 - Removed the optional `purpose` parameter from `FileClient.GetFilesAsync` and `FileClient.GetFiles` methods, and added overloads where `purpose` is required. (commit_hash)
+- Renamed `ModerationClient`'s `ClassifyTextInput` methods to `ClassifyText`. (commit_hash)
 
 ### Bugs Fixed
 

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -2152,14 +2152,14 @@ namespace OpenAI.Moderations {
         public ModerationClient(string model, ApiKeyCredential credential, OpenAIClientOptions options);
         public ModerationClient(string model, ApiKeyCredential credential);
         public virtual ClientPipeline Pipeline { get; }
-        public virtual ClientResult<ModerationResult> ClassifyTextInput(string input, CancellationToken cancellationToken = default);
-        public virtual Task<ClientResult<ModerationResult>> ClassifyTextInputAsync(string input, CancellationToken cancellationToken = default);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual ClientResult ClassifyTextInputs(BinaryContent content, RequestOptions options = null);
-        public virtual ClientResult<ModerationCollection> ClassifyTextInputs(IEnumerable<string> inputs, CancellationToken cancellationToken = default);
+        public virtual ClientResult ClassifyText(BinaryContent content, RequestOptions options = null);
+        public virtual ClientResult<ModerationCollection> ClassifyText(IEnumerable<string> inputs, CancellationToken cancellationToken = default);
+        public virtual ClientResult<ModerationResult> ClassifyText(string input, CancellationToken cancellationToken = default);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual Task<ClientResult> ClassifyTextInputsAsync(BinaryContent content, RequestOptions options = null);
-        public virtual Task<ClientResult<ModerationCollection>> ClassifyTextInputsAsync(IEnumerable<string> inputs, CancellationToken cancellationToken = default);
+        public virtual Task<ClientResult> ClassifyTextAsync(BinaryContent content, RequestOptions options = null);
+        public virtual Task<ClientResult<ModerationCollection>> ClassifyTextAsync(IEnumerable<string> inputs, CancellationToken cancellationToken = default);
+        public virtual Task<ClientResult<ModerationResult>> ClassifyTextAsync(string input, CancellationToken cancellationToken = default);
     }
     public class ModerationCollection : ObjectModel.ReadOnlyCollection<ModerationResult>, IJsonModel<ModerationCollection>, IPersistableModel<ModerationCollection> {
         public string Id { get; }

--- a/.dotnet/src/Custom/Moderations/ModerationClient.Protocol.cs
+++ b/.dotnet/src/Custom/Moderations/ModerationClient.Protocol.cs
@@ -19,7 +19,7 @@ public partial class ModerationClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual async Task<ClientResult> ClassifyTextInputsAsync(BinaryContent content, RequestOptions options = null)
+    public virtual async Task<ClientResult> ClassifyTextAsync(BinaryContent content, RequestOptions options = null)
     {
         Argument.AssertNotNull(content, nameof(content));
 
@@ -36,7 +36,7 @@ public partial class ModerationClient
     /// <exception cref="ClientResultException"> Service returned a non-success status code. </exception>
     /// <returns> The response returned from the service. </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public virtual ClientResult ClassifyTextInputs(BinaryContent content, RequestOptions options = null)
+    public virtual ClientResult ClassifyText(BinaryContent content, RequestOptions options = null)
     {
         Argument.AssertNotNull(content, nameof(content));
 

--- a/.dotnet/src/Custom/Moderations/ModerationClient.cs
+++ b/.dotnet/src/Custom/Moderations/ModerationClient.cs
@@ -82,7 +82,7 @@ public partial class ModerationClient
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="input"/> is an empty string, and was expected to be non-empty. </exception>
-    public virtual async Task<ClientResult<ModerationResult>> ClassifyTextInputAsync(string input, CancellationToken cancellationToken = default)
+    public virtual async Task<ClientResult<ModerationResult>> ClassifyTextAsync(string input, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(input, nameof(input));
 
@@ -90,7 +90,7 @@ public partial class ModerationClient
         CreateModerationOptions(BinaryData.FromObjectAsJson(input), ref options);
 
         using BinaryContent content = options.ToBinaryContent();
-        ClientResult result = await ClassifyTextInputsAsync(content, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        ClientResult result = await ClassifyTextAsync(content, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
         return ClientResult.FromValue(ModerationCollection.FromResponse(result.GetRawResponse()).FirstOrDefault(), result.GetRawResponse());
     }
 
@@ -99,7 +99,7 @@ public partial class ModerationClient
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="input"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="input"/> is an empty string, and was expected to be non-empty. </exception>
-    public virtual ClientResult<ModerationResult> ClassifyTextInput(string input, CancellationToken cancellationToken = default)
+    public virtual ClientResult<ModerationResult> ClassifyText(string input, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(input, nameof(input));
 
@@ -107,7 +107,7 @@ public partial class ModerationClient
         CreateModerationOptions(BinaryData.FromObjectAsJson(input), ref options);
 
         using BinaryContent content = options.ToBinaryContent();
-        ClientResult result = ClassifyTextInputs(content, cancellationToken.ToRequestOptions());
+        ClientResult result = ClassifyText(content, cancellationToken.ToRequestOptions());
         return ClientResult.FromValue(ModerationCollection.FromResponse(result.GetRawResponse()).FirstOrDefault(), result.GetRawResponse());
     }
 
@@ -116,7 +116,7 @@ public partial class ModerationClient
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="inputs"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="inputs"/> is an empty collection, and was expected to be non-empty. </exception>
-    public virtual async Task<ClientResult<ModerationCollection>> ClassifyTextInputsAsync(IEnumerable<string> inputs, CancellationToken cancellationToken = default)
+    public virtual async Task<ClientResult<ModerationCollection>> ClassifyTextAsync(IEnumerable<string> inputs, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(inputs, nameof(inputs));
 
@@ -124,7 +124,7 @@ public partial class ModerationClient
         CreateModerationOptions(BinaryData.FromObjectAsJson(inputs), ref options);
 
         using BinaryContent content = options.ToBinaryContent();
-        ClientResult result = await ClassifyTextInputsAsync(content, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        ClientResult result = await ClassifyTextAsync(content, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
         return ClientResult.FromValue(ModerationCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
@@ -133,7 +133,7 @@ public partial class ModerationClient
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="inputs"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="inputs"/> is an empty collection, and was expected to be non-empty. </exception>
-    public virtual ClientResult<ModerationCollection> ClassifyTextInputs(IEnumerable<string> inputs, CancellationToken cancellationToken = default)
+    public virtual ClientResult<ModerationCollection> ClassifyText(IEnumerable<string> inputs, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNullOrEmpty(inputs, nameof(inputs));
 
@@ -141,7 +141,7 @@ public partial class ModerationClient
         CreateModerationOptions(BinaryData.FromObjectAsJson(inputs), ref options);
 
         using BinaryContent content = options.ToBinaryContent();
-        ClientResult result = ClassifyTextInputs(content, cancellationToken.ToRequestOptions());
+        ClientResult result = ClassifyText(content, cancellationToken.ToRequestOptions());
         return ClientResult.FromValue(ModerationCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 

--- a/.dotnet/tests/Moderations/ModerationTests.cs
+++ b/.dotnet/tests/Moderations/ModerationTests.cs
@@ -25,8 +25,8 @@ public partial class ModerationTests : SyncAsyncTestBase
         const string input = "I am killing all my houseplants!";
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync(input)
-            : client.ClassifyTextInput(input);
+            ? await client.ClassifyTextAsync(input)
+            : client.ClassifyText(input);
         Assert.That(moderation, Is.Not.Null);
         Assert.That(moderation.Flagged, Is.True);
         Assert.That(moderation.Categories.Violence, Is.True);
@@ -45,8 +45,8 @@ public partial class ModerationTests : SyncAsyncTestBase
             ];
 
         ModerationCollection moderations = IsAsync
-            ? await client.ClassifyTextInputsAsync(inputs)
-            : client.ClassifyTextInputs(inputs);
+            ? await client.ClassifyTextAsync(inputs)
+            : client.ClassifyText(inputs);
         Assert.That(moderations, Is.Not.Null);
         Assert.That(moderations.Count, Is.EqualTo(2));
         Assert.That(moderations.Model, Does.StartWith("text-moderation"));

--- a/.dotnet/tests/Moderations/ModerationsMockTests.cs
+++ b/.dotnet/tests/Moderations/ModerationsMockTests.cs
@@ -42,8 +42,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, hate: (true, 0.895f));
     }
@@ -68,8 +68,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, hateThreatening: (true, 0.895f));
     }
@@ -94,8 +94,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, harassment: (true, 0.895f));
     }
@@ -120,8 +120,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, harassmentThreatening: (true, 0.895f));
     }
@@ -146,8 +146,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, selfHarm: (true, 0.895f));
     }
@@ -172,8 +172,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, selfHarmIntent: (true, 0.895f));
     }
@@ -198,8 +198,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, selfHarmInstructions: (true, 0.895f));
     }
@@ -224,8 +224,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, sexual: (true, 0.895f));
     }
@@ -250,8 +250,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, sexualMinors: (true, 0.895f));
     }
@@ -276,8 +276,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, violence: (true, 0.895f));
     }
@@ -302,8 +302,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationResult moderation = IsAsync
-            ? await client.ClassifyTextInputAsync("input")
-            : client.ClassifyTextInput("input");
+            ? await client.ClassifyTextAsync("input")
+            : client.ClassifyText("input");
 
         AssertModerationCategories(moderation, violenceGraphic: (true, 0.895f));
     }
@@ -317,12 +317,12 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
 
         if (IsAsync)
         {
-            Assert.That(async () => await client.ClassifyTextInputAsync("input", cancellationSource.Token),
+            Assert.That(async () => await client.ClassifyTextAsync("input", cancellationSource.Token),
                 Throws.InstanceOf<OperationCanceledException>());
         }
         else
         {
-            Assert.That(() => client.ClassifyTextInput("input", cancellationSource.Token),
+            Assert.That(() => client.ClassifyText("input", cancellationSource.Token),
                 Throws.InstanceOf<OperationCanceledException>());
         }
     }
@@ -347,8 +347,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, hate: (true, 0.895f));
@@ -374,8 +374,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, hateThreatening: (true, 0.895f));
@@ -401,8 +401,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, harassment: (true, 0.895f));
@@ -428,8 +428,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, harassmentThreatening: (true, 0.895f));
@@ -455,8 +455,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, selfHarm: (true, 0.895f));
@@ -482,8 +482,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, selfHarmIntent: (true, 0.895f));
@@ -509,8 +509,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, selfHarmInstructions: (true, 0.895f));
@@ -536,8 +536,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, sexual: (true, 0.895f));
@@ -563,8 +563,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, sexualMinors: (true, 0.895f));
@@ -590,8 +590,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, violence: (true, 0.895f));
@@ -617,8 +617,8 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
         ModerationClient client = new ModerationClient("model", s_fakeCredential, clientOptions);
 
         ModerationCollection resultCollection = IsAsync
-            ? await client.ClassifyTextInputsAsync(["input"])
-            : client.ClassifyTextInputs(["input"]);
+            ? await client.ClassifyTextAsync(["input"])
+            : client.ClassifyText(["input"]);
         ModerationResult moderation = resultCollection.Single();
 
         AssertModerationCategories(moderation, violenceGraphic: (true, 0.895f));
@@ -633,12 +633,12 @@ public partial class ModerationsMockTests : SyncAsyncTestBase
 
         if (IsAsync)
         {
-            Assert.That(async () => await client.ClassifyTextInputsAsync(["input"], cancellationSource.Token),
+            Assert.That(async () => await client.ClassifyTextAsync(["input"], cancellationSource.Token),
                 Throws.InstanceOf<OperationCanceledException>());
         }
         else
         {
-            Assert.That(() => client.ClassifyTextInputs(["input"], cancellationSource.Token),
+            Assert.That(() => client.ClassifyText(["input"], cancellationSource.Token),
                 Throws.InstanceOf<OperationCanceledException>());
         }
     }


### PR DESCRIPTION
Renamed `ModerationClient`'s `ClassifyTextInput` methods to `ClassifyText`.