### PR TITLE
Misc fixes to TranscribedSegment and TranscribedWord

### DIFF
--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/AudioTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/AudioTests.cs
@@ -82,8 +82,8 @@ public class AudioTests(bool isAsync) : AoaiTestBase<AudioClient>(isAsync)
             TranscribedSegment firstSegment = transcription.Segments[0];
             Assert.That(firstSegment, Is.Not.Null);
             Assert.That(firstSegment.Id, Is.EqualTo(0));
-            Assert.That(firstSegment.Start, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0)));
-            Assert.That(firstSegment.End, Is.GreaterThan(firstSegment.Start));
+            Assert.That(firstSegment.StartTime, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0)));
+            Assert.That(firstSegment.EndTime, Is.GreaterThan(firstSegment.StartTime));
             Assert.That(firstSegment.Text, Is.Not.Null.Or.Empty);
         }
     }
@@ -159,8 +159,8 @@ public class AudioTests(bool isAsync) : AoaiTestBase<AudioClient>(isAsync)
             TranscribedSegment firstSegment = translation.Segments[0];
             Assert.That(firstSegment, Is.Not.Null);
             Assert.That(firstSegment.Id, Is.EqualTo(0));
-            Assert.That(firstSegment.Start, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0)));
-            Assert.That(firstSegment.End, Is.GreaterThan(firstSegment.Start));
+            Assert.That(firstSegment.StartTime, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0)));
+            Assert.That(firstSegment.EndTime, Is.GreaterThan(firstSegment.StartTime));
             Assert.That(firstSegment.Text, Is.Not.Null.Or.Empty);
         }
     }

--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -16,7 +16,11 @@
 - Removed setters from collection properties. (commit_hash)
 - Renamed `ChatTokenLogProbabilityInfo` to `ChatTokenLogProbabilityDetails`. (commit_hash)
 - Renamed `ChatTokenTopLogProbabilityInfo` to `ChatTokenTopLogProbabilityDetails`. (commit_hash)
