### PR TITLE
Misc. fixes to AssistantChatMessage

### DIFF
--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -1314,6 +1314,7 @@ namespace OpenAI.Batch {
 namespace OpenAI.Chat {
     public class AssistantChatMessage : ChatMessage, IJsonModel<AssistantChatMessage>, IPersistableModel<AssistantChatMessage> {
         public AssistantChatMessage(ChatCompletion chatCompletion);
+        [Obsolete("This constructor is obsolete. Please use the constructor that takes an IEnumerable<ChatToolCall> parameter instead.")]
         public AssistantChatMessage(ChatFunctionCall functionCall);
         public AssistantChatMessage(params ChatMessageContentPart[] contentParts);
         public AssistantChatMessage(IEnumerable<ChatMessageContentPart> contentParts);

--- a/.dotnet/src/Custom/Chat/AssistantChatMessage.cs
+++ b/.dotnet/src/Custom/Chat/AssistantChatMessage.cs
@@ -74,7 +74,7 @@ public partial class AssistantChatMessage : ChatMessage
     /// (deprecated in favor of <c>tool_calls</c>) that was made by the model.
     /// </summary>
     /// <param name="functionCall"> The <c>function_call</c> made by the model. </param>
-    [Obsolete($"This constructor is obsolete. Please use the constructor that takes a {nameof(IEnumerable<ChatToolCall>)} parameter instead.")]
+    [Obsolete($"This constructor is obsolete. Please use the constructor that takes an IEnumerable<ChatToolCall> parameter instead.")]
     public AssistantChatMessage(ChatFunctionCall functionCall)
         : base(ChatMessageRole.Assistant)
     {

--- a/.dotnet/src/Custom/Chat/AssistantChatMessage.cs
+++ b/.dotnet/src/Custom/Chat/AssistantChatMessage.cs
@@ -61,7 +61,7 @@ public partial class AssistantChatMessage : ChatMessage
     public AssistantChatMessage(IEnumerable<ChatToolCall> toolCalls)
         : base(ChatMessageRole.Assistant)
     {
-        Argument.AssertNotNull(toolCalls, nameof(toolCalls));
+        Argument.AssertNotNullOrEmpty(toolCalls, nameof(toolCalls));
 
         foreach (ChatToolCall toolCall in toolCalls)
         {
@@ -74,6 +74,7 @@ public partial class AssistantChatMessage : ChatMessage
     /// (deprecated in favor of <c>tool_calls</c>) that was made by the model.
     /// </summary>
     /// <param name="functionCall"> The <c>function_call</c> made by the model. </param>
+    [Obsolete($"This constructor is obsolete. Please use the constructor that takes a {nameof(IEnumerable<ChatToolCall>)} parameter instead.")]
     public AssistantChatMessage(ChatFunctionCall functionCall)
         : base(ChatMessageRole.Assistant)
     {

--- a/.dotnet/src/Custom/Chat/ChatMessageContentPart.Serialization.cs
+++ b/.dotnet/src/Custom/Chat/ChatMessageContentPart.Serialization.cs
@@ -45,7 +45,7 @@ public partial class ChatMessageContentPart : IJsonModel<ChatMessageContentPart>
         }
 
         writer.WritePropertyName("content"u8);
-        if (instances.Count == 1 && !string.IsNullOrEmpty(instances[0].Text))
+        if (instances.Count == 1 && instances[0].Text != null)
         {
             writer.WriteStringValue(instances[0].Text);
         }


### PR DESCRIPTION
Three small fixes for `AssistantChatMessage`:
1. Marked constructor with `ChatFunctionCall` as Obsolete.
2. Changed the `Assert` in the constructor with `IEnumerable<ChatToolCall>` to validate that this argument is not an empty list.
3. Changed the serialization behavior so that if there is a single text content part, it gets serialized as a plain string regardless of if it is an empty string or not.