### PR TITLE
Introduce ChatMessageContent

### DIFF
--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -1325,6 +1325,7 @@ namespace OpenAI.Chat {
         public AssistantChatMessage(IEnumerable<ChatMessageContentPart> contentParts);
         public AssistantChatMessage(IEnumerable<ChatToolCall> toolCalls);
         public AssistantChatMessage(string content);
+        public AssistantChatMessage(ChatMessageContent content);
         [Obsolete("This property is obsolete. Please use ToolCalls instead.")]
         public ChatFunctionCall FunctionCall { get; set; }
         public string ParticipantName { get; set; }
@@ -1358,7 +1359,7 @@ namespace OpenAI.Chat {
         public virtual AsyncCollectionResult<StreamingChatCompletionUpdate> CompleteChatStreamingAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default);
     }
     public class ChatCompletion : IJsonModel<ChatCompletion>, IPersistableModel<ChatCompletion> {
-        public IReadOnlyList<ChatMessageContentPart> Content { get; }
+        public ChatMessageContent Content { get; }
         public IReadOnlyList<ChatTokenLogProbabilityDetails> ContentTokenLogProbabilities { get; }
         public DateTimeOffset CreatedAt { get; }
         public ChatFinishReason FinishReason { get; }
@@ -1377,7 +1378,6 @@ namespace OpenAI.Chat {
         ChatCompletion IPersistableModel<ChatCompletion>.Create(BinaryData data, ModelReaderWriterOptions options);
         string IPersistableModel<ChatCompletion>.GetFormatFromOptions(ModelReaderWriterOptions options);
         BinaryData IPersistableModel<ChatCompletion>.Write(ModelReaderWriterOptions options);
-        public override string ToString();
     }
     public class ChatCompletionOptions : IJsonModel<ChatCompletionOptions>, IPersistableModel<ChatCompletionOptions> {
         public string EndUserId { get; set; }
@@ -1464,30 +1464,42 @@ namespace OpenAI.Chat {
         public override readonly string ToString();
     }
     public abstract class ChatMessage : IJsonModel<ChatMessage>, IPersistableModel<ChatMessage> {
-        public IList<ChatMessageContentPart> Content { get; }
+        public ChatMessageContent Content { get; set; }
         public static AssistantChatMessage CreateAssistantMessage(ChatCompletion chatCompletion);
         public static AssistantChatMessage CreateAssistantMessage(ChatFunctionCall functionCall);
         public static AssistantChatMessage CreateAssistantMessage(params ChatMessageContentPart[] contentParts);
         public static AssistantChatMessage CreateAssistantMessage(IEnumerable<ChatMessageContentPart> contentParts);
         public static AssistantChatMessage CreateAssistantMessage(IEnumerable<ChatToolCall> toolCalls);
         public static AssistantChatMessage CreateAssistantMessage(string content);
+        public static AssistantChatMessage CreateAssistantMessage(ChatMessageContent content);
         [Obsolete("This method is obsolete. Please use CreateToolMessage instead.")]
         public static FunctionChatMessage CreateFunctionMessage(string functionName, string content);
         public static SystemChatMessage CreateSystemMessage(params ChatMessageContentPart[] contentParts);
         public static SystemChatMessage CreateSystemMessage(IEnumerable<ChatMessageContentPart> contentParts);
         public static SystemChatMessage CreateSystemMessage(string content);
+
+        public static SystemChatMessage CreateSystemMessage(ChatMessageContent content);
         public static ToolChatMessage CreateToolMessage(string toolCallId, params ChatMessageContentPart[] contentParts);
         public static ToolChatMessage CreateToolMessage(string toolCallId, IEnumerable<ChatMessageContentPart> contentParts);
         public static ToolChatMessage CreateToolMessage(string toolCallId, string content);
+        public static ToolChatMessage CreateToolMessage(string toolCallId, ChatMessageContent content);
         public static UserChatMessage CreateUserMessage(params ChatMessageContentPart[] contentParts);
         public static UserChatMessage CreateUserMessage(IEnumerable<ChatMessageContentPart> contentParts);
         public static UserChatMessage CreateUserMessage(string content);
+        public static UserChatMessage CreateUserMessage(ChatMessageContent content);
         public static implicit operator ChatMessage(string userMessage);
         ChatMessage IJsonModel<ChatMessage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<ChatMessage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
         ChatMessage IPersistableModel<ChatMessage>.Create(BinaryData data, ModelReaderWriterOptions options);
         string IPersistableModel<ChatMessage>.GetFormatFromOptions(ModelReaderWriterOptions options);
         BinaryData IPersistableModel<ChatMessage>.Write(ModelReaderWriterOptions options);
+    }
+    public class ChatMessageContent {
+        public IList<ChatMessageContentPart> Parts { get; }
+
+        public ChatMessageContent(string text);
+        public ChatMessageContent(IEnumerable<ChatMessageContentPart> parts);
+        public ChatMessageContent(params ChatMessageContentPart[] parts);
     }
     public class ChatMessageContentPart : IJsonModel<ChatMessageContentPart>, IPersistableModel<ChatMessageContentPart> {
         public BinaryData ImageBytes { get; }
@@ -1716,6 +1728,7 @@ namespace OpenAI.Chat {
         public SystemChatMessage(params ChatMessageContentPart[] contentParts);
         public SystemChatMessage(IEnumerable<ChatMessageContentPart> contentParts);
         public SystemChatMessage(string content);
+        public SystemChatMessage(ChatMessageContent content);
         public string ParticipantName { get; set; }
         SystemChatMessage IJsonModel<SystemChatMessage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<SystemChatMessage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
@@ -1727,6 +1740,7 @@ namespace OpenAI.Chat {
         public ToolChatMessage(string toolCallId, params ChatMessageContentPart[] contentParts);
         public ToolChatMessage(string toolCallId, IEnumerable<ChatMessageContentPart> contentParts);
         public ToolChatMessage(string toolCallId, string content);
+        public ToolChatMessage(string toolCallId, ChatMessageContent content);
         public string ToolCallId { get; }
         ToolChatMessage IJsonModel<ToolChatMessage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<ToolChatMessage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
@@ -1738,6 +1752,7 @@ namespace OpenAI.Chat {
         public UserChatMessage(params ChatMessageContentPart[] content);
         public UserChatMessage(IEnumerable<ChatMessageContentPart> content);
         public UserChatMessage(string content);
+        public UserChatMessage(ChatMessageContent content);
         public string ParticipantName { get; set; }
         UserChatMessage IJsonModel<UserChatMessage>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<UserChatMessage>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);


### PR DESCRIPTION
This is a draft of what the public API would look like.

Based on this prototype, my current assessment is that this change does not add a lot of value, and therefore, my current inclination is to not go ahead with it. Let me know what you think.

Summary:

We add a new class that looks like this:

```csharp
public class ChatMessageContent {
    public IList<ChatMessageContentPart> Parts { get; }

    public ChatMessageContent(string text);
    public ChatMessageContent(IEnumerable<ChatMessageContentPart> parts);
    public ChatMessageContent(params ChatMessageContentPart[] parts);
}
```

We use it to replace:
1. `ChatCompletion`'s `IReadOnlyList<ChatMessageContentPart> Content` property.
2. `ChatMessage`'s `IList<ChatMessageContentPart> Content` property.

Q: How does this affect the code that customers write?
A: I believe it doesn't change much.

🟢 Example 1: Creating a `ChatMessage`
To create a `ChatMessage`, it is still more convenient to use the constructors that take a plain `string` or an `IEnumerable<ChatMessageContentPart>` than to have to instantiate a new `ChatMessageContent` using the same plain `string` or an `IEnumerable<ChatMessageContentPart>`.

🟢 Example 2: Reading the multimodal content of a `ChatMessage`
For example, to render the multimodal contents of a `ChatMessage` in some UI, users need to iterate through the `Parts` of the `ChatMessageContent`. In other words, the following:

`foreach (ChatMessageContentPart part in message.Content) { ... }`

Becomes:

`foreach (ChatMessageContentPart part in message.Content.Parts) { ... }`

While relatively trivial, this still looks like a minor regression in usability. We could mitigate it by making `ChatMessageContent` inherit from `Collection<ChatMessageContentPart>` instead of having a `Parts` property, but all this does is keep the experience the same (not any worse, not any better).