-- Renamed the `Utf8ByteValues` properties of `ChatTokenLogProbabilityDetails` and `ChatTokenTopLogProbabilityDetails` to `Utf8Bytes` and changed their type from `IReadOnlyList<int>` to `ReadOnlyMemory<byte>?`
+- Renamed the `Utf8ByteValues` properties of `ChatTokenLogProbabilityDetails` and `ChatTokenTopLogProbabilityDetails` to `Utf8Bytes` and changed their type from `IReadOnlyList<int>` to `ReadOnlyMemory<byte>?`. (commit_hash)
+- Renamed the `Start` and `End` properties of `TranscribedSegment` and `TranscribedWord` to `StartTime` and `EndTime`. (commit_hash)
+- Changed the type of `TranscribedSegment`'s `AverageLogProbability` and `NoSpeechProbability` properties from `double` to `float`. (commit_hash)
+- Changed the type of `TranscribedSegment`'s `SeekOffset` property from `long` to `int`. (commit_hash)
+- Changed the type of `TranscribedSegment`'s `TokenIds` property from `IReadOnlyList<long>` to `IReadOnlyList<int>`. (commit_hash)
 
 ### Bugs Fixed
 

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -1170,8 +1170,8 @@ namespace OpenAI.Audio {
     public static class OpenAIAudioModelFactory {
         public static AudioTranscription AudioTranscription(string language = null, TimeSpan? duration = null, string text = null, IEnumerable<TranscribedWord> words = null, IEnumerable<TranscribedSegment> segments = null);
         public static AudioTranslation AudioTranslation(string language = null, TimeSpan? duration = null, string text = null, IEnumerable<TranscribedSegment> segments = null);
-        public static TranscribedSegment TranscribedSegment(int id = 0, long seekOffset = 0, TimeSpan start = default, TimeSpan end = default, string text = null, IEnumerable<long> tokenIds = null, float temperature = 0, double averageLogProbability = 0, float compressionRatio = 0, double noSpeechProbability = 0);
-        public static TranscribedWord TranscribedWord(string word = null, TimeSpan start = default, TimeSpan end = default);
+        public static TranscribedSegment TranscribedSegment(int id = 0, int seekOffset = 0, TimeSpan startTime = default, TimeSpan endTime = default, string text = null, IEnumerable<int> tokenIds = null, float temperature = 0, float averageLogProbability = 0, float compressionRatio = 0, float noSpeechProbability = 0);
+        public static TranscribedWord TranscribedWord(string word = null, TimeSpan startTime = default, TimeSpan endTime = default);
     }
     public class SpeechGenerationOptions : IJsonModel<SpeechGenerationOptions>, IPersistableModel<SpeechGenerationOptions> {
         public GeneratedSpeechFormat? ResponseFormat { get; set; }
@@ -1185,16 +1185,16 @@ namespace OpenAI.Audio {
     public readonly partial struct TranscribedSegment : IJsonModel<TranscribedSegment>, IPersistableModel<TranscribedSegment>, IJsonModel<object>, IPersistableModel<object> {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public double AverageLogProbability { get; }
+        public float AverageLogProbability { get; }
         public float CompressionRatio { get; }
-        public TimeSpan End { get; }
+        public TimeSpan EndTime { get; }
         public int Id { get; }
-        public double NoSpeechProbability { get; }
-        public long SeekOffset { get; }
-        public TimeSpan Start { get; }
+        public float NoSpeechProbability { get; }
+        public int SeekOffset { get; }
+        public TimeSpan StartTime { get; }
         public float Temperature { get; }
         public string Text { get; }
-        public IReadOnlyList<long> TokenIds { get; }
+        public IReadOnlyList<int> TokenIds { get; }
         readonly TranscribedSegment IJsonModel<TranscribedSegment>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         readonly void IJsonModel<TranscribedSegment>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         readonly object IJsonModel<object>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
@@ -1209,8 +1209,8 @@ namespace OpenAI.Audio {
     public readonly partial struct TranscribedWord : IJsonModel<TranscribedWord>, IPersistableModel<TranscribedWord>, IJsonModel<object>, IPersistableModel<object> {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public TimeSpan End { get; }
-        public TimeSpan Start { get; }
+        public TimeSpan EndTime { get; }
+        public TimeSpan StartTime { get; }
         public string Word { get; }
         readonly TranscribedWord IJsonModel<TranscribedWord>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         readonly void IJsonModel<TranscribedWord>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);

--- a/.dotnet/examples/Audio/Example03_VerboseTranscription.cs
+++ b/.dotnet/examples/Audio/Example03_VerboseTranscription.cs
@@ -29,14 +29,14 @@ public partial class AudioExamples
         Console.WriteLine($"Words:");
         foreach (TranscribedWord word in transcription.Words)
         {
-            Console.WriteLine($"  {word.Word,15} : {word.Start.TotalMilliseconds,5:0} - {word.End.TotalMilliseconds,5:0}");
+            Console.WriteLine($"  {word.Word,15} : {word.StartTime.TotalMilliseconds,5:0} - {word.EndTime.TotalMilliseconds,5:0}");
         }
 
         Console.WriteLine();
         Console.WriteLine($"Segments:");
         foreach (TranscribedSegment segment in transcription.Segments)
         {
-            Console.WriteLine($"  {segment.Text,90} : {segment.Start.TotalMilliseconds,5:0} - {segment.End.TotalMilliseconds,5:0}");
+            Console.WriteLine($"  {segment.Text,90} : {segment.StartTime.TotalMilliseconds,5:0} - {segment.EndTime.TotalMilliseconds,5:0}");
         }
     }
 }

--- a/.dotnet/examples/Audio/Example03_VerboseTrascriptionAsync.cs
+++ b/.dotnet/examples/Audio/Example03_VerboseTrascriptionAsync.cs
@@ -30,14 +30,14 @@ public partial class AudioExamples
         Console.WriteLine($"Words:");
         foreach (TranscribedWord word in transcription.Words)
         {
-            Console.WriteLine($"  {word.Word,15} : {word.Start.TotalMilliseconds,5:0} - {word.End.TotalMilliseconds,5:0}");
+            Console.WriteLine($"  {word.Word,15} : {word.StartTime.TotalMilliseconds,5:0} - {word.EndTime.TotalMilliseconds,5:0}");
         }
 
         Console.WriteLine();
         Console.WriteLine($"Segments:");
         foreach (TranscribedSegment segment in transcription.Segments)
         {
-            Console.WriteLine($"  {segment.Text,90} : {segment.Start.TotalMilliseconds,5:0} - {segment.End.TotalMilliseconds,5:0}");
+            Console.WriteLine($"  {segment.Text,90} : {segment.StartTime.TotalMilliseconds,5:0} - {segment.EndTime.TotalMilliseconds,5:0}");
         }
     }
 }

--- a/.dotnet/src/Custom/Audio/OpenAIAudioModelFactory.cs
+++ b/.dotnet/src/Custom/Audio/OpenAIAudioModelFactory.cs
@@ -41,15 +41,15 @@ public static partial class OpenAIAudioModelFactory
 
     /// <summary> Initializes a new instance of <see cref="OpenAI.Audio.TranscribedSegment"/>. </summary>
     /// <returns> A new <see cref="OpenAI.Audio.TranscribedSegment"/> instance for mocking. </returns>
-    public static TranscribedSegment TranscribedSegment(int id = default, long seekOffset = default, TimeSpan start = default, TimeSpan end = default, string text = null, IEnumerable<long> tokenIds = null, float temperature = default, double averageLogProbability = default, float compressionRatio = default, double noSpeechProbability = default)
+    public static TranscribedSegment TranscribedSegment(int id = default, int seekOffset = default, TimeSpan startTime = default, TimeSpan endTime = default, string text = null, IEnumerable<int> tokenIds = null, float temperature = default, float averageLogProbability = default, float compressionRatio = default, float noSpeechProbability = default)
     {
-        tokenIds ??= new List<long>();
+        tokenIds ??= new List<int>();
 
         return new TranscribedSegment(
             id,
             seekOffset,
-            start,
-            end,
+            startTime,
+            endTime,
             text,
             tokenIds.ToList(),
             temperature,
@@ -61,12 +61,12 @@ public static partial class OpenAIAudioModelFactory
 
     /// <summary> Initializes a new instance of <see cref="OpenAI.Audio.TranscribedWord"/>. </summary>
     /// <returns> A new <see cref="OpenAI.Audio.TranscribedWord"/> instance for mocking. </returns>
-    public static TranscribedWord TranscribedWord(string word = null, TimeSpan start = default, TimeSpan end = default)
+    public static TranscribedWord TranscribedWord(string word = null, TimeSpan startTime = default, TimeSpan endTime = default)
     {
         return new TranscribedWord(
             word,
-            start,
-            end,
+            startTime,
+            endTime,
             serializedAdditionalRawData: null);
     }
 }

--- a/.dotnet/src/Custom/Audio/TranscribedSegment.cs
+++ b/.dotnet/src/Custom/Audio/TranscribedSegment.cs
@@ -4,26 +4,41 @@ using System.Runtime.InteropServices;
 
 namespace OpenAI.Audio;
 
+/// <summary> A segment of the transcribed audio. </summary>
 [CodeGenModel("TranscriptionSegment")]
 [StructLayout(LayoutKind.Auto)]
 public readonly partial struct TranscribedSegment
 {
-    // CUSTOM: Remove setter.
+    // CUSTOM: Remove setter. Auto-implemented instance properties in readonly structs must be readonly.
     internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; }
 
-    // CUSTOM: Rename.
+    // CUSTOM: Renamed.
+    /// <summary> The start time of the segment. </summary>
+    [CodeGenMember("Start")]
+    public TimeSpan StartTime { get; }
+
+    // CUSTOM: Renamed.
+    /// <summary> The end time of the segment. </summary>
+    [CodeGenMember("End")]
+    public TimeSpan EndTime { get; }
+
+    // CUSTOM: Renamed.
+    /// <summary> The seek offset of the segment. </summary>
     [CodeGenMember("Seek")]
-    public long SeekOffset { get; }
+    public int SeekOffset { get; }
 
-    // CUSTOM: Rename.
+    // CUSTOM: Renamed.
+    /// <summary> The token IDs corresponding to the text content of the segment. </summary>
     [CodeGenMember("Tokens")]
-    public IReadOnlyList<long> TokenIds { get; }
+    public IReadOnlyList<int> TokenIds { get; }
 
-    // CUSTOM: Rename.
+    // CUSTOM: Renamed.
+    /// <summary> The average log probability of the segment. </summary>
     [CodeGenMember("AvgLogprob")]
-    public double AverageLogProbability { get; }
+    public float AverageLogProbability { get; }
 
-    // CUSTOM: Rename.
+    // CUSTOM: Renamed.
+    /// <summary> The probability that the segment contains no speech. </summary>
     [CodeGenMember("NoSpeechProb")]
-    public double NoSpeechProbability { get; }
+    public float NoSpeechProbability { get; }
 }

--- a/.dotnet/src/Custom/Audio/TranscribedWord.cs
+++ b/.dotnet/src/Custom/Audio/TranscribedWord.cs
@@ -4,10 +4,21 @@ using System.Runtime.InteropServices;
 
 namespace OpenAI.Audio;
 
+/// <summary> A word of the transcribed audio. </summary>
 [CodeGenModel("TranscriptionWord")]
 [StructLayout(LayoutKind.Auto)]
 public readonly partial struct TranscribedWord
 {
-    // CUSTOM: Remove setter.
+    // CUSTOM: Remove setter. Auto-implemented instance properties in readonly structs must be readonly.
     internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; }
+
+    // CUSTOM: Renamed.
+    /// <summary> The start time of the word. </summary>
+    [CodeGenMember("Start")]
+    public TimeSpan StartTime { get; }
+
+    // CUSTOM: Renamed.
+    /// <summary> The end time of the word. </summary>
+    [CodeGenMember("End")]
+    public TimeSpan EndTime { get; }
 }

