### PR TITLE
Remove Optional parameters from model constructors

### DIFF
--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.Functions.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.Functions.cs
@@ -34,7 +34,7 @@ public partial class ChatTests
                     }
                 }
             }
-            """) };
+            """)};
 
     public enum FunctionCallTestType
     {

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.Functions.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.Functions.cs
@@ -122,13 +122,11 @@ public partial class ChatTests
 
         // Complete the function call
         messages.Add(new AssistantChatMessage(completion.FunctionCall));
-        var functionChatMessage = new FunctionChatMessage(FUNCTION_TEMPERATURE.FunctionName);
-        functionChatMessage.Content.Add(ChatMessageContentPart.CreateTextPart(JsonSerializer.Serialize(new
+        messages.Add(new FunctionChatMessage(FUNCTION_TEMPERATURE.FunctionName, JsonSerializer.Serialize(new
         {
             temperature = 31,
             unit = "celsius"
         })));
-        messages.Add(functionChatMessage);
 
         requestOptions = new()
         {
@@ -246,14 +244,12 @@ public partial class ChatTests
             //             us manual control are internal. So let's use JSON.
             var converted = ModelReaderWriter.Read<ChatFunctionCall>(BinaryData.FromString(JsonSerializer.Serialize(new { name = functionName, arguments = functionArgs.ToString() })));
             messages.Add(new AssistantChatMessage(converted));
-            var functionChatMessage = new FunctionChatMessage(FUNCTION_TEMPERATURE.FunctionName);
-            functionChatMessage.Content.Add(ChatMessageContentPart.CreateTextPart(JsonSerializer.Serialize(new
+            messages.Add(new FunctionChatMessage(FUNCTION_TEMPERATURE.FunctionName, JsonSerializer.Serialize(new
             {
                 temperature = 31,
                 unit = "celsius"
             })));
-            messages.Add(functionChatMessage);
-            
+
             requestOptions = new()
             {
                 Functions = { FUNCTION_TEMPERATURE },

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.Functions.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.Functions.cs
@@ -17,10 +17,9 @@ namespace Azure.AI.OpenAI.Tests;
 public partial class ChatTests
 {
     [Obsolete]
-    private static readonly ChatFunction FUNCTION_TEMPERATURE = new(
-        "get_future_temperature",
-        "requests the anticipated future temperature at a provided location to help inform advice about topics like choice of attire",
-        BinaryData.FromString(
+    private static readonly ChatFunction FUNCTION_TEMPERATURE = new("get_future_temperature") {
+        FunctionDescription = "requests the anticipated future temperature at a provided location to help inform advice about topics like choice of attire",
+        FunctionParameters = BinaryData.FromString(
             """
             {
                 "type": "object",
@@ -35,7 +34,7 @@ public partial class ChatTests
                     }
                 }
             }
-            """));
+            """) };
 
     public enum FunctionCallTestType
     {
@@ -123,11 +122,13 @@ public partial class ChatTests
 
         // Complete the function call
         messages.Add(new AssistantChatMessage(completion.FunctionCall));
-        messages.Add(new FunctionChatMessage(FUNCTION_TEMPERATURE.FunctionName, JsonSerializer.Serialize(new
+        var functionChatMessage = new FunctionChatMessage(FUNCTION_TEMPERATURE.FunctionName);
+        functionChatMessage.Content.Add(ChatMessageContentPart.CreateTextPart(JsonSerializer.Serialize(new
         {
             temperature = 31,
             unit = "celsius"
         })));
+        messages.Add(functionChatMessage);
 
         requestOptions = new()
         {
@@ -245,12 +246,14 @@ public partial class ChatTests
             //             us manual control are internal. So let's use JSON.
             var converted = ModelReaderWriter.Read<ChatFunctionCall>(BinaryData.FromString(JsonSerializer.Serialize(new { name = functionName, arguments = functionArgs.ToString() })));
             messages.Add(new AssistantChatMessage(converted));
-            messages.Add(new FunctionChatMessage(FUNCTION_TEMPERATURE.FunctionName, JsonSerializer.Serialize(new
+            var functionChatMessage = new FunctionChatMessage(FUNCTION_TEMPERATURE.FunctionName);
+            functionChatMessage.Content.Add(ChatMessageContentPart.CreateTextPart(JsonSerializer.Serialize(new
             {
                 temperature = 31,
                 unit = "celsius"
             })));
-
+            messages.Add(functionChatMessage);
+            
             requestOptions = new()
             {
                 Functions = { FUNCTION_TEMPERATURE },

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Samples/01_Chat.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Samples/01_Chat.cs
@@ -276,7 +276,9 @@ public partial class AzureOpenAISamples
                 functionArgumentBuildersByIndex[indexToIdPair.Key].ToString()));
         }
 
-        conversationMessages.Add(new AssistantChatMessage(toolCalls, contentBuilder.ToString()));
+        var assistantChatMessage = new AssistantChatMessage(toolCalls);
+        assistantChatMessage.Content.Add(ChatMessageContentPart.CreateTextPart(contentBuilder.ToString()));
+        conversationMessages.Add(assistantChatMessage);
 
         // Placeholder: each tool call must be resolved, like in the non-streaming case
         string GetToolCallOutput(ChatToolCall toolCall) => null;

--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Changed the type of `TranscribedSegment`'s `SeekOffset` property from `long` to `int`. (commit_hash)
 - Changed the type of `TranscribedSegment`'s `TokenIds` property from `IReadOnlyList<long>` to `IReadOnlyList<int>`. (commit_hash)
 - Updated the `Embedding.Vector` property to the `Embedding.ToFloats()` method. (commit_hash)
-- Removed the optional parameter from the constructors of `VectorStoreCreationHelper`, `AssistantChatMessage`, `ChatFunction`, and `FunctionChatMessage`. (commit_hash)
+- Removed the optional parameter from the constructors of `VectorStoreCreationHelper`, `AssistantChatMessage`, and `ChatFunction`. (commit_hash)
 - Removed the optional `purpose` parameter from `FileClient.GetFilesAsync` and `FileClient.GetFiles` methods, and added overloads where `purpose` is required. (commit_hash)
 
 ### Bugs Fixed

--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Changed the type of `TranscribedSegment`'s `SeekOffset` property from `long` to `int`. (commit_hash)
 - Changed the type of `TranscribedSegment`'s `TokenIds` property from `IReadOnlyList<long>` to `IReadOnlyList<int>`. (commit_hash)
 - Updated the `Embedding.Vector` property to the `Embedding.ToFloats()` method. (commit_hash)
+- Removed the optional parameter from the constructors of `VectorStoreCreationHelper`, `AssistantChatMessage`, `ChatFunction`, and `FunctionChatMessage`. (commit_hash)
+- Removed the optional `purpose` parameter from `FileClient.GetFilesAsync` and `FileClient.GetFiles` methods, and added overloads where `purpose` is required. (commit_hash)
 
 ### Bugs Fixed
 

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -1022,8 +1022,8 @@ namespace OpenAI.Assistants {
     }
     public class VectorStoreCreationHelper : IJsonModel<VectorStoreCreationHelper>, IPersistableModel<VectorStoreCreationHelper> {
         public VectorStoreCreationHelper();
-        public VectorStoreCreationHelper(IEnumerable<OpenAIFileInfo> files, IDictionary<string, string> metadata = null);
-        public VectorStoreCreationHelper(IEnumerable<string> fileIds, IDictionary<string, string> metadata = null);
+        public VectorStoreCreationHelper(IEnumerable<OpenAIFileInfo> files);
+        public VectorStoreCreationHelper(IEnumerable<string> fileIds);
         public FileChunkingStrategy ChunkingStrategy { get; set; }
         public IList<string> FileIds { get; }
         public IDictionary<string, string> Metadata { get; }
@@ -1244,10 +1244,10 @@ namespace OpenAI.Batch {
 namespace OpenAI.Chat {
     public class AssistantChatMessage : ChatMessage, IJsonModel<AssistantChatMessage>, IPersistableModel<AssistantChatMessage> {
         public AssistantChatMessage(ChatCompletion chatCompletion);
-        public AssistantChatMessage(ChatFunctionCall functionCall, string content = null);
+        public AssistantChatMessage(ChatFunctionCall functionCall);
         public AssistantChatMessage(params ChatMessageContentPart[] contentParts);
         public AssistantChatMessage(IEnumerable<ChatMessageContentPart> contentParts);
-        public AssistantChatMessage(IEnumerable<ChatToolCall> toolCalls, string content = null);
+        public AssistantChatMessage(IEnumerable<ChatToolCall> toolCalls);
         public AssistantChatMessage(string content);
         [Obsolete("This property is obsolete. Please use ToolCalls instead.")]
         public ChatFunctionCall FunctionCall { get; set; }
@@ -1336,7 +1336,7 @@ namespace OpenAI.Chat {
     }
     [Obsolete("This class is obsolete. Please use ChatTool instead.")]
     public class ChatFunction : IJsonModel<ChatFunction>, IPersistableModel<ChatFunction> {
-        public ChatFunction(string functionName, string functionDescription = null, BinaryData functionParameters = null);
+        public ChatFunction(string functionName);
         public string FunctionDescription { get; set; }
         public string FunctionName { get; }
         public BinaryData FunctionParameters { get; set; }
@@ -1388,13 +1388,13 @@ namespace OpenAI.Chat {
     public abstract class ChatMessage : IJsonModel<ChatMessage>, IPersistableModel<ChatMessage> {
         public IList<ChatMessageContentPart> Content { get; }
         public static AssistantChatMessage CreateAssistantMessage(ChatCompletion chatCompletion);
-        public static AssistantChatMessage CreateAssistantMessage(ChatFunctionCall functionCall, string content = null);
+        public static AssistantChatMessage CreateAssistantMessage(ChatFunctionCall functionCall);
         public static AssistantChatMessage CreateAssistantMessage(params ChatMessageContentPart[] contentParts);
         public static AssistantChatMessage CreateAssistantMessage(IEnumerable<ChatMessageContentPart> contentParts);
-        public static AssistantChatMessage CreateAssistantMessage(IEnumerable<ChatToolCall> toolCalls, string content = null);
+        public static AssistantChatMessage CreateAssistantMessage(IEnumerable<ChatToolCall> toolCalls);
         public static AssistantChatMessage CreateAssistantMessage(string content);
         [Obsolete("This method is obsolete. Please use CreateToolMessage instead.")]
-        public static FunctionChatMessage CreateFunctionMessage(string functionName, string content);
+        public static FunctionChatMessage CreateFunctionMessage(string functionName);
         public static SystemChatMessage CreateSystemMessage(params ChatMessageContentPart[] contentParts);
         public static SystemChatMessage CreateSystemMessage(IEnumerable<ChatMessageContentPart> contentParts);
         public static SystemChatMessage CreateSystemMessage(string content);
@@ -1563,7 +1563,7 @@ namespace OpenAI.Chat {
     }
     [Obsolete("This class is obsolete. Please use ToolChatMessage instead.")]
     public class FunctionChatMessage : ChatMessage, IJsonModel<FunctionChatMessage>, IPersistableModel<FunctionChatMessage> {
-        public FunctionChatMessage(string functionName, string content = null);
+        public FunctionChatMessage(string functionName);
         public string FunctionName { get; }
         FunctionChatMessage IJsonModel<FunctionChatMessage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<FunctionChatMessage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
@@ -1743,12 +1743,14 @@ namespace OpenAI.Files {
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<ClientResult> GetFileAsync(string fileId, RequestOptions options);
         public virtual Task<ClientResult<OpenAIFileInfo>> GetFileAsync(string fileId, CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFileInfoCollection> GetFiles(OpenAIFilePurpose? purpose = null, CancellationToken cancellationToken = default);
+        public virtual ClientResult<OpenAIFileInfoCollection> GetFiles(OpenAIFilePurpose purpose, CancellationToken cancellationToken = default);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult GetFiles(string purpose, RequestOptions options);
-        public virtual Task<ClientResult<OpenAIFileInfoCollection>> GetFilesAsync(OpenAIFilePurpose? purpose = null, CancellationToken cancellationToken = default);
+        public virtual ClientResult<OpenAIFileInfoCollection> GetFiles(CancellationToken cancellationToken = default);
+        public virtual Task<ClientResult<OpenAIFileInfoCollection>> GetFilesAsync(OpenAIFilePurpose purpose, CancellationToken cancellationToken = default);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<ClientResult> GetFilesAsync(string purpose, RequestOptions options);
+        public virtual Task<ClientResult<OpenAIFileInfoCollection>> GetFilesAsync(CancellationToken cancellationToken = default);
         public virtual ClientResult<OpenAIFileInfo> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose);
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult UploadFile(BinaryContent content, string contentType, RequestOptions options = null);

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -1394,7 +1394,7 @@ namespace OpenAI.Chat {
         public static AssistantChatMessage CreateAssistantMessage(IEnumerable<ChatToolCall> toolCalls);
         public static AssistantChatMessage CreateAssistantMessage(string content);
         [Obsolete("This method is obsolete. Please use CreateToolMessage instead.")]
-        public static FunctionChatMessage CreateFunctionMessage(string functionName);
+        public static FunctionChatMessage CreateFunctionMessage(string functionName, string content);
         public static SystemChatMessage CreateSystemMessage(params ChatMessageContentPart[] contentParts);
         public static SystemChatMessage CreateSystemMessage(IEnumerable<ChatMessageContentPart> contentParts);
         public static SystemChatMessage CreateSystemMessage(string content);
@@ -1563,7 +1563,7 @@ namespace OpenAI.Chat {
     }
     [Obsolete("This class is obsolete. Please use ToolChatMessage instead.")]
     public class FunctionChatMessage : ChatMessage, IJsonModel<FunctionChatMessage>, IPersistableModel<FunctionChatMessage> {
-        public FunctionChatMessage(string functionName);
+        public FunctionChatMessage(string functionName, string content);
         public string FunctionName { get; }
         FunctionChatMessage IJsonModel<FunctionChatMessage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<FunctionChatMessage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);

--- a/.dotnet/examples/Chat/Example04_FunctionCallingStreaming.cs
+++ b/.dotnet/examples/Chat/Example04_FunctionCallingStreaming.cs
@@ -101,8 +101,13 @@ public partial class ChatExamples
                             }
 
                             // Next, add the assistant message with tool calls to the conversation history.
+                            var assistantChatMessage = new AssistantChatMessage(toolCalls);
                             string content = contentBuilder.Length > 0 ? contentBuilder.ToString() : null;
-                            messages.Add(new AssistantChatMessage(toolCalls, content));
+                            if (content != null)
+                            {
+                                assistantChatMessage.Content.Add(ChatMessageContentPart.CreateTextPart(content));
+                            }
+                            messages.Add(assistantChatMessage);
 
                             // Then, add a new tool message for each tool call to be resolved.
                             foreach (ChatToolCall toolCall in toolCalls)

--- a/.dotnet/examples/Chat/Example04_FunctionCallingStreamingAsync.cs
+++ b/.dotnet/examples/Chat/Example04_FunctionCallingStreamingAsync.cs
@@ -102,8 +102,13 @@ public partial class ChatExamples
                             }
 
                             // Next, add the assistant message with tool calls to the conversation history.
+                            var assistantChatMessage = new AssistantChatMessage(toolCalls);
                             string content = contentBuilder.Length > 0 ? contentBuilder.ToString() : null;
-                            messages.Add(new AssistantChatMessage(toolCalls, content));
+                            if (content != null)
+                            {
+                                assistantChatMessage.Content.Add(ChatMessageContentPart.CreateTextPart(content));
+                            }
+                            messages.Add(assistantChatMessage);
 
                             // Then, add a new tool message for each tool call to be resolved.
                             foreach (ChatToolCall toolCall in toolCalls)

--- a/.dotnet/src/Custom/Assistants/VectorStoreCreationHelper.cs
+++ b/.dotnet/src/Custom/Assistants/VectorStoreCreationHelper.cs
@@ -13,13 +13,13 @@ public partial class VectorStoreCreationHelper
     [CodeGenMember("ChunkingStrategy")]
     public FileChunkingStrategy ChunkingStrategy { get; set; }
 
-    public VectorStoreCreationHelper(IEnumerable<string> fileIds, IDictionary<string, string> metadata = null)
+    public VectorStoreCreationHelper(IEnumerable<string> fileIds)
     {
         FileIds = fileIds.ToList();
-        Metadata = metadata ?? new ChangeTrackingDictionary<string, string>();
+        Metadata = new ChangeTrackingDictionary<string, string>();
     }
 
-    public VectorStoreCreationHelper(IEnumerable<OpenAIFileInfo> files, IDictionary<string, string> metadata = null)
-        : this(files?.Select(file => file.Id) ?? [], metadata)
+    public VectorStoreCreationHelper(IEnumerable<OpenAIFileInfo> files)
+        : this(files?.Select(file => file.Id) ?? [])
     { }
 }

--- a/.dotnet/src/Custom/Chat/AssistantChatMessage.cs
+++ b/.dotnet/src/Custom/Chat/AssistantChatMessage.cs
@@ -58,9 +58,8 @@ public partial class AssistantChatMessage : ChatMessage
     /// were provided by the model.
     /// </summary>
     /// <param name="toolCalls"> The <c>tool_calls</c> made by the model. </param>
-    /// <param name="content"> Optional text content associated with the message. </param>
-    public AssistantChatMessage(IEnumerable<ChatToolCall> toolCalls, string content = null)
-        : base(ChatMessageRole.Assistant, content)
+    public AssistantChatMessage(IEnumerable<ChatToolCall> toolCalls)
+        : base(ChatMessageRole.Assistant)
     {
         Argument.AssertNotNull(toolCalls, nameof(toolCalls));
 
@@ -75,9 +74,8 @@ public partial class AssistantChatMessage : ChatMessage
     /// (deprecated in favor of <c>tool_calls</c>) that was made by the model.
     /// </summary>
     /// <param name="functionCall"> The <c>function_call</c> made by the model. </param>
-    /// <param name="content"> Optional text content associated with the message. </param>
-    public AssistantChatMessage(ChatFunctionCall functionCall, string content = null)
-        : base(ChatMessageRole.Assistant, content)
+    public AssistantChatMessage(ChatFunctionCall functionCall)
+        : base(ChatMessageRole.Assistant)
     {
         Argument.AssertNotNull(functionCall, nameof(functionCall));
 

--- a/.dotnet/src/Custom/Chat/ChatFunction.cs
+++ b/.dotnet/src/Custom/Chat/ChatFunction.cs
@@ -15,15 +15,11 @@ public partial class ChatFunction
     /// Creates a new instance of <see cref="ChatFunction"/>.
     /// </summary>
     /// <param name="functionName"> The <c>name</c> of the function. </param>
-    /// <param name="functionDescription"> The <c>description</c> of the function. </param>
-    /// <param name="functionParameters"> The <c>parameters</c> into the function, in JSON Schema format. </param>
-    public ChatFunction(string functionName, string functionDescription = null, BinaryData functionParameters = null)
+    public ChatFunction(string functionName)
     {
         Argument.AssertNotNull(functionName, nameof(functionName));
 
         FunctionName = functionName;
-        FunctionDescription = functionDescription;
-        FunctionParameters = functionParameters;
     }
 
     // CUSTOM: Renamed.

--- a/.dotnet/src/Custom/Chat/ChatMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatMessage.cs
@@ -149,7 +149,7 @@ public abstract partial class ChatMessage
     #region FunctionChatMessage
     /// <inheritdoc cref="FunctionChatMessage(string, string)"/>
     [Obsolete($"This method is obsolete. Please use {nameof(CreateToolMessage)} instead.")]
-    public static FunctionChatMessage CreateFunctionMessage(string functionName) => new(functionName);
+    public static FunctionChatMessage CreateFunctionMessage(string functionName, string content) => new(functionName, content);
     #endregion
 
     /// <summary>

--- a/.dotnet/src/Custom/Chat/ChatMessage.cs
+++ b/.dotnet/src/Custom/Chat/ChatMessage.cs
@@ -78,7 +78,7 @@ public abstract partial class ChatMessage
         }
     }
 
-    internal ChatMessage(ChatMessageRole role, string content)
+    internal ChatMessage(ChatMessageRole role, string content = null)
     {
         Role = role;
 
@@ -126,10 +126,10 @@ public abstract partial class ChatMessage
     public static AssistantChatMessage CreateAssistantMessage(params ChatMessageContentPart[] contentParts) => new(contentParts);
 
     /// <inheritdoc cref="AssistantChatMessage(IEnumerable{ChatToolCall}, string)"/>
-    public static AssistantChatMessage CreateAssistantMessage(IEnumerable<ChatToolCall> toolCalls, string content = null) => new(toolCalls, content);
+    public static AssistantChatMessage CreateAssistantMessage(IEnumerable<ChatToolCall> toolCalls) => new(toolCalls);
 
     /// <inheritdoc cref="AssistantChatMessage(ChatFunctionCall, string)"/>
-    public static AssistantChatMessage CreateAssistantMessage(ChatFunctionCall functionCall, string content = null) => new(functionCall, content);
+    public static AssistantChatMessage CreateAssistantMessage(ChatFunctionCall functionCall) => new(functionCall);
 
     /// <inheritdoc cref="AssistantChatMessage(ChatCompletion)"/>
     public static AssistantChatMessage CreateAssistantMessage(ChatCompletion chatCompletion) => new(chatCompletion);
@@ -149,7 +149,7 @@ public abstract partial class ChatMessage
     #region FunctionChatMessage
     /// <inheritdoc cref="FunctionChatMessage(string, string)"/>
     [Obsolete($"This method is obsolete. Please use {nameof(CreateToolMessage)} instead.")]
-    public static FunctionChatMessage CreateFunctionMessage(string functionName, string content) => new(functionName, content);
+    public static FunctionChatMessage CreateFunctionMessage(string functionName) => new(functionName);
     #endregion
 
     /// <summary>

--- a/.dotnet/src/Custom/Chat/FunctionChatMessage.cs
+++ b/.dotnet/src/Custom/Chat/FunctionChatMessage.cs
@@ -20,8 +20,12 @@ public partial class FunctionChatMessage : ChatMessage
     /// <param name="functionName">
     ///     The name of the called function that this message provides information from.
     /// </param>
-    public FunctionChatMessage(string functionName)
-        : base(ChatMessageRole.Function)
+    /// <param name="content">
+    ///     The textual content that represents the output or result from the called function. There is no format
+    ///     restriction (e.g. JSON) imposed on this content.
+    /// </param>
+    public FunctionChatMessage(string functionName, string content)
+        : base(ChatMessageRole.Function, content)
     {
         Argument.AssertNotNull(functionName, nameof(functionName));
 

--- a/.dotnet/src/Custom/Chat/FunctionChatMessage.cs
+++ b/.dotnet/src/Custom/Chat/FunctionChatMessage.cs
@@ -20,12 +20,8 @@ public partial class FunctionChatMessage : ChatMessage
     /// <param name="functionName">
     ///     The name of the called function that this message provides information from.
     /// </param>
-    /// <param name="content">
-    ///     The textual content that represents the output or result from the called function. There is no format
-    ///     restriction (e.g. JSON) imposed on this content.
-    /// </param>
-    public FunctionChatMessage(string functionName, string content = null)
-        : base(ChatMessageRole.Function, content)
+    public FunctionChatMessage(string functionName)
+        : base(ChatMessageRole.Function)
     {
         Argument.AssertNotNull(functionName, nameof(functionName));
 

--- a/.dotnet/src/Custom/Files/FileClient.cs
+++ b/.dotnet/src/Custom/Files/FileClient.cs
@@ -200,20 +200,36 @@ public partial class FileClient
     }
 
     /// <summary> Gets basic information about each of the files belonging to the user's organization. </summary>
-    /// <param name="purpose"> Only return files with the given purpose. </param>
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
-    public virtual async Task<ClientResult<OpenAIFileInfoCollection>> GetFilesAsync(OpenAIFilePurpose? purpose = null, CancellationToken cancellationToken = default)
+    public virtual async Task<ClientResult<OpenAIFileInfoCollection>> GetFilesAsync(CancellationToken cancellationToken = default)
     {
-        ClientResult result = await GetFilesAsync(purpose?.ToString(), cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        ClientResult result = await GetFilesAsync(null, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        return ClientResult.FromValue(OpenAIFileInfoCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
+    }
+
+    /// <summary> Gets basic information about each of the files belonging to the user's organization. </summary>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    public virtual ClientResult<OpenAIFileInfoCollection> GetFiles(CancellationToken cancellationToken = default)
+    {
+        ClientResult result = GetFiles(null, cancellationToken.ToRequestOptions());
         return ClientResult.FromValue(OpenAIFileInfoCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 
     /// <summary> Gets basic information about each of the files belonging to the user's organization. </summary>
     /// <param name="purpose"> Only return files with the given purpose. </param>
     /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
-    public virtual ClientResult<OpenAIFileInfoCollection> GetFiles(OpenAIFilePurpose? purpose = null, CancellationToken cancellationToken = default)
+    public virtual async Task<ClientResult<OpenAIFileInfoCollection>> GetFilesAsync(OpenAIFilePurpose purpose, CancellationToken cancellationToken = default)
     {
-        ClientResult result = GetFiles(purpose?.ToString(), cancellationToken.ToRequestOptions());
+        ClientResult result = await GetFilesAsync(purpose.ToString(), cancellationToken.ToRequestOptions()).ConfigureAwait(false);
+        return ClientResult.FromValue(OpenAIFileInfoCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
+    }
+
+    /// <summary> Gets basic information about each of the files belonging to the user's organization. </summary>
+    /// <param name="purpose"> Only return files with the given purpose. </param>
+    /// <param name="cancellationToken"> A token that can be used to cancel this method call. </param>
+    public virtual ClientResult<OpenAIFileInfoCollection> GetFiles(OpenAIFilePurpose purpose, CancellationToken cancellationToken = default)
+    {
+        ClientResult result = GetFiles(purpose.ToString(), cancellationToken.ToRequestOptions());
         return ClientResult.FromValue(OpenAIFileInfoCollection.FromResponse(result.GetRawResponse()), result.GetRawResponse());
     }
 

--- a/.dotnet/tests/Chat/ChatSmokeTests.cs
+++ b/.dotnet/tests/Chat/ChatSmokeTests.cs
@@ -581,8 +581,7 @@ public partial class ChatSmokeTests : SyncAsyncTestBase
             """));
         Assert.That(assistantMessage.Content, Has.Count.EqualTo(1));
         Assert.That(assistantMessage.Content[0], Is.Null);
-        FunctionChatMessage functionMessage = new("my_function");
-        functionMessage.Content.Add(null);
+        FunctionChatMessage functionMessage = new("my_function", null);
         BinaryData serializedMessage = ModelReaderWriter.Write(functionMessage);
         Console.WriteLine(serializedMessage.ToString());
 

--- a/.dotnet/tests/Chat/ChatToolTests.cs
+++ b/.dotnet/tests/Chat/ChatToolTests.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using OpenAI.Chat;
 using OpenAI.Tests.Utility;
 using System;
 using System.ClientModel;
-using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -66,10 +64,10 @@ public partial class ChatToolTests : SyncAsyncTestBase
 
 #pragma warning disable CS0618
     private const string GetFavoriteColorForMonthFunctionName = "get_favorite_color_for_month";
-    private static ChatFunction s_getFavoriteColorForMonthFunction = new ChatFunction(
-        GetFavoriteColorForMonthFunctionName,
-        "gets the caller's favorite color for a given month",
-        BinaryData.FromString("""
+    private static ChatFunction s_getFavoriteColorForMonthFunction = new ChatFunction(GetFavoriteColorForMonthFunctionName)
+    {
+        FunctionDescription = "gets the caller's favorite color for a given month",
+        FunctionParameters = BinaryData.FromString("""
             {
                 "type": "object",
                 "properties": {
@@ -81,7 +79,7 @@ public partial class ChatToolTests : SyncAsyncTestBase
                 "required": [ "month_name" ]
             }
             """)
-    );
+    };
 #pragma warning restore CS0618
 
     private const string GetWeatherForCityToolName = "get_weather_for_city";
@@ -234,7 +232,9 @@ public partial class ChatToolTests : SyncAsyncTestBase
         Assert.That(argumentsJson.ContainsKey("month_name"));
         Assert.That(argumentsJson["month_name"].ToString().ToLowerInvariant(), Is.EqualTo("february"));
         messages.Add(new AssistantChatMessage(result.Value));
-        messages.Add(new FunctionChatMessage(GetFavoriteColorForMonthFunctionName, "chartreuse"));
+        var functionChatMessage = new FunctionChatMessage(GetFavoriteColorForMonthFunctionName);
+        functionChatMessage.Content.Add(ChatMessageContentPart.CreateTextPart("chartreuse"));
+        messages.Add(functionChatMessage);
         result = IsAsync
             ? await client.CompleteChatAsync(messages, options)
             : client.CompleteChat(messages, options);

--- a/.dotnet/tests/Chat/ChatToolTests.cs
+++ b/.dotnet/tests/Chat/ChatToolTests.cs
@@ -232,9 +232,7 @@ public partial class ChatToolTests : SyncAsyncTestBase
         Assert.That(argumentsJson.ContainsKey("month_name"));
         Assert.That(argumentsJson["month_name"].ToString().ToLowerInvariant(), Is.EqualTo("february"));
         messages.Add(new AssistantChatMessage(result.Value));
-        var functionChatMessage = new FunctionChatMessage(GetFavoriteColorForMonthFunctionName);
-        functionChatMessage.Content.Add(ChatMessageContentPart.CreateTextPart("chartreuse"));
-        messages.Add(functionChatMessage);
+        messages.Add(new FunctionChatMessage(GetFavoriteColorForMonthFunctionName, "chartreuse"));
         result = IsAsync
             ? await client.CompleteChatAsync(messages, options)
             : client.CompleteChat(messages, options);


### PR DESCRIPTION
This PR includes the following updates:
- Removed the optional parameter from the constructors of `VectorStoreCreationHelper`, `AssistantChatMessage`, `ChatFunction`, and `FunctionChatMessage`.
- Removed the optional `purpose` parameter from `FileClient.GetFilesAsync` and `FileClient.GetFiles` methods, and added overloads with `purpose` as a required parameter.

For the reference, here's the list where we had optional parameters: https://gist.github.com/ShivangiReja/029d9eb032ac60103827ea55f97ec4f7