### PR TITLE
Rename `Granularities` property to `TimestampGranularities`

### DIFF
--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/AudioTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/AudioTests.cs
@@ -100,7 +100,7 @@ public class AudioTests(bool isAsync) : AoaiTestBase<AudioClient>(isAsync)
         using Stream audioFileStream = File.OpenRead(audioInfo.RelativePath);
         AudioTranscriptionOptions options = new()
         {
-            Granularities = granularityFlags,
+            TimestampGranularities = granularityFlags,
             ResponseFormat = AudioTranscriptionFormat.Verbose,
         };
         ClientResult<AudioTranscription> transcriptionResult = await client.TranscribeAudioAsync(

--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Renamed properties `InputTokens` to `InputTokenCount` and `TotalTokens` to `TotalTokenCount` in the `EmbeddingTokenUsage` type. (commit_id)
 - Renamed properties `MaxPromptTokens` to `MaxInputTokenCount` and `MaxCompletionTokens` to `MaxOutputTokenCount` in the `ThreadRun`, `RunCreationOptions`, and `RunIncompleteReason` types. (commit_id)
 - Removed the `virtual` keyword from the `Pipeline` property across all clients. (commit_id)
+- Renamed the `Granularities` property of `AudioTranscriptionOptions` to `TimestampGranularities`. (commit_id)
 
 ### Bugs Fixed
 

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -1162,11 +1162,11 @@ namespace OpenAI.Audio {
         Vtt = 4
     }
     public class AudioTranscriptionOptions : IJsonModel<AudioTranscriptionOptions>, IPersistableModel<AudioTranscriptionOptions> {
-        public AudioTimestampGranularities Granularities { get; set; }
         public string Language { get; set; }
         public string Prompt { get; set; }
         public AudioTranscriptionFormat? ResponseFormat { get; set; }
         public float? Temperature { get; set; }
+        public AudioTimestampGranularities TimestampGranularities { get; set; }
         AudioTranscriptionOptions IJsonModel<AudioTranscriptionOptions>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<AudioTranscriptionOptions>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         AudioTranscriptionOptions IPersistableModel<AudioTranscriptionOptions>.Create(BinaryData data, ModelReaderWriterOptions options);

--- a/.dotnet/examples/Audio/Example03_VerboseTranscription.cs
+++ b/.dotnet/examples/Audio/Example03_VerboseTranscription.cs
@@ -17,7 +17,7 @@ public partial class AudioExamples
         AudioTranscriptionOptions options = new()
         {
             ResponseFormat = AudioTranscriptionFormat.Verbose,
-            Granularities = AudioTimestampGranularities.Word | AudioTimestampGranularities.Segment,
+            TimestampGranularities = AudioTimestampGranularities.Word | AudioTimestampGranularities.Segment,
         };
 
         AudioTranscription transcription = client.TranscribeAudio(audioFilePath, options);

--- a/.dotnet/examples/Audio/Example03_VerboseTrascriptionAsync.cs
+++ b/.dotnet/examples/Audio/Example03_VerboseTrascriptionAsync.cs
@@ -18,7 +18,7 @@ public partial class AudioExamples
         AudioTranscriptionOptions options = new()
         {
             ResponseFormat = AudioTranscriptionFormat.Verbose,
-            Granularities = AudioTimestampGranularities.Word | AudioTimestampGranularities.Segment,
+            TimestampGranularities = AudioTimestampGranularities.Word | AudioTimestampGranularities.Segment,
         };
 
         AudioTranscription transcription = await client.TranscribeAudioAsync(audioFilePath, options);

--- a/.dotnet/src/Custom/Audio/AudioTranscriptionOptions.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranscriptionOptions.cs
@@ -1,4 +1,3 @@
-using OpenAI.Internal;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,69 +9,15 @@ namespace OpenAI.Audio;
 public partial class AudioTranscriptionOptions
 {
     // CUSTOM: Made internal. This value comes from a parameter on the client method.
-    /// <summary>
-    /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4,
-    /// mpeg, mpga, m4a, ogg, pcm, wav, or webm.
-    /// <para>
-    /// To assign a byte[] to this property use <see cref="BinaryData.FromBytes(byte[])"/>.
-    /// The byte[] will be serialized to a Base64 encoded string.
-    /// </para>
-    /// <para>
-    /// Examples:
-    /// <list type="bullet">
-    /// <item>
-    /// <term>BinaryData.FromBytes(new byte[] { 1, 2, 3 })</term>
-    /// <description>Creates a payload of "AQID".</description>
-    /// </item>
-    /// </list>
-    /// </para>
-    /// </summary>
     internal BinaryData File { get; }
 
     // CUSTOM:
     // - Made internal. The model is specified by the client.
     // - Added setter.
-    /// <summary>
-    /// ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model)
-    /// is currently available.
-    /// </summary>
     internal InternalCreateTranscriptionRequestModel Model { get; set; }
 
-    // CUSTOM: Made internal. The model is specified by the client.
-    /// <summary>
-    /// The timestamp granularities to populate for this transcription. `response_format` must be set
-    /// `verbose_json` to use timestamp granularities. Either or both of these options are supported:
-    /// `word`, or `segment`. Note: There is no additional latency for segment timestamps, but
-    /// generating word timestamps incurs additional latency.
-    /// <para>
-    /// To assign an object to the element of this property use <see cref="BinaryData.FromObjectAsJson{T}(T, System.Text.Json.JsonSerializerOptions?)"/>.
-    /// </para>
-    /// <para>
-    /// To assign an already formatted json string to this property use <see cref="BinaryData.FromString(string)"/>.
-    /// </para>
-    /// <para>
-    /// Examples:
-    /// <list type="bullet">
-    /// <item>
-    /// <term>BinaryData.FromObjectAsJson("foo")</term>
-    /// <description>Creates a payload of "foo".</description>
-    /// </item>
-    /// <item>
-    /// <term>BinaryData.FromString("\"foo\"")</term>
-    /// <description>Creates a payload of "foo".</description>
-    /// </item>
-    /// <item>
-    /// <term>BinaryData.FromObjectAsJson(new { key = "value" })</term>
-    /// <description>Creates a payload of { "key": "value" }.</description>
-    /// </item>
-    /// <item>
-    /// <term>BinaryData.FromString("{\"key\": \"value\"}")</term>
-    /// <description>Creates a payload of { "key": "value" }.</description>
-    /// </item>
-    /// </list>
-    /// </para>
-    /// </summary>
-    internal IList<BinaryData> TimestampGranularities { get; }
+    [CodeGenMember("TimestampGranularities")]
+    internal IList<BinaryData> InternalTimestampGranularities { get; }
 
     // CUSTOM: Made public now that there are no required properties.
     /// <summary> Initializes a new instance of <see cref="AudioTranscriptionOptions"/>. </summary>
@@ -83,7 +28,7 @@ public partial class AudioTranscriptionOptions
     /// <summary>
     /// The timestamp granularities to populate for this transcription.
     /// </summary>
-    public AudioTimestampGranularities Granularities { get; set; }
+    public AudioTimestampGranularities TimestampGranularities { get; set; }
 
     internal MultipartFormDataBinaryContent ToMultipartContent(Stream audio, string audioFilename)
     {
@@ -121,12 +66,12 @@ public partial class AudioTranscriptionOptions
             content.Add(Temperature.Value, "temperature");
         }
 
-        if (Granularities.HasFlag(AudioTimestampGranularities.Word))
+        if (TimestampGranularities.HasFlag(AudioTimestampGranularities.Word))
         {
             content.Add("word", "timestamp_granularities[]");
         }
 
-        if (Granularities.HasFlag(AudioTimestampGranularities.Segment))
+        if (TimestampGranularities.HasFlag(AudioTimestampGranularities.Segment))
         {
             content.Add("segment", "timestamp_granularities[]");
         }

--- a/.dotnet/src/Custom/Audio/AudioTranslationOptions.cs
+++ b/.dotnet/src/Custom/Audio/AudioTranslationOptions.cs
@@ -1,6 +1,3 @@
-using OpenAI.Embeddings;
-using OpenAI.Images;
-using OpenAI.Internal;
 using System;
 using System.IO;
 
@@ -11,32 +8,11 @@ namespace OpenAI.Audio;
 public partial class AudioTranslationOptions
 {
     // CUSTOM: Made internal. This value comes from a parameter on the client method.
-    /// <summary>
-    /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4,
-    /// mpeg, mpga, m4a, ogg, pcm, wav, or webm.
-    /// <para>
-    /// To assign a byte[] to this property use <see cref="BinaryData.FromBytes(byte[])"/>.
-    /// The byte[] will be serialized to a Base64 encoded string.
-    /// </para>
-    /// <para>
-    /// Examples:
-    /// <list type="bullet">
-    /// <item>
-    /// <term>BinaryData.FromBytes(new byte[] { 1, 2, 3 })</term>
-    /// <description>Creates a payload of "AQID".</description>
-    /// </item>
-    /// </list>
-    /// </para>
-    /// </summary>
     internal BinaryData File { get; }
 
     // CUSTOM:
     // - Made internal. The model is specified by the client.
     // - Added setter.
-    /// <summary>
-    /// ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model)
-    /// is currently available.
-    /// </summary>
     internal InternalCreateTranslationRequestModel Model { get; set; }
 
     // CUSTOM: Made public now that there are no required properties.

--- a/.dotnet/src/Generated/Models/AudioTranscriptionOptions.Serialization.cs
+++ b/.dotnet/src/Generated/Models/AudioTranscriptionOptions.Serialization.cs
@@ -59,11 +59,11 @@ namespace OpenAI.Audio
                 writer.WritePropertyName("temperature"u8);
                 writer.WriteNumberValue(Temperature.Value);
             }
-            if (SerializedAdditionalRawData?.ContainsKey("timestamp_granularities") != true && Optional.IsCollectionDefined(TimestampGranularities))
+            if (SerializedAdditionalRawData?.ContainsKey("timestamp_granularities") != true && Optional.IsCollectionDefined(InternalTimestampGranularities))
             {
                 writer.WritePropertyName("timestamp_granularities"u8);
                 writer.WriteStartArray();
-                foreach (var item in TimestampGranularities)
+                foreach (var item in InternalTimestampGranularities)
                 {
                     if (item == null)
                     {
@@ -247,9 +247,9 @@ namespace OpenAI.Audio
             {
                 content.Add(Temperature.Value, "temperature");
             }
-            if (Optional.IsCollectionDefined(TimestampGranularities))
+            if (Optional.IsCollectionDefined(InternalTimestampGranularities))
             {
-                foreach (BinaryData item in TimestampGranularities)
+                foreach (BinaryData item in InternalTimestampGranularities)
                 {
                     content.Add(item, "timestamp_granularities", "timestamp_granularities");
                 }

--- a/.dotnet/src/Generated/Models/AudioTranscriptionOptions.cs
+++ b/.dotnet/src/Generated/Models/AudioTranscriptionOptions.cs
@@ -11,7 +11,7 @@ namespace OpenAI.Audio
     {
         internal IDictionary<string, BinaryData> SerializedAdditionalRawData { get; set; }
 
-        internal AudioTranscriptionOptions(BinaryData file, InternalCreateTranscriptionRequestModel model, string language, string prompt, AudioTranscriptionFormat? responseFormat, float? temperature, IList<BinaryData> timestampGranularities, IDictionary<string, BinaryData> serializedAdditionalRawData)
+        internal AudioTranscriptionOptions(BinaryData file, InternalCreateTranscriptionRequestModel model, string language, string prompt, AudioTranscriptionFormat? responseFormat, float? temperature, IList<BinaryData> internalTimestampGranularities, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
             File = file;
             Model = model;
@@ -19,7 +19,7 @@ namespace OpenAI.Audio
             Prompt = prompt;
             ResponseFormat = responseFormat;
             Temperature = temperature;
-            TimestampGranularities = timestampGranularities;
+            InternalTimestampGranularities = internalTimestampGranularities;
             SerializedAdditionalRawData = serializedAdditionalRawData;
         }
         public string Language { get; set; }

--- a/.dotnet/tests/Audio/TranscriptionTests.cs
+++ b/.dotnet/tests/Audio/TranscriptionTests.cs
@@ -71,7 +71,7 @@ public partial class TranscriptionTests : SyncAsyncTestBase
         {
             ResponseFormat = AudioTranscriptionFormat.Verbose,
             Temperature = 0.4f,
-            Granularities = granularityFlags,
+            TimestampGranularities = granularityFlags,
         };
 
         ClientResult<AudioTranscription> transcriptionResult = IsAsync


### PR DESCRIPTION
Renamed the `Granularities` property of `AudioTranscriptionOptions` to `TimestampGranularities`.