--- a/.dotnet/src/Generated/Models/TranscribedSegment.Serialization.cs
+++ b/.dotnet/src/Generated/Models/TranscribedSegment.Serialization.cs
@@ -34,12 +34,12 @@ namespace OpenAI.Audio
             if (SerializedAdditionalRawData?.ContainsKey("start") != true)
             {
                 writer.WritePropertyName("start"u8);
-                writer.WriteNumberValue(Convert.ToDouble(Start.ToString("s\\.FFF")));
+                writer.WriteNumberValue(Convert.ToDouble(StartTime.ToString("s\\.FFF")));
             }
             if (SerializedAdditionalRawData?.ContainsKey("end") != true)
             {
                 writer.WritePropertyName("end"u8);
-                writer.WriteNumberValue(Convert.ToDouble(End.ToString("s\\.FFF")));
+                writer.WriteNumberValue(Convert.ToDouble(EndTime.ToString("s\\.FFF")));
             }
             if (SerializedAdditionalRawData?.ContainsKey("text") != true)
             {
@@ -119,15 +119,15 @@ namespace OpenAI.Audio
             options ??= ModelSerializationExtensions.WireOptions;
 
             int id = default;
-            long seek = default;
+            int seek = default;
             TimeSpan start = default;
             TimeSpan end = default;
             string text = default;
-            IReadOnlyList<long> tokens = default;
+            IReadOnlyList<int> tokens = default;
             float temperature = default;
-            double avgLogprob = default;
+            float avgLogprob = default;
             float compressionRatio = default;
-            double noSpeechProb = default;
+            float noSpeechProb = default;
             IDictionary<string, BinaryData> serializedAdditionalRawData = default;
             Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
             foreach (var property in element.EnumerateObject())
@@ -139,7 +139,7 @@ namespace OpenAI.Audio
                 }
                 if (property.NameEquals("seek"u8))
                 {
-                    seek = property.Value.GetInt64();
+                    seek = property.Value.GetInt32();
                     continue;
                 }
                 if (property.NameEquals("start"u8))
@@ -159,10 +159,10 @@ namespace OpenAI.Audio
                 }
                 if (property.NameEquals("tokens"u8))
                 {
-                    List<long> array = new List<long>();
+                    List<int> array = new List<int>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetInt64());
+                        array.Add(item.GetInt32());
                     }
                     tokens = array;
                     continue;
@@ -174,7 +174,7 @@ namespace OpenAI.Audio
                 }
                 if (property.NameEquals("avg_logprob"u8))
                 {
-                    avgLogprob = property.Value.GetDouble();
+                    avgLogprob = property.Value.GetSingle();
                     continue;
                 }
                 if (property.NameEquals("compression_ratio"u8))
@@ -184,7 +184,7 @@ namespace OpenAI.Audio
                 }
                 if (property.NameEquals("no_speech_prob"u8))
                 {
-                    noSpeechProb = property.Value.GetDouble();
+                    noSpeechProb = property.Value.GetSingle();
                     continue;
                 }
                 if (true)

--- a/.dotnet/src/Generated/Models/TranscribedSegment.cs
+++ b/.dotnet/src/Generated/Models/TranscribedSegment.cs
@@ -10,15 +10,15 @@ namespace OpenAI.Audio
 {
     public readonly partial struct TranscribedSegment
     {
-        internal TranscribedSegment(int id, long seekOffset, TimeSpan start, TimeSpan end, string text, IEnumerable<long> tokenIds, float temperature, double averageLogProbability, float compressionRatio, double noSpeechProbability)
+        internal TranscribedSegment(int id, int seekOffset, TimeSpan startTime, TimeSpan endTime, string text, IEnumerable<int> tokenIds, float temperature, float averageLogProbability, float compressionRatio, float noSpeechProbability)
         {
             Argument.AssertNotNull(text, nameof(text));
             Argument.AssertNotNull(tokenIds, nameof(tokenIds));
 
             Id = id;
             SeekOffset = seekOffset;
-            Start = start;
-            End = end;
+            StartTime = startTime;
+            EndTime = endTime;
             Text = text;
             TokenIds = tokenIds.ToList();
             Temperature = temperature;
@@ -27,12 +27,12 @@ namespace OpenAI.Audio
             NoSpeechProbability = noSpeechProbability;
         }
 
-        internal TranscribedSegment(int id, long seekOffset, TimeSpan start, TimeSpan end, string text, IReadOnlyList<long> tokenIds, float temperature, double averageLogProbability, float compressionRatio, double noSpeechProbability, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal TranscribedSegment(int id, int seekOffset, TimeSpan startTime, TimeSpan endTime, string text, IReadOnlyList<int> tokenIds, float temperature, float averageLogProbability, float compressionRatio, float noSpeechProbability, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             Id = id;
             SeekOffset = seekOffset;
-            Start = start;
-            End = end;
+            StartTime = startTime;
+            EndTime = endTime;
             Text = text;
             TokenIds = tokenIds;
             Temperature = temperature;
@@ -47,8 +47,6 @@ namespace OpenAI.Audio
         }
 
         public int Id { get; }
-        public TimeSpan Start { get; }
-        public TimeSpan End { get; }
         public string Text { get; }
         public float Temperature { get; }
         public float CompressionRatio { get; }

--- a/.dotnet/src/Generated/Models/TranscribedWord.Serialization.cs
+++ b/.dotnet/src/Generated/Models/TranscribedWord.Serialization.cs
@@ -29,12 +29,12 @@ namespace OpenAI.Audio
             if (SerializedAdditionalRawData?.ContainsKey("start") != true)
             {
                 writer.WritePropertyName("start"u8);
-                writer.WriteNumberValue(Convert.ToDouble(Start.ToString("s\\.FFF")));
+                writer.WriteNumberValue(Convert.ToDouble(StartTime.ToString("s\\.FFF")));
             }
             if (SerializedAdditionalRawData?.ContainsKey("end") != true)
             {
                 writer.WritePropertyName("end"u8);
-                writer.WriteNumberValue(Convert.ToDouble(End.ToString("s\\.FFF")));
+                writer.WriteNumberValue(Convert.ToDouble(EndTime.ToString("s\\.FFF")));
             }
             if (SerializedAdditionalRawData != null)
             {

--- a/.dotnet/src/Generated/Models/TranscribedWord.cs
+++ b/.dotnet/src/Generated/Models/TranscribedWord.cs
@@ -9,20 +9,20 @@ namespace OpenAI.Audio
 {
     public readonly partial struct TranscribedWord
     {
-        internal TranscribedWord(string word, TimeSpan start, TimeSpan end)
+        internal TranscribedWord(string word, TimeSpan startTime, TimeSpan endTime)
         {
             Argument.AssertNotNull(word, nameof(word));
 
             Word = word;
-            Start = start;
-            End = end;
+            StartTime = startTime;
+            EndTime = endTime;
         }
 
-        internal TranscribedWord(string word, TimeSpan start, TimeSpan end, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal TranscribedWord(string word, TimeSpan startTime, TimeSpan endTime, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             Word = word;
-            Start = start;
-            End = end;
+            StartTime = startTime;
+            EndTime = endTime;
             SerializedAdditionalRawData = serializedAdditionalRawData;
         }
 
@@ -31,7 +31,5 @@ namespace OpenAI.Audio
         }
 
         public string Word { get; }
-        public TimeSpan Start { get; }
-        public TimeSpan End { get; }
     }
 }

--- a/.dotnet/src/Generated/OpenAIModelFactory.cs
+++ b/.dotnet/src/Generated/OpenAIModelFactory.cs
@@ -17,20 +17,20 @@ namespace OpenAI
 {
     internal static partial class OpenAIModelFactory
     {
-        public static TranscribedWord TranscribedWord(string word = null, TimeSpan start = default, TimeSpan end = default)
+        public static TranscribedWord TranscribedWord(string word = null, TimeSpan startTime = default, TimeSpan endTime = default)
         {
-            return new TranscribedWord(word, start, end, serializedAdditionalRawData: null);
+            return new TranscribedWord(word, startTime, endTime, serializedAdditionalRawData: null);
         }
 
-        public static TranscribedSegment TranscribedSegment(int id = default, long seekOffset = default, TimeSpan start = default, TimeSpan end = default, string text = null, IEnumerable<long> tokenIds = null, float temperature = default, double averageLogProbability = default, float compressionRatio = default, double noSpeechProbability = default)
+        public static TranscribedSegment TranscribedSegment(int id = default, int seekOffset = default, TimeSpan startTime = default, TimeSpan endTime = default, string text = null, IEnumerable<int> tokenIds = null, float temperature = default, float averageLogProbability = default, float compressionRatio = default, float noSpeechProbability = default)
         {
-            tokenIds ??= new List<long>();
+            tokenIds ??= new List<int>();
 
             return new TranscribedSegment(
                 id,
                 seekOffset,
-                start,
-                end,
+                startTime,
+                endTime,
                 text,
                 tokenIds?.ToList(),
                 temperature,

--- a/.dotnet/tests/Audio/OpenAIAudioModelFactoryTests.cs
+++ b/.dotnet/tests/Audio/OpenAIAudioModelFactoryTests.cs
@@ -161,15 +161,15 @@ public partial class OpenAIAudioModelFactoryTests
         TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment();
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
@@ -179,69 +179,69 @@ public partial class OpenAIAudioModelFactoryTests
         TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(id: id);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(id));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
     public void TranscribedSegmentWithSeekOffsetWorks()
     {
-        long seekOffset = 9000000000;
+        int seekOffset = 900000000;
         TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(seekOffset: seekOffset);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
         Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(seekOffset));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
     public void TranscribedSegmentWithStartWorks()
     {
-        TimeSpan start = TimeSpan.FromSeconds(45);
-        TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(start: start);
+        TimeSpan startTime = TimeSpan.FromSeconds(45);
+        TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(startTime: startTime);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(start));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(startTime));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
     public void TranscribedSegmentWithEndWorks()
     {
-        TimeSpan end = TimeSpan.FromSeconds(45);
-        TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(end: end);
+        TimeSpan endTime = TimeSpan.FromSeconds(45);
+        TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(endTime: endTime);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(end));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(endTime));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
@@ -251,33 +251,33 @@ public partial class OpenAIAudioModelFactoryTests
         TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(text: text);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.EqualTo(text));
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
     public void TranscribedSegmentWithTokenIdsWorks()
     {
-        IEnumerable<long> tokenIds = [9000000000, 9000000010];
+        IEnumerable<int> tokenIds = [900000000, 900000001];
         TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(tokenIds: tokenIds);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds.SequenceEqual(tokenIds), Is.True);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
@@ -287,33 +287,33 @@ public partial class OpenAIAudioModelFactoryTests
         TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(temperature: temperature);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(temperature));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
     public void TranscribedSegmentWithAverageLogProbabilityWorks()
     {
-        double averageLogProbability = -3.1415;
+        float averageLogProbability = -3.1415f;
         TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(averageLogProbability: averageLogProbability);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(averageLogProbability));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
@@ -323,31 +323,31 @@ public partial class OpenAIAudioModelFactoryTests
         TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(compressionRatio: compressionRatio);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(compressionRatio));
-        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(default(float)));
     }
 
     [Test]
     public void TranscribedSegmentWithNoSpeechProbabilityWorks()
     {
-        double noSpeechProbability = 0.02;
+        float noSpeechProbability = 0.02f;
         TranscribedSegment transcribedSegment = OpenAIAudioModelFactory.TranscribedSegment(noSpeechProbability: noSpeechProbability);
 
         Assert.That(transcribedSegment.Id, Is.EqualTo(default(int)));
-        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(long)));
-        Assert.That(transcribedSegment.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedSegment.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.SeekOffset, Is.EqualTo(default(int)));
+        Assert.That(transcribedSegment.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedSegment.EndTime, Is.EqualTo(default(TimeSpan)));
         Assert.That(transcribedSegment.Text, Is.Null);
         Assert.That(transcribedSegment.TokenIds, Is.Not.Null.And.Empty);
         Assert.That(transcribedSegment.Temperature, Is.EqualTo(default(float)));
-        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(double)));
+        Assert.That(transcribedSegment.AverageLogProbability, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.CompressionRatio, Is.EqualTo(default(float)));
         Assert.That(transcribedSegment.NoSpeechProbability, Is.EqualTo(noSpeechProbability));
     }
@@ -358,8 +358,8 @@ public partial class OpenAIAudioModelFactoryTests
         TranscribedWord transcribedWord = OpenAIAudioModelFactory.TranscribedWord();
 
         Assert.That(transcribedWord.Word, Is.Null);
-        Assert.That(transcribedWord.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedWord.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedWord.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedWord.EndTime, Is.EqualTo(default(TimeSpan)));
     }
 
     [Test]
@@ -369,29 +369,29 @@ public partial class OpenAIAudioModelFactoryTests
         TranscribedWord transcribedWord = OpenAIAudioModelFactory.TranscribedWord(word: word);
 
         Assert.That(transcribedWord.Word, Is.EqualTo(word));
-        Assert.That(transcribedWord.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedWord.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedWord.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedWord.EndTime, Is.EqualTo(default(TimeSpan)));
     }
 
     [Test]
     public void TranscribedWordWithStartWorks()
     {
-        TimeSpan start = TimeSpan.FromSeconds(45);
-        TranscribedWord transcribedWord = OpenAIAudioModelFactory.TranscribedWord(start: start);
+        TimeSpan startTime = TimeSpan.FromSeconds(45);
+        TranscribedWord transcribedWord = OpenAIAudioModelFactory.TranscribedWord(startTime: startTime);
 
         Assert.That(transcribedWord.Word, Is.Null);
-        Assert.That(transcribedWord.Start, Is.EqualTo(start));
-        Assert.That(transcribedWord.End, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedWord.StartTime, Is.EqualTo(startTime));
+        Assert.That(transcribedWord.EndTime, Is.EqualTo(default(TimeSpan)));
     }
 
     [Test]
     public void TranscribedWordWithEndWorks()
     {
-        TimeSpan end = TimeSpan.FromSeconds(45);
-        TranscribedWord transcribedWord = OpenAIAudioModelFactory.TranscribedWord(end: end);
+        TimeSpan endTime = TimeSpan.FromSeconds(45);
+        TranscribedWord transcribedWord = OpenAIAudioModelFactory.TranscribedWord(endTime: endTime);
 
         Assert.That(transcribedWord.Word, Is.Null);
-        Assert.That(transcribedWord.Start, Is.EqualTo(default(TimeSpan)));
-        Assert.That(transcribedWord.End, Is.EqualTo(end));
+        Assert.That(transcribedWord.StartTime, Is.EqualTo(default(TimeSpan)));
+        Assert.That(transcribedWord.EndTime, Is.EqualTo(endTime));
     }
 }

--- a/.dotnet/tests/Audio/TranscriptionMockTests.cs
+++ b/.dotnet/tests/Audio/TranscriptionMockTests.cs
@@ -132,9 +132,9 @@ public partial class TranscriptionMockTests : SyncAsyncTestBase
         Assert.That(segment.Text, Is.EqualTo("The quick brown fox got lost."));
         Assert.That(segment.TokenIds.SequenceEqual([255, 305, 678]));
         Assert.That(segment.Temperature, Is.EqualTo(0.8f));
-        Assert.That(segment.AverageLogProbability, Is.EqualTo(-0.3));
+        Assert.That(segment.AverageLogProbability, Is.EqualTo(-0.3f));
         Assert.That(segment.CompressionRatio, Is.EqualTo(1.5f));
-        Assert.That(segment.NoSpeechProbability, Is.EqualTo(0.2));
+        Assert.That(segment.NoSpeechProbability, Is.EqualTo(0.2f));
     }
 
     [Test]

--- a/.dotnet/tests/Audio/TranscriptionMockTests.cs
+++ b/.dotnet/tests/Audio/TranscriptionMockTests.cs
@@ -93,8 +93,8 @@ public partial class TranscriptionMockTests : SyncAsyncTestBase
         TranscribedWord word = transcription.Words.Single();
 
         Assert.That(word.Word, Is.EqualTo("pneumonoultramicroscopicsilicovolcanoconiosis"));
-        Assert.That(word.Start, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
-        Assert.That(word.End, Is.EqualTo(TimeSpan.FromSeconds(7.5)));
+        Assert.That(word.StartTime, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+        Assert.That(word.EndTime, Is.EqualTo(TimeSpan.FromSeconds(7.5)));
     }
 
     [Test]
@@ -127,8 +127,8 @@ public partial class TranscriptionMockTests : SyncAsyncTestBase
 
         Assert.That(segment.Id, Is.EqualTo(15));
         Assert.That(segment.SeekOffset, Is.EqualTo(50));
-        Assert.That(segment.Start, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
-        Assert.That(segment.End, Is.EqualTo(TimeSpan.FromSeconds(7.5)));
+        Assert.That(segment.StartTime, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+        Assert.That(segment.EndTime, Is.EqualTo(TimeSpan.FromSeconds(7.5)));
         Assert.That(segment.Text, Is.EqualTo("The quick brown fox got lost."));
         Assert.That(segment.TokenIds.SequenceEqual([255, 305, 678]));
         Assert.That(segment.Temperature, Is.EqualTo(0.8f));

--- a/.dotnet/tests/Audio/TranscriptionTests.cs
+++ b/.dotnet/tests/Audio/TranscriptionTests.cs
@@ -101,9 +101,9 @@ public partial class TranscriptionTests : SyncAsyncTestBase
         {
             if (i > 0)
             {
-                Assert.That(words[i].Start, Is.GreaterThanOrEqualTo(words[i - 1].End));
+                Assert.That(words[i].StartTime, Is.GreaterThanOrEqualTo(words[i - 1].EndTime));
             }
-            Assert.That(words[i].End, Is.GreaterThan(words[i].Start));
+            Assert.That(words[i].EndTime, Is.GreaterThan(words[i].StartTime));
             Assert.That(string.IsNullOrEmpty(words[i].Word), Is.False);
         }
 
@@ -113,9 +113,9 @@ public partial class TranscriptionTests : SyncAsyncTestBase
             {
                 Assert.That(segments[i].Id, Is.GreaterThan(segments[i - 1].Id));
                 Assert.That(segments[i].SeekOffset, Is.GreaterThan(0));
-                Assert.That(segments[i].Start, Is.GreaterThanOrEqualTo(segments[i - 1].End));
+                Assert.That(segments[i].StartTime, Is.GreaterThanOrEqualTo(segments[i - 1].EndTime));
             }
-            Assert.That(segments[i].End, Is.GreaterThan(segments[i].Start));
+            Assert.That(segments[i].EndTime, Is.GreaterThan(segments[i].StartTime));
             Assert.That(string.IsNullOrEmpty(segments[i].Text), Is.False);
             Assert.That(segments[i].TokenIds, Is.Not.Null.And.Not.Empty);
             foreach (int tokenId in segments[i].TokenIds)

--- a/.dotnet/tests/Audio/TranslationMockTests.cs
+++ b/.dotnet/tests/Audio/TranslationMockTests.cs
@@ -103,8 +103,8 @@ public partial class TranslationMockTests : SyncAsyncTestBase
 
         Assert.That(segment.Id, Is.EqualTo(15));
         Assert.That(segment.SeekOffset, Is.EqualTo(50));
-        Assert.That(segment.Start, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
-        Assert.That(segment.End, Is.EqualTo(TimeSpan.FromSeconds(7.5)));
+        Assert.That(segment.StartTime, Is.EqualTo(TimeSpan.FromSeconds(2.5)));
+        Assert.That(segment.EndTime, Is.EqualTo(TimeSpan.FromSeconds(7.5)));
         Assert.That(segment.Text, Is.EqualTo("The quick brown fox got lost."));
         Assert.That(segment.TokenIds.SequenceEqual([255, 305, 678]));
         Assert.That(segment.Temperature, Is.EqualTo(0.8f));

--- a/.dotnet/tests/Audio/TranslationMockTests.cs
+++ b/.dotnet/tests/Audio/TranslationMockTests.cs
@@ -108,9 +108,9 @@ public partial class TranslationMockTests : SyncAsyncTestBase
         Assert.That(segment.Text, Is.EqualTo("The quick brown fox got lost."));
         Assert.That(segment.TokenIds.SequenceEqual([255, 305, 678]));
         Assert.That(segment.Temperature, Is.EqualTo(0.8f));
-        Assert.That(segment.AverageLogProbability, Is.EqualTo(-0.3));
+        Assert.That(segment.AverageLogProbability, Is.EqualTo(-0.3f));
         Assert.That(segment.CompressionRatio, Is.EqualTo(1.5f));
-        Assert.That(segment.NoSpeechProbability, Is.EqualTo(0.2));
+        Assert.That(segment.NoSpeechProbability, Is.EqualTo(0.2f));
     }
 
     [Test]

--- a/.dotnet/tests/Audio/TranslationTests.cs
+++ b/.dotnet/tests/Audio/TranslationTests.cs
@@ -87,11 +87,11 @@ public partial class TranslationTests : SyncAsyncTestBase
 
                 if (i > 0)
                 {
-                    Assert.That(segment.Start, Is.GreaterThanOrEqualTo(translation.Segments[i - 1].End));
+                    Assert.That(segment.StartTime, Is.GreaterThanOrEqualTo(translation.Segments[i - 1].EndTime));
                 }
 
                 Assert.That(segment.Id, Is.EqualTo(i));
-                Assert.That(segment.End, Is.GreaterThanOrEqualTo(segment.Start));
+                Assert.That(segment.EndTime, Is.GreaterThanOrEqualTo(segment.StartTime));
                 Assert.That(segment.TokenIds, Is.Not.Null.And.Not.Empty);
 
                 Assert.That(segment.AverageLogProbability, Is.LessThan(-0.001f).Or.GreaterThan(0.001f));

--- a/.dotnet/tests/Chat/OpenAIChatModelFactoryTests.cs
+++ b/.dotnet/tests/Chat/OpenAIChatModelFactoryTests.cs
@@ -322,7 +322,7 @@ public partial class OpenAIChatModelFactoryTests
 
         Assert.That(chatTokenLogProbabilityDetails.Token, Is.Null);
         Assert.That(chatTokenLogProbabilityDetails.LogProbability, Is.EqualTo(0f));
-        Assert.That(chatTokenLogProbabilityDetails.Utf8Bytes, Is.Not.Null.And.Empty);
+        Assert.That(chatTokenLogProbabilityDetails.Utf8Bytes, Is.Null);
         Assert.That(chatTokenLogProbabilityDetails.TopLogProbabilities, Is.Not.Null.And.Empty);
     }
 
@@ -334,7 +334,7 @@ public partial class OpenAIChatModelFactoryTests
 
         Assert.That(chatTokenLogProbabilityDetails.Token, Is.EqualTo(token));
         Assert.That(chatTokenLogProbabilityDetails.LogProbability, Is.EqualTo(0f));
-        Assert.That(chatTokenLogProbabilityDetails.Utf8Bytes, Is.Not.Null.And.Empty);
+        Assert.That(chatTokenLogProbabilityDetails.Utf8Bytes, Is.Null);
         Assert.That(chatTokenLogProbabilityDetails.TopLogProbabilities, Is.Not.Null.And.Empty);
     }
 
@@ -346,7 +346,7 @@ public partial class OpenAIChatModelFactoryTests
 
         Assert.That(chatTokenLogProbabilityDetails.Token, Is.Null);
         Assert.That(chatTokenLogProbabilityDetails.LogProbability, Is.EqualTo(logProbability));
-        Assert.That(chatTokenLogProbabilityDetails.Utf8Bytes, Is.Not.Null.And.Empty);
+        Assert.That(chatTokenLogProbabilityDetails.Utf8Bytes, Is.Null);
         Assert.That(chatTokenLogProbabilityDetails.TopLogProbabilities, Is.Not.Null.And.Empty);
     }
 
@@ -373,7 +373,7 @@ public partial class OpenAIChatModelFactoryTests
 
         Assert.That(chatTokenLogProbabilityDetails.Token, Is.Null);
         Assert.That(chatTokenLogProbabilityDetails.LogProbability, Is.EqualTo(0f));
-        Assert.That(chatTokenLogProbabilityDetails.Utf8Bytes, Is.Not.Null.And.Empty);
+        Assert.That(chatTokenLogProbabilityDetails.Utf8Bytes, Is.Null);
         Assert.That(chatTokenLogProbabilityDetails.TopLogProbabilities.SequenceEqual(topLogProbabilities), Is.True);
     }
 
@@ -384,7 +384,7 @@ public partial class OpenAIChatModelFactoryTests
 
         Assert.That(chatTokenTopLogProbabilityDetails.Token, Is.Null);
         Assert.That(chatTokenTopLogProbabilityDetails.LogProbability, Is.EqualTo(0f));
-        Assert.That(chatTokenTopLogProbabilityDetails.Utf8Bytes, Is.Not.Null.And.Empty);
+        Assert.That(chatTokenTopLogProbabilityDetails.Utf8Bytes, Is.Null);
     }
 
     [Test]
@@ -395,7 +395,7 @@ public partial class OpenAIChatModelFactoryTests
 
         Assert.That(chatTokenTopLogProbabilityDetails.Token, Is.EqualTo(token));
         Assert.That(chatTokenTopLogProbabilityDetails.LogProbability, Is.EqualTo(0f));
-        Assert.That(chatTokenTopLogProbabilityDetails.Utf8Bytes, Is.Not.Null.And.Empty);
+        Assert.That(chatTokenTopLogProbabilityDetails.Utf8Bytes, Is.Null);
     }
 
     [Test]
@@ -406,7 +406,7 @@ public partial class OpenAIChatModelFactoryTests
 
         Assert.That(chatTokenTopLogProbabilityDetails.Token, Is.Null);
         Assert.That(chatTokenTopLogProbabilityDetails.LogProbability, Is.EqualTo(logProbability));
-        Assert.That(chatTokenTopLogProbabilityDetails.Utf8Bytes, Is.Not.Null.And.Empty);
+        Assert.That(chatTokenTopLogProbabilityDetails.Utf8Bytes, Is.Null);
     }
 
     [Test]


### PR DESCRIPTION
- Renamed the `Start` and `End` properties of `TranscribedSegment` and `TranscribedWord` to `StartTime` and `EndTime`. 
- Changed the type of `TranscribedSegment`'s `AverageLogProbability` and `NoSpeechProbability` properties from `double` to `float`.
- Changed the type of `TranscribedSegment`'s `SeekOffset` property from `long` to `int`.
- Changed the type of `TranscribedSegment`'s `TokenIds` property from `IReadOnlyList<long>` to `IReadOnlyList<int>`. 