### PR TITLE
Rename FileClient and ModelClient

### DIFF
--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIClient.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIClient.cs
@@ -190,7 +190,7 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// Gets a new <see cref="FileClient"/> instance configured for file operation use with the Azure OpenAI service.
     /// </summary>
     /// <returns> A new <see cref="FileClient"/> instance. </returns>
-    public override FileClient GetFileClient()
+    public override OpenAIFileClient GetOpenAIFileClient()
         => new AzureFileClient(Pipeline, _endpoint, _options);
 
     /// <summary>
@@ -213,7 +213,7 @@ public partial class AzureOpenAIClient : OpenAIClient
     /// Model management operations are not supported with Azure OpenAI.
     /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public override ModelClient GetModelClient()
+    public override OpenAIModelClient GetOpenAIModelClient()
         => throw new NotSupportedException($"Azure OpenAI does not support the OpenAI model management API. Please "
             + "use the Azure AI Services Account Management API to interact with Azure OpenAI model deployments.");
 

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Files/AzureFileClient.Protocol.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Files/AzureFileClient.Protocol.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 
 namespace Azure.AI.OpenAI.Files;
 
-internal partial class AzureFileClient : FileClient
+internal partial class AzureFileClient : OpenAIFileClient
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override ClientResult DeleteFile(string fileId, RequestOptions options)

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Files/AzureFileClient.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Files/AzureFileClient.cs
@@ -13,7 +13,7 @@ namespace Azure.AI.OpenAI.Files;
 /// <remarks>
 /// To retrieve an instance of this type, use the matching method on <see cref="AzureOpenAIClient"/>.
 /// </remarks>
-internal partial class AzureFileClient : FileClient
+internal partial class AzureFileClient : OpenAIFileClient
 {
     private readonly Uri _endpoint;
     private readonly string _apiVersion;

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/AssistantTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/AssistantTests.cs
@@ -508,7 +508,7 @@ public class AssistantTests(bool isAsync) : AoaiTestBase<AssistantClient>(isAsyn
         // First, we need to upload a simple test file.
         AssistantClient client = GetTestClient();
         string modelName = client.DeploymentOrThrow();
-        FileClient fileClient = GetTestClientFrom<FileClient>(client);
+        OpenAIFileClient fileClient = GetTestClientFrom<OpenAIFileClient>(client);
 
         OpenAIFile testFile = await fileClient.UploadFileAsync(
             BinaryData.FromString("""

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/BatchTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/BatchTests.cs
@@ -120,7 +120,7 @@ public class BatchTests : AoaiTestBase<BatchClient>
         private MockHttpMessageHandler _handler;
         private List<BatchOperation> _operations;
         private string? _uploadId;
-        private FileClient _fileClient;
+        private OpenAIFileClient _fileClient;
 
         public BatchOperations(AoaiTestBase<BatchClient> testBase, BatchClient batchClient)
         {
@@ -130,7 +130,7 @@ public class BatchTests : AoaiTestBase<BatchClient>
 
             BatchFileName = "batch-" + Guid.NewGuid().ToString("D") + ".json";
 
-            _fileClient = testBase.GetTestClientFrom<FileClient>(batchClient);
+            _fileClient = testBase.GetTestClientFrom<OpenAIFileClient>(batchClient);
 
             // Generate the fake pipeline to capture requests and save them to a file later
             AzureOpenAIClient fakeTopLevel = new AzureOpenAIClient(

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/FileTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/FileTests.cs
@@ -8,19 +8,19 @@ using OpenAI.TestFramework;
 
 namespace Azure.AI.OpenAI.Tests;
 
-public class FileTests : AoaiTestBase<FileClient>
+public class FileTests : AoaiTestBase<OpenAIFileClient>
 {
     public FileTests(bool isAsync) : base(isAsync)
     { }
 
     [Test]
     [Category("Smoke")]
-    public void CanCreateClient() => Assert.That(GetTestClient(), Is.InstanceOf<FileClient>());
+    public void CanCreateClient() => Assert.That(GetTestClient(), Is.InstanceOf<OpenAIFileClient>());
 
     [RecordedTest]
     public async Task CanUploadAndDeleteFiles()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         OpenAIFile file = await client.UploadFileAsync(
             BinaryData.FromString("hello, world!"),
             "test_file_delete_me.txt",
@@ -34,7 +34,7 @@ public class FileTests : AoaiTestBase<FileClient>
     [RecordedTest]
     public async Task CanListFiles()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         OpenAIFileCollection files = await client.GetFilesAsync();
         Assert.That(files, Has.Count.GreaterThan(0));
     }

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/FineTuningTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/FineTuningTests.cs
@@ -135,7 +135,7 @@ public class FineTuningTests : AoaiTestBase<FineTuningClient>
         var fineTuningFile = Assets.FineTuning;
 
         FineTuningClient client = GetTestClient();
-        FileClient fileClient = GetTestClientFrom<FileClient>(client);
+        OpenAIFileClient fileClient = GetTestClientFrom<OpenAIFileClient>(client);
 
         // upload training data
         OpenAIFile uploadedFile = await UploadAndWaitForCompleteOrFail(fileClient, fineTuningFile.RelativePath);
@@ -198,7 +198,7 @@ public class FineTuningTests : AoaiTestBase<FineTuningClient>
         var fineTuningFile = Assets.FineTuning;
 
         FineTuningClient client = GetTestClient();
-        FileClient fileClient = GetTestClientFrom<FileClient>(client);
+        OpenAIFileClient fileClient = GetTestClientFrom<OpenAIFileClient>(client);
         OpenAIFile uploadedFile;
         try
         {
@@ -329,7 +329,7 @@ public class FineTuningTests : AoaiTestBase<FineTuningClient>
         return model!;
     }
 
-    private async Task<OpenAIFile> UploadAndWaitForCompleteOrFail(FileClient fileClient, string path)
+    private async Task<OpenAIFile> UploadAndWaitForCompleteOrFail(OpenAIFileClient fileClient, string path)
     {
         OpenAIFile uploadedFile = await fileClient.UploadFileAsync(path, FileUploadPurpose.FineTune);
         Validate(uploadedFile);

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Utils/AoaiTestBase.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Utils/AoaiTestBase.cs
@@ -397,8 +397,8 @@ public class AoaiTestBase<TClient> : RecordedClientTestBase where TClient : clas
             case nameof(EmbeddingClient):
                 clientObject = topLevelClient.GetEmbeddingClient(getDeployment());
                 break;
-            case nameof(FileClient):
-                clientObject = topLevelClient.GetFileClient();
+            case nameof(OpenAIFileClient):
+                clientObject = topLevelClient.GetOpenAIFileClient();
                 break;
             case nameof(FineTuningClient):
                 clientObject = topLevelClient.GetFineTuningClient();
@@ -637,7 +637,7 @@ public class AoaiTestBase<TClient> : RecordedClientTestBase where TClient : clas
         });
         AssistantClient client = topLevelCleanupClient.GetAssistantClient();
         VectorStoreClient vectorStoreClient = topLevelCleanupClient.GetVectorStoreClient();
-        FileClient fileClient = topLevelCleanupClient.GetFileClient();
+        OpenAIFileClient fileClient = topLevelCleanupClient.GetOpenAIFileClient();
         RequestOptions requestOptions = new() { ErrorOptions = ClientErrorBehaviors.NoThrow, };
         foreach ((string threadId, string messageId) in _threadIdsWithMessageIdsToDelete)
         {

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/VectorStoreTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/VectorStoreTests.cs
@@ -233,7 +233,7 @@ public class VectorStoreTests : AoaiTestBase<VectorStoreClient>
             ShouldOutputRequests = false,
             ShouldOutputResponses = false,
         });
-        FileClient client = GetTestClient<FileClient>(azureClient, config);
+        OpenAIFileClient client = GetTestClient<OpenAIFileClient>(azureClient, config);
 
         List<OpenAIFile> files = [];
         for (int i = 0; i < count; i++)

--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Renamed `StreamingChatCompletionUpdate`'s `Id` to `CompletionId` (commit_hash)
 - Replaced `Auto` and `None` in the deprecated `ChatFunctionChoice` with `CreateAutoChoice()` and `CreateNoneChoice()` (commit_hash)
 - Replaced the deprecated `ChatFunctionChoice(ChatFunction)` constructor with `CreateNamedChoice(string functionName)` (commit_hash)
+- Renamed `FileClient` to `OpenAIFileClient` and the corresponding `GetFileClient()` method in `OpenAIClient` to `GetOpenAIFileClient()`. (commit_hash)
+- Renamed `ModelClient` to `OpenAIModelClient` and the corresponding `GetModelClient()` method in `OpenAIClient` to `GetOpenAIModelClient()`. (commit_hash)
 
 ## 2.0.0-beta.13 (2024-09-27)
 

--- a/.dotnet/MigrationGuide.md
+++ b/.dotnet/MigrationGuide.md
@@ -48,8 +48,8 @@ Old library's endpoint|New library's client
 |Translations | AudioClient
 |Moderation | ModerationClient
 |Embeddings | EmbeddingClient
-|Files | FileClient
-|Models | ModelClient
+|Files | OpenAIFileClient
+|Models | OpenAIModelClient
 |Completions | Not supported
 
 ## Authentication

--- a/.dotnet/README.md
+++ b/.dotnet/README.md
@@ -74,9 +74,9 @@ The library is organized into several namespaces corresponding to OpenAI feature
 | `OpenAI.Chat`                 | `ChatClient`                 |                                                                   |
 | `OpenAI.Embeddings`           | `EmbeddingClient`            |                                                                   |
 | `OpenAI.FineTuning`           | `FineTuningClient`           | ![Experimental](https://img.shields.io/badge/experimental-purple) |
-| `OpenAI.Files`                | `FileClient`                 |                                                                   |
+| `OpenAI.Files`                | `OpenAIFileClient`           |                                                                   |
 | `OpenAI.Images`               | `ImageClient`                |                                                                   |
-| `OpenAI.Models`               | `ModelClient`                |                                                                   |
+| `OpenAI.Models`               | `OpenAIModelClient`          |                                                                   |
 | `OpenAI.Moderations`          | `ModerationClient`           |                                                                   |
 | `OpenAI.VectorStores`         | `VectorStoreClient`          | ![Experimental](https://img.shields.io/badge/experimental-purple) |
 
@@ -466,7 +466,7 @@ foreach (TranscribedSegment segment in transcription.Segments)
 
 In this example, you have a JSON document with the monthly sales information of different products, and you want to build an assistant capable of analyzing it and answering questions about it.
 
-To achieve this, use both `FileClient` from the `OpenAI.Files` namespace and `AssistantClient` from the `OpenAI.Assistants` namespace.
+To achieve this, use both `OpenAIFileClient` from the `OpenAI.Files` namespace and `AssistantClient` from the `OpenAI.Assistants` namespace.
 
 Important: The Assistants REST API is currently in beta. As such, the details are subject to change, and correspondingly the `AssistantClient` is attributed as `[Experimental]`. To use it, suppress the `OPENAI001` warning at either the project level or, as below, in the code itself.
 
@@ -477,7 +477,7 @@ using OpenAI.Files;
 // Assistants is a beta API and subject to change; acknowledge its experimental status by suppressing the matching warning.
 #pragma warning disable OPENAI001
 OpenAIClient openAIClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-FileClient fileClient = openAIClient.GetFileClient();
+OpenAIFileClient fileClient = openAIClient.GetOpenAIFileClient();
 AssistantClient assistantClient = openAIClient.GetAssistantClient();
 ```
 
@@ -514,7 +514,7 @@ using Stream document = BinaryData.FromString("""
     """).ToStream();
 ```
 
-Upload this document to OpenAI using the `FileClient`'s `UploadFile` method, ensuring that you use `FileUploadPurpose.Assistants` to allow your assistant to access it later:
+Upload this document to OpenAI using the `OpenAIFileClient`'s `UploadFile` method, ensuring that you use `FileUploadPurpose.Assistants` to allow your assistant to access it later:
 
 ```csharp
 OpenAIFile salesFile = fileClient.UploadFile(
@@ -654,13 +654,13 @@ The graph above visualizes this trend, showing a peak in sales during February.
 
 This example shows how to use the v2 Assistants API to provide image data to an assistant and then stream the run's response.
 
-As before, you will use a `FileClient` and an `AssistantClient`:
+As before, you will use a `OpenAIFileClient` and an `AssistantClient`:
 
 ```csharp
 // Assistants is a beta API and subject to change; acknowledge its experimental status by suppressing the matching warning.
 #pragma warning disable OPENAI001
 OpenAIClient openAIClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-FileClient fileClient = openAIClient.GetFileClient();
+OpenAIFileClient fileClient = openAIClient.GetOpenAIFileClient();
 AssistantClient assistantClient = openAIClient.GetAssistantClient();
 ```
 

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -11,11 +11,11 @@ namespace OpenAI {
         public virtual BatchClient GetBatchClient();
         public virtual ChatClient GetChatClient(string model);
         public virtual EmbeddingClient GetEmbeddingClient(string model);
-        public virtual FileClient GetFileClient();
         public virtual FineTuningClient GetFineTuningClient();
         public virtual ImageClient GetImageClient(string model);
-        public virtual ModelClient GetModelClient();
         public virtual ModerationClient GetModerationClient(string model);
+        public virtual OpenAIFileClient GetOpenAIFileClient();
+        public virtual OpenAIModelClient GetOpenAIModelClient();
         public virtual VectorStoreClient GetVectorStoreClient();
     }
     public class OpenAIClientOptions : ClientPipelineOptions {
@@ -1767,58 +1767,6 @@ namespace OpenAI.Embeddings {
     }
 }
 namespace OpenAI.Files {
-    public class FileClient {
-        protected FileClient();
-        public FileClient(ApiKeyCredential credential, OpenAIClientOptions options);
-        public FileClient(ApiKeyCredential credential);
-        protected internal FileClient(ClientPipeline pipeline, OpenAIClientOptions options);
-        public FileClient(string apiKey);
-        public ClientPipeline Pipeline { get; }
-        public virtual ClientResult AddUploadPart(string uploadId, BinaryContent content, string contentType, RequestOptions options = null);
-        public virtual Task<ClientResult> AddUploadPartAsync(string uploadId, BinaryContent content, string contentType, RequestOptions options = null);
-        public virtual ClientResult CancelUpload(string uploadId, RequestOptions options = null);
-        public virtual Task<ClientResult> CancelUploadAsync(string uploadId, RequestOptions options = null);
-        public virtual ClientResult CompleteUpload(string uploadId, BinaryContent content, RequestOptions options = null);
-        public virtual Task<ClientResult> CompleteUploadAsync(string uploadId, BinaryContent content, RequestOptions options = null);
-        public virtual ClientResult CreateUpload(BinaryContent content, RequestOptions options = null);
-        public virtual Task<ClientResult> CreateUploadAsync(BinaryContent content, RequestOptions options = null);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual ClientResult DeleteFile(string fileId, RequestOptions options);
-        public virtual ClientResult<FileDeletionResult> DeleteFile(string fileId, CancellationToken cancellationToken = default);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual Task<ClientResult> DeleteFileAsync(string fileId, RequestOptions options);
-        public virtual Task<ClientResult<FileDeletionResult>> DeleteFileAsync(string fileId, CancellationToken cancellationToken = default);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual ClientResult DownloadFile(string fileId, RequestOptions options);
-        public virtual ClientResult<BinaryData> DownloadFile(string fileId, CancellationToken cancellationToken = default);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual Task<ClientResult> DownloadFileAsync(string fileId, RequestOptions options);
-        public virtual Task<ClientResult<BinaryData>> DownloadFileAsync(string fileId, CancellationToken cancellationToken = default);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual ClientResult GetFile(string fileId, RequestOptions options);
-        public virtual ClientResult<OpenAIFile> GetFile(string fileId, CancellationToken cancellationToken = default);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual Task<ClientResult> GetFileAsync(string fileId, RequestOptions options);
-        public virtual Task<ClientResult<OpenAIFile>> GetFileAsync(string fileId, CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFileCollection> GetFiles(FilePurpose purpose, CancellationToken cancellationToken = default);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual ClientResult GetFiles(string purpose, RequestOptions options);
-        public virtual ClientResult<OpenAIFileCollection> GetFiles(CancellationToken cancellationToken = default);
-        public virtual Task<ClientResult<OpenAIFileCollection>> GetFilesAsync(FilePurpose purpose, CancellationToken cancellationToken = default);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual Task<ClientResult> GetFilesAsync(string purpose, RequestOptions options);
-        public virtual Task<ClientResult<OpenAIFileCollection>> GetFilesAsync(CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual ClientResult UploadFile(BinaryContent content, string contentType, RequestOptions options = null);
-        public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
-        public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose);
-        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual Task<ClientResult> UploadFileAsync(BinaryContent content, string contentType, RequestOptions options = null);
-        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
-        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose);
-    }
     public class FileDeletionResult : IJsonModel<FileDeletionResult>, IPersistableModel<FileDeletionResult> {
         public bool Deleted { get; }
         public string FileId { get; }
@@ -1876,6 +1824,58 @@ namespace OpenAI.Files {
         OpenAIFile IPersistableModel<OpenAIFile>.Create(BinaryData data, ModelReaderWriterOptions options);
         string IPersistableModel<OpenAIFile>.GetFormatFromOptions(ModelReaderWriterOptions options);
         BinaryData IPersistableModel<OpenAIFile>.Write(ModelReaderWriterOptions options);
+    }
+    public class OpenAIFileClient {
+        protected OpenAIFileClient();
+        public OpenAIFileClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public OpenAIFileClient(ApiKeyCredential credential);
+        protected internal OpenAIFileClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        public OpenAIFileClient(string apiKey);
+        public ClientPipeline Pipeline { get; }
+        public virtual ClientResult AddUploadPart(string uploadId, BinaryContent content, string contentType, RequestOptions options = null);
+        public virtual Task<ClientResult> AddUploadPartAsync(string uploadId, BinaryContent content, string contentType, RequestOptions options = null);
+        public virtual ClientResult CancelUpload(string uploadId, RequestOptions options = null);
+        public virtual Task<ClientResult> CancelUploadAsync(string uploadId, RequestOptions options = null);
+        public virtual ClientResult CompleteUpload(string uploadId, BinaryContent content, RequestOptions options = null);
+        public virtual Task<ClientResult> CompleteUploadAsync(string uploadId, BinaryContent content, RequestOptions options = null);
+        public virtual ClientResult CreateUpload(BinaryContent content, RequestOptions options = null);
+        public virtual Task<ClientResult> CreateUploadAsync(BinaryContent content, RequestOptions options = null);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual ClientResult DeleteFile(string fileId, RequestOptions options);
+        public virtual ClientResult<FileDeletionResult> DeleteFile(string fileId, CancellationToken cancellationToken = default);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual Task<ClientResult> DeleteFileAsync(string fileId, RequestOptions options);
+        public virtual Task<ClientResult<FileDeletionResult>> DeleteFileAsync(string fileId, CancellationToken cancellationToken = default);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual ClientResult DownloadFile(string fileId, RequestOptions options);
+        public virtual ClientResult<BinaryData> DownloadFile(string fileId, CancellationToken cancellationToken = default);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual Task<ClientResult> DownloadFileAsync(string fileId, RequestOptions options);
+        public virtual Task<ClientResult<BinaryData>> DownloadFileAsync(string fileId, CancellationToken cancellationToken = default);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual ClientResult GetFile(string fileId, RequestOptions options);
+        public virtual ClientResult<OpenAIFile> GetFile(string fileId, CancellationToken cancellationToken = default);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual Task<ClientResult> GetFileAsync(string fileId, RequestOptions options);
+        public virtual Task<ClientResult<OpenAIFile>> GetFileAsync(string fileId, CancellationToken cancellationToken = default);
+        public virtual ClientResult<OpenAIFileCollection> GetFiles(FilePurpose purpose, CancellationToken cancellationToken = default);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual ClientResult GetFiles(string purpose, RequestOptions options);
+        public virtual ClientResult<OpenAIFileCollection> GetFiles(CancellationToken cancellationToken = default);
+        public virtual Task<ClientResult<OpenAIFileCollection>> GetFilesAsync(FilePurpose purpose, CancellationToken cancellationToken = default);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual Task<ClientResult> GetFilesAsync(string purpose, RequestOptions options);
+        public virtual Task<ClientResult<OpenAIFileCollection>> GetFilesAsync(CancellationToken cancellationToken = default);
+        public virtual ClientResult<OpenAIFile> UploadFile(BinaryData file, string filename, FileUploadPurpose purpose);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual ClientResult UploadFile(BinaryContent content, string contentType, RequestOptions options = null);
+        public virtual ClientResult<OpenAIFile> UploadFile(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
+        public virtual ClientResult<OpenAIFile> UploadFile(string filePath, FileUploadPurpose purpose);
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(BinaryData file, string filename, FileUploadPurpose purpose);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual Task<ClientResult> UploadFileAsync(BinaryContent content, string contentType, RequestOptions options = null);
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(Stream file, string filename, FileUploadPurpose purpose, CancellationToken cancellationToken = default);
+        public virtual Task<ClientResult<OpenAIFile>> UploadFileAsync(string filePath, FileUploadPurpose purpose);
     }
     public class OpenAIFileCollection : ObjectModel.ReadOnlyCollection<OpenAIFile>, IJsonModel<OpenAIFileCollection>, IPersistableModel<OpenAIFileCollection> {
         OpenAIFileCollection IJsonModel<OpenAIFileCollection>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
@@ -2095,12 +2095,31 @@ namespace OpenAI.Images {
     }
 }
 namespace OpenAI.Models {
-    public class ModelClient {
-        protected ModelClient();
-        public ModelClient(ApiKeyCredential credential, OpenAIClientOptions options);
-        public ModelClient(ApiKeyCredential credential);
-        protected internal ModelClient(ClientPipeline pipeline, OpenAIClientOptions options);
-        public ModelClient(string apiKey);
+    public class ModelDeletionResult : IJsonModel<ModelDeletionResult>, IPersistableModel<ModelDeletionResult> {
+        public bool Deleted { get; }
+        public string ModelId { get; }
+        ModelDeletionResult IJsonModel<ModelDeletionResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
+        void IJsonModel<ModelDeletionResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
+        ModelDeletionResult IPersistableModel<ModelDeletionResult>.Create(BinaryData data, ModelReaderWriterOptions options);
+        string IPersistableModel<ModelDeletionResult>.GetFormatFromOptions(ModelReaderWriterOptions options);
+        BinaryData IPersistableModel<ModelDeletionResult>.Write(ModelReaderWriterOptions options);
+    }
+    public class OpenAIModel : IJsonModel<OpenAIModel>, IPersistableModel<OpenAIModel> {
+        public DateTimeOffset CreatedAt { get; }
+        public string Id { get; }
+        public string OwnedBy { get; }
+        OpenAIModel IJsonModel<OpenAIModel>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
+        void IJsonModel<OpenAIModel>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
+        OpenAIModel IPersistableModel<OpenAIModel>.Create(BinaryData data, ModelReaderWriterOptions options);
+        string IPersistableModel<OpenAIModel>.GetFormatFromOptions(ModelReaderWriterOptions options);
+        BinaryData IPersistableModel<OpenAIModel>.Write(ModelReaderWriterOptions options);
+    }
+    public class OpenAIModelClient {
+        protected OpenAIModelClient();
+        public OpenAIModelClient(ApiKeyCredential credential, OpenAIClientOptions options);
+        public OpenAIModelClient(ApiKeyCredential credential);
+        protected internal OpenAIModelClient(ClientPipeline pipeline, OpenAIClientOptions options);
+        public OpenAIModelClient(string apiKey);
         public ClientPipeline Pipeline { get; }
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual ClientResult DeleteModel(string model, RequestOptions options);
@@ -2120,25 +2139,6 @@ namespace OpenAI.Models {
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual Task<ClientResult> GetModelsAsync(RequestOptions options);
         public virtual Task<ClientResult<OpenAIModelCollection>> GetModelsAsync(CancellationToken cancellationToken = default);
-    }
-    public class ModelDeletionResult : IJsonModel<ModelDeletionResult>, IPersistableModel<ModelDeletionResult> {
-        public bool Deleted { get; }
-        public string ModelId { get; }
-        ModelDeletionResult IJsonModel<ModelDeletionResult>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
-        void IJsonModel<ModelDeletionResult>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
-        ModelDeletionResult IPersistableModel<ModelDeletionResult>.Create(BinaryData data, ModelReaderWriterOptions options);
-        string IPersistableModel<ModelDeletionResult>.GetFormatFromOptions(ModelReaderWriterOptions options);
-        BinaryData IPersistableModel<ModelDeletionResult>.Write(ModelReaderWriterOptions options);
-    }
-    public class OpenAIModel : IJsonModel<OpenAIModel>, IPersistableModel<OpenAIModel> {
-        public DateTimeOffset CreatedAt { get; }
-        public string Id { get; }
-        public string OwnedBy { get; }
-        OpenAIModel IJsonModel<OpenAIModel>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
-        void IJsonModel<OpenAIModel>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
-        OpenAIModel IPersistableModel<OpenAIModel>.Create(BinaryData data, ModelReaderWriterOptions options);
-        string IPersistableModel<OpenAIModel>.GetFormatFromOptions(ModelReaderWriterOptions options);
-        BinaryData IPersistableModel<OpenAIModel>.Write(ModelReaderWriterOptions options);
     }
     public class OpenAIModelCollection : ObjectModel.ReadOnlyCollection<OpenAIModel>, IJsonModel<OpenAIModelCollection>, IPersistableModel<OpenAIModelCollection> {
         OpenAIModelCollection IJsonModel<OpenAIModelCollection>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);

--- a/.dotnet/examples/Assistants/Example01_RetrievalAugmentedGeneration.cs
+++ b/.dotnet/examples/Assistants/Example01_RetrievalAugmentedGeneration.cs
@@ -16,7 +16,7 @@ public partial class AssistantExamples
         // Assistants is a beta API and subject to change; acknowledge its experimental status by suppressing the matching warning.
         #pragma warning disable OPENAI001
         OpenAIClient openAIClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-        FileClient fileClient = openAIClient.GetFileClient();
+        OpenAIFileClient fileClient = openAIClient.GetOpenAIFileClient();
         AssistantClient assistantClient = openAIClient.GetAssistantClient();
 
         // First, let's contrive a document we'll use retrieval with and upload it.

--- a/.dotnet/examples/Assistants/Example01_RetrievalAugmentedGenerationAsync.cs
+++ b/.dotnet/examples/Assistants/Example01_RetrievalAugmentedGenerationAsync.cs
@@ -17,7 +17,7 @@ public partial class AssistantExamples
         // Assistants is a beta API and subject to change; acknowledge its experimental status by suppressing the matching warning.
         #pragma warning disable OPENAI001
         OpenAIClient openAIClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-        FileClient fileClient = openAIClient.GetFileClient();
+        OpenAIFileClient fileClient = openAIClient.GetOpenAIFileClient();
         AssistantClient assistantClient = openAIClient.GetAssistantClient();
 
         // First, let's contrive a document we'll use retrieval with and upload it.

--- a/.dotnet/examples/Assistants/Example04_AllTheTools.cs
+++ b/.dotnet/examples/Assistants/Example04_AllTheTools.cs
@@ -43,7 +43,7 @@ public partial class AssistantExamples
         };
 
         #region Upload a mock file for use with file search
-        FileClient fileClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
+        OpenAIFileClient fileClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
         OpenAIFile favoriteNumberFile = fileClient.UploadFile(
             BinaryData.FromString("""
                 This file contains the favorite numbers for individuals.

--- a/.dotnet/examples/Assistants/Example05_AssistantsWithVision.cs
+++ b/.dotnet/examples/Assistants/Example05_AssistantsWithVision.cs
@@ -15,7 +15,7 @@ public partial class AssistantExamples
         // Assistants is a beta API and subject to change; acknowledge its experimental status by suppressing the matching warning.
         #pragma warning disable OPENAI001
         OpenAIClient openAIClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-        FileClient fileClient = openAIClient.GetFileClient();
+        OpenAIFileClient fileClient = openAIClient.GetOpenAIFileClient();
         AssistantClient assistantClient = openAIClient.GetAssistantClient();
 
         OpenAIFile pictureOfAppleFile = fileClient.UploadFile(

--- a/.dotnet/examples/Assistants/Example05_AssistantsWithVisionAsync.cs
+++ b/.dotnet/examples/Assistants/Example05_AssistantsWithVisionAsync.cs
@@ -16,7 +16,7 @@ public partial class AssistantExamples
         // Assistants is a beta API and subject to change; acknowledge its experimental status by suppressing the matching warning.
         #pragma warning disable OPENAI001
         OpenAIClient openAIClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-        FileClient fileClient = openAIClient.GetFileClient();
+        OpenAIFileClient fileClient = openAIClient.GetOpenAIFileClient();
         AssistantClient assistantClient = openAIClient.GetAssistantClient();
 
         OpenAIFile pictureOfAppleFile = await fileClient.UploadFileAsync(

--- a/.dotnet/examples/ClientExamples.cs
+++ b/.dotnet/examples/ClientExamples.cs
@@ -41,7 +41,7 @@ public partial class ClientExamples
     public void CreateAssistantAndFileClients()
     {
         OpenAIClient openAIClient = new(Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-        FileClient fileClient = openAIClient.GetFileClient();
+        OpenAIFileClient fileClient = openAIClient.GetOpenAIFileClient();
         AssistantClient assistantClient = openAIClient.GetAssistantClient();
     }
 }

--- a/.dotnet/src/Custom/Files/OpenAIFileClient.Protocol.cs
+++ b/.dotnet/src/Custom/Files/OpenAIFileClient.Protocol.cs
@@ -17,7 +17,7 @@ namespace OpenAI.Files;
 [CodeGenSuppress("DeleteFile", typeof(string), typeof(RequestOptions))]
 [CodeGenSuppress("DownloadFileAsync", typeof(string), typeof(RequestOptions))]
 [CodeGenSuppress("DownloadFile", typeof(string), typeof(RequestOptions))]
-public partial class FileClient
+public partial class OpenAIFileClient
 {
     /// <summary>
     /// [Protocol Method] Upload a file that can be used across various endpoints. The size of all the files uploaded by

--- a/.dotnet/src/Custom/Files/OpenAIFileClient.cs
+++ b/.dotnet/src/Custom/Files/OpenAIFileClient.cs
@@ -12,7 +12,7 @@ namespace OpenAI.Files;
 // - Suppressed constructor that takes endpoint parameter; endpoint is now a property in the options class.
 /// <summary> The service client for OpenAI file operations. </summary>
 [CodeGenClient("Files")]
-[CodeGenSuppress("FileClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
+[CodeGenSuppress("OpenAIFileClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("CreateFileAsync", typeof(InternalFileUploadOptions))]
 [CodeGenSuppress("CreateFile", typeof(InternalFileUploadOptions))]
 [CodeGenSuppress("GetFilesAsync", typeof(string))]
@@ -23,7 +23,7 @@ namespace OpenAI.Files;
 [CodeGenSuppress("DeleteFile", typeof(string))]
 [CodeGenSuppress("DownloadFileAsync", typeof(string))]
 [CodeGenSuppress("DownloadFile", typeof(string))]
-public partial class FileClient
+public partial class OpenAIFileClient
 {
     private InternalUploadsClient _internalUploadsClient;
 
@@ -34,33 +34,33 @@ public partial class FileClient
     public ClientPipeline Pipeline => _pipeline;
 
     // CUSTOM: Added as a convenience.
-    /// <summary> Initializes a new instance of <see cref="FileClient">. </summary>
+    /// <summary> Initializes a new instance of <see cref="OpenAIFileClient">. </summary>
     /// <param name="model"> The name of the model to use in requests sent to the service. To learn more about the available models, see <see href="https://platform.openai.com/docs/models"/>. </param>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="model"/> or <paramref name="apiKey"/> is null. </exception>
     /// <exception cref="ArgumentException"> <paramref name="model"/> is an empty string, and was expected to be non-empty. </exception>
-    public FileClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public OpenAIFileClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
     {
     }
 
     // CUSTOM:
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.
-    /// <summary> Initializes a new instance of <see cref="FileClient">. </summary>
+    /// <summary> Initializes a new instance of <see cref="OpenAIFileClient">. </summary>
     /// <param name="credential"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public FileClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public OpenAIFileClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
     }
 
     // CUSTOM:
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.
-    /// <summary> Initializes a new instance of <see cref="FileClient">. </summary>
+    /// <summary> Initializes a new instance of <see cref="OpenAIFileClient">. </summary>
     /// <param name="credential"> The API key to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public FileClient(ApiKeyCredential credential, OpenAIClientOptions options)
+    public OpenAIFileClient(ApiKeyCredential credential, OpenAIClientOptions options)
     {
         Argument.AssertNotNull(credential, nameof(credential));
         options ??= new OpenAIClientOptions();
@@ -74,11 +74,11 @@ public partial class FileClient
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.
     // - Made protected.
-    /// <summary> Initializes a new instance of <see cref="FileClient">. </summary>
+    /// <summary> Initializes a new instance of <see cref="OpenAIFileClient">. </summary>
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal FileClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal OpenAIFileClient(ClientPipeline pipeline, OpenAIClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
         options ??= new OpenAIClientOptions();

--- a/.dotnet/src/Custom/Models/OpenAIModelClient.Protocol.cs
+++ b/.dotnet/src/Custom/Models/OpenAIModelClient.Protocol.cs
@@ -12,7 +12,7 @@ namespace OpenAI.Models;
 [CodeGenSuppress("RetrieveModel", typeof(string), typeof(RequestOptions))]
 [CodeGenSuppress("DeleteModelAsync", typeof(string), typeof(RequestOptions))]
 [CodeGenSuppress("DeleteModel", typeof(string), typeof(RequestOptions))]
-public partial class ModelClient
+public partial class OpenAIModelClient
 {
     /// <summary>
     /// [Protocol Method] Lists the currently available models, and provides basic information about each one such as the

--- a/.dotnet/src/Custom/Models/OpenAIModelClient.cs
+++ b/.dotnet/src/Custom/Models/OpenAIModelClient.cs
@@ -12,7 +12,7 @@ namespace OpenAI.Models;
 // - Renamed convenience methods.
 /// <summary> The service client for OpenAI model operations. </summary>
 [CodeGenClient("ModelsOps")]
-[CodeGenSuppress("ModelClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
+[CodeGenSuppress("OpenAIModelClient", typeof(ClientPipeline), typeof(ApiKeyCredential), typeof(Uri))]
 [CodeGenSuppress("GetModelsAsync")]
 [CodeGenSuppress("GetModels")]
 [CodeGenSuppress("RetrieveModelAsync", typeof(string))]
@@ -20,7 +20,7 @@ namespace OpenAI.Models;
 [CodeGenSuppress("DeleteModelAsync", typeof(string))]
 [CodeGenSuppress("DeleteModel", typeof(string))]
 
-public partial class ModelClient
+public partial class OpenAIModelClient
 {
     // CUSTOM: Remove virtual keyword.
     /// <summary>
@@ -29,31 +29,31 @@ public partial class ModelClient
     public ClientPipeline Pipeline => _pipeline;
 
     // CUSTOM: Added as a convenience.
-    /// <summary> Initializes a new instance of <see cref="ModelClient">. </summary>
+    /// <summary> Initializes a new instance of <see cref="OpenAIModelClient">. </summary>
     /// <param name="apiKey"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="apiKey"/> is null. </exception>
-    public ModelClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
+    public OpenAIModelClient(string apiKey) : this(new ApiKeyCredential(apiKey), new OpenAIClientOptions())
     {
     }
 
     // CUSTOM:
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.
-    /// <summary> Initializes a new instance of <see cref="ModelClient">. </summary>
+    /// <summary> Initializes a new instance of <see cref="OpenAIModelClient">. </summary>
     /// <param name="credential"> The API key to authenticate with the service. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public ModelClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
+    public OpenAIModelClient(ApiKeyCredential credential) : this(credential, new OpenAIClientOptions())
     {
     }
 
     // CUSTOM:
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.
-    /// <summary> Initializes a new instance of <see cref="ModelClient">. </summary>
+    /// <summary> Initializes a new instance of <see cref="OpenAIModelClient">. </summary>
     /// <param name="credential"> The API key to authenticate with the service. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="credential"/> is null. </exception>
-    public ModelClient(ApiKeyCredential credential, OpenAIClientOptions options)
+    public OpenAIModelClient(ApiKeyCredential credential, OpenAIClientOptions options)
     {
         Argument.AssertNotNull(credential, nameof(credential));
         options ??= new OpenAIClientOptions();
@@ -66,11 +66,11 @@ public partial class ModelClient
     // - Used a custom pipeline.
     // - Demoted the endpoint parameter to be a property in the options class.
     // - Made protected.
-    /// <summary> Initializes a new instance of <see cref="ModelClient">. </summary>
+    /// <summary> Initializes a new instance of <see cref="OpenAIModelClient">. </summary>
     /// <param name="pipeline"> The HTTP pipeline to send and receive REST requests and responses. </param>
     /// <param name="options"> The options to configure the client. </param>
     /// <exception cref="ArgumentNullException"> <paramref name="pipeline"/> is null. </exception>
-    protected internal ModelClient(ClientPipeline pipeline, OpenAIClientOptions options)
+    protected internal OpenAIModelClient(ClientPipeline pipeline, OpenAIClientOptions options)
     {
         Argument.AssertNotNull(pipeline, nameof(pipeline));
         options ??= new OpenAIClientOptions();

--- a/.dotnet/src/Custom/OpenAIClient.cs
+++ b/.dotnet/src/Custom/OpenAIClient.cs
@@ -32,7 +32,7 @@ namespace OpenAI;
 [CodeGenSuppress("_cachedBatchClient")]
 [CodeGenSuppress("_cachedChatClient")]
 [CodeGenSuppress("_cachedEmbeddingClient")]
-[CodeGenSuppress("_cachedFileClient")]
+[CodeGenSuppress("_cachedOpenAIFileClient")]
 [CodeGenSuppress("_cachedFineTuningClient")]
 [CodeGenSuppress("_cachedImageClient")]
 [CodeGenSuppress("_cachedInternalAssistantMessageClient")]
@@ -40,7 +40,7 @@ namespace OpenAI;
 [CodeGenSuppress("_cachedInternalAssistantThreadClient")]
 [CodeGenSuppress("_cachedInternalUploadsClient")]
 [CodeGenSuppress("_cachedLegacyCompletionClient")]
-[CodeGenSuppress("_cachedModelClient")]
+[CodeGenSuppress("_cachedOpenAIModelClient")]
 [CodeGenSuppress("_cachedModerationClient")]
 [CodeGenSuppress("_cachedVectorStoreClient")]
 [CodeGenSuppress("GetAssistantClient")]
@@ -188,15 +188,15 @@ public partial class OpenAIClient
     public virtual EmbeddingClient GetEmbeddingClient(string model) => new(_pipeline, model, _options);
 
     /// <summary>
-    /// Gets a new instance of <see cref="FileClient"/> that reuses the client configuration details provided to
+    /// Gets a new instance of <see cref="OpenAIFileClient"/> that reuses the client configuration details provided to
     /// the <see cref="OpenAIClient"/> instance.
     /// </summary>
     /// <remarks>
-    /// This method is functionally equivalent to using the <see cref="FileClient"/> constructor directly with
+    /// This method is functionally equivalent to using the <see cref="OpenAIFileClient"/> constructor directly with
     /// the same configuration details.
     /// </remarks>
-    /// <returns> A new <see cref="FileClient"/>. </returns>
-    public virtual FileClient GetFileClient() => new(_pipeline, _options);
+    /// <returns> A new <see cref="OpenAIFileClient"/>. </returns>
+    public virtual OpenAIFileClient GetOpenAIFileClient() => new(_pipeline, _options);
 
     /// <summary>
     /// Gets a new instance of <see cref="FineTuningClient"/> that reuses the client configuration details provided to
@@ -222,15 +222,15 @@ public partial class OpenAIClient
     public virtual ImageClient GetImageClient(string model) => new(_pipeline, model, _options);
 
     /// <summary>
-    /// Gets a new instance of <see cref="ModelClient"/> that reuses the client configuration details provided to
+    /// Gets a new instance of <see cref="OpenAIModelClient"/> that reuses the client configuration details provided to
     /// the <see cref="OpenAIClient"/> instance.
     /// </summary>
     /// <remarks>
-    /// This method is functionally equivalent to using the <see cref="ModelClient"/> constructor directly with
+    /// This method is functionally equivalent to using the <see cref="OpenAIModelClient"/> constructor directly with
     /// the same configuration details.
     /// </remarks>
-    /// <returns> A new <see cref="ModelClient"/>. </returns>
-    public virtual ModelClient GetModelClient() => new(_pipeline, _options);
+    /// <returns> A new <see cref="OpenAIModelClient"/>. </returns>
+    public virtual OpenAIModelClient GetOpenAIModelClient() => new(_pipeline, _options);
 
     /// <summary>
     /// Gets a new instance of <see cref="ModerationClient"/> that reuses the client configuration details provided to
@@ -251,7 +251,7 @@ public partial class OpenAIClient
     /// This method is functionally equivalent to using the <see cref="VectorStoreClient"/> constructor directly with
     /// the same configuration details.
     /// </remarks>
-    /// <returns> A new <see cref="ModelClient"/>. </returns>
+    /// <returns> A new <see cref="OpenAIModelClient"/>. </returns>
     [Experimental("OPENAI001")]
     public virtual VectorStoreClient GetVectorStoreClient() => new(_pipeline, _options);
 

--- a/.dotnet/src/Custom/VectorStores/VectorStoreClient.cs
+++ b/.dotnet/src/Custom/VectorStores/VectorStoreClient.cs
@@ -473,7 +473,7 @@ public partial class VectorStoreClient
     /// store.
     /// </summary>
     /// <remarks>
-    /// This does not delete the file. To delete the file, use <see cref="FileClient.DeleteFile(string)"/>.
+    /// This does not delete the file. To delete the file, use <see cref="OpenAIFileClient.DeleteFile(string)"/>.
     /// </remarks>
     /// <param name="vectorStoreId"> The ID of the vector store that the file should be removed from. </param>
     /// <param name="fileId"> The ID of the file to remove from the vector store. </param>
@@ -492,7 +492,7 @@ public partial class VectorStoreClient
     /// store.
     /// </summary>
     /// <remarks>
-    /// This does not delete the file. To delete the file, use <see cref="FileClient.DeleteFile(string)"/>.
+    /// This does not delete the file. To delete the file, use <see cref="OpenAIFileClient.DeleteFile(string)"/>.
     /// </remarks>
     /// <param name="vectorStoreId"> The ID of the vector store that the file should be removed from. </param>
     /// <param name="fileId"> The ID of the file to remove from the vector store. </param>

--- a/.dotnet/src/Generated/OpenAIFileClient.cs
+++ b/.dotnet/src/Generated/OpenAIFileClient.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace OpenAI.Files
 {
     // Data plane generated sub-client.
-    public partial class FileClient
+    public partial class OpenAIFileClient
     {
         private const string AuthorizationHeader = "Authorization";
         private readonly ApiKeyCredential _keyCredential;
@@ -18,7 +18,7 @@ namespace OpenAI.Files
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        protected FileClient()
+        protected OpenAIFileClient()
         {
         }
 

--- a/.dotnet/src/Generated/OpenAIModelClient.cs
+++ b/.dotnet/src/Generated/OpenAIModelClient.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace OpenAI.Models
 {
     // Data plane generated sub-client.
-    public partial class ModelClient
+    public partial class OpenAIModelClient
     {
         private const string AuthorizationHeader = "Authorization";
         private readonly ApiKeyCredential _keyCredential;
@@ -18,7 +18,7 @@ namespace OpenAI.Models
         private readonly ClientPipeline _pipeline;
         private readonly Uri _endpoint;
 
-        protected ModelClient()
+        protected OpenAIModelClient()
         {
         }
 

--- a/.dotnet/tests/Assistants/Assistants.VectorStoresTests.cs
+++ b/.dotnet/tests/Assistants/Assistants.VectorStoresTests.cs
@@ -621,7 +621,7 @@ public class VectorStoresTests : SyncAsyncTestBase
     {
         List<OpenAIFile> files = [];
 
-        FileClient client = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient client = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         for (int i = 0; i < count; i++)
         {
             OpenAIFile file = client.UploadFile(
@@ -638,7 +638,7 @@ public class VectorStoresTests : SyncAsyncTestBase
     [TearDown]
     protected void Cleanup()
     {
-        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient fileClient = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         VectorStoreClient vectorStoreClient = GetTestClient<VectorStoreClient>(TestScenario.VectorStores);
         RequestOptions requestOptions = new()
         {

--- a/.dotnet/tests/Assistants/AssistantsTests.cs
+++ b/.dotnet/tests/Assistants/AssistantsTests.cs
@@ -50,7 +50,7 @@ public class AssistantsTests : SyncAsyncTestBase
         }
 
         AssistantClient client = GetTestClient<AssistantClient>(TestScenario.Assistants);
-        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient fileClient = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         VectorStoreClient vectorStoreClient = GetTestClient<VectorStoreClient>(TestScenario.VectorStores);
         RequestOptions requestOptions = new()
         {
@@ -370,7 +370,7 @@ public class AssistantsTests : SyncAsyncTestBase
         });
         Validate(assistant);
 
-        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient fileClient = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         OpenAIFile equationFile = fileClient.UploadFile(
             BinaryData.FromString("""
             x,y
@@ -792,7 +792,7 @@ public class AssistantsTests : SyncAsyncTestBase
     public async Task FileSearchWorks()
     {
         // First, we need to upload a simple test file.
-        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient fileClient = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         OpenAIFile testFile = fileClient.UploadFile(
             BinaryData.FromString("""
             This file describes the favorite foods of several people.
@@ -968,7 +968,7 @@ public class AssistantsTests : SyncAsyncTestBase
 
         const string fileName = "favorite_foods.txt";
 
-        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient fileClient = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         AssistantClient client = GetTestClient<AssistantClient>(TestScenario.Assistants);
 
         // First, upload a simple test file.
@@ -1656,7 +1656,7 @@ public class AssistantsTests : SyncAsyncTestBase
         });
         Validate(assistant);
 
-        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient fileClient = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         OpenAIFile equationFile = fileClient.UploadFile(
             BinaryData.FromString("""
             x,y
@@ -1731,7 +1731,7 @@ public class AssistantsTests : SyncAsyncTestBase
         });
         Validate(assistant);
 
-        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient fileClient = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         OpenAIFile equationFile = fileClient.UploadFile(
             BinaryData.FromString("""
             x,y

--- a/.dotnet/tests/Batch/BatchTests.cs
+++ b/.dotnet/tests/Batch/BatchTests.cs
@@ -98,7 +98,7 @@ public class BatchTests : SyncAsyncTestBase
         streamWriter.Flush();
         testFileStream.Position = 0;
 
-        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient fileClient = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         OpenAIFile inputFile = await fileClient.UploadFileAsync(testFileStream, "test-batch-file", FileUploadPurpose.Batch);
         Assert.That(inputFile.Id, Is.Not.Null.And.Not.Empty);
 
@@ -163,7 +163,7 @@ public class BatchTests : SyncAsyncTestBase
         streamWriter.Flush();
         testFileStream.Position = 0;
 
-        FileClient fileClient = GetTestClient<FileClient>(TestScenario.Files);
+        OpenAIFileClient fileClient = GetTestClient<OpenAIFileClient>(TestScenario.Files);
         OpenAIFile inputFile = await fileClient.UploadFileAsync(testFileStream, "test-batch-file", FileUploadPurpose.Batch);
         Assert.That(inputFile.Id, Is.Not.Null.And.Not.Empty);
 

--- a/.dotnet/tests/Files/Files.UploadsTests.cs
+++ b/.dotnet/tests/Files/Files.UploadsTests.cs
@@ -15,7 +15,7 @@ namespace OpenAI.Tests.Files;
 [Category("Uploads")]
 public class UploadsTests : SyncAsyncTestBase
 {
-    private static FileClient GetTestClient() => GetTestClient<FileClient>(TestScenario.Files);
+    private static OpenAIFileClient GetTestClient() => GetTestClient<OpenAIFileClient>(TestScenario.Files);
 
     public UploadsTests(bool isAsync) : base(isAsync)
     {
@@ -29,8 +29,8 @@ public class UploadsTests : SyncAsyncTestBase
         // Test with the top-level client as well to validate that both FileClient constructors
         // are setting the internal Uploads client correctly.
 
-        FileClient fileClient = useTopLevelClient
-            ? TestHelpers.GetTestTopLevelClient().GetFileClient()
+        OpenAIFileClient fileClient = useTopLevelClient
+            ? TestHelpers.GetTestTopLevelClient().GetOpenAIFileClient()
             : GetTestClient();
         BinaryContent content = BinaryContent.Create(BinaryData.FromObjectAsJson(new
         {
@@ -63,7 +63,7 @@ public class UploadsTests : SyncAsyncTestBase
     [Test]
     public async Task AddUploadPartWorks()
     {
-        FileClient fileClient = GetTestClient();
+        OpenAIFileClient fileClient = GetTestClient();
         UploadDetails uploadDetails = await CreateTestUploadAsync(fileClient);
         using MultipartFormDataBinaryContent content = new();
 
@@ -86,7 +86,7 @@ public class UploadsTests : SyncAsyncTestBase
     [Test]
     public async Task CompleteUploadWorks()
     {
-        FileClient fileClient = GetTestClient();
+        OpenAIFileClient fileClient = GetTestClient();
         UploadDetails createdUploadDetails = await CreateTestUploadAsync(fileClient);
         using MultipartFormDataBinaryContent firstPartContent = new();
         using MultipartFormDataBinaryContent secondPartContent = new();
@@ -144,7 +144,7 @@ public class UploadsTests : SyncAsyncTestBase
     [Test]
     public async Task CancelUploadWorks()
     {
-        FileClient fileClient = GetTestClient();
+        OpenAIFileClient fileClient = GetTestClient();
         UploadDetails createdUploadDetails = await CreateTestUploadAsync(fileClient);
 
         ClientResult result = IsAsync
@@ -165,7 +165,7 @@ public class UploadsTests : SyncAsyncTestBase
         Assert.That(canceledUploadDetails.ExpiresAt, Is.EqualTo(createdUploadDetails.ExpiresAt));
     }
 
-    private async Task<UploadDetails> CreateTestUploadAsync(FileClient fileClient)
+    private async Task<UploadDetails> CreateTestUploadAsync(OpenAIFileClient fileClient)
     {
         BinaryContent content = BinaryContent.Create(BinaryData.FromObjectAsJson(new
         {
@@ -182,7 +182,7 @@ public class UploadsTests : SyncAsyncTestBase
         return GetUploadDetails(jsonDocument);
     }
 
-    private async Task<UploadPartDetails> AddTestUploadPartAsync(FileClient fileClient, string uploadId, MultipartFormDataBinaryContent content)
+    private async Task<UploadPartDetails> AddTestUploadPartAsync(OpenAIFileClient fileClient, string uploadId, MultipartFormDataBinaryContent content)
     {
         ClientResult result = await fileClient.AddUploadPartAsync(uploadId, content, content.ContentType);
         BinaryData response = result.GetRawResponse().Content;

--- a/.dotnet/tests/Files/FilesMockTests.cs
+++ b/.dotnet/tests/Files/FilesMockTests.cs
@@ -61,7 +61,7 @@ public class FilesMockTests : SyncAsyncTestBase
             "id": "returned_file_id"
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFile fileInfo = IsAsync
             ? await client.GetFileAsync("file_id")
@@ -78,7 +78,7 @@ public class FilesMockTests : SyncAsyncTestBase
             "created_at": 1704096000
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFile fileInfo = IsAsync
             ? await client.GetFileAsync("file_id")
@@ -96,7 +96,7 @@ public class FilesMockTests : SyncAsyncTestBase
             "purpose": "{{purpose.stringValue}}"
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFile fileInfo = IsAsync
             ? await client.GetFileAsync("file_id")
@@ -116,7 +116,7 @@ public class FilesMockTests : SyncAsyncTestBase
             "status": "{{status.stringValue}}"
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFile fileInfo = IsAsync
             ? await client.GetFileAsync("file_id")
@@ -135,7 +135,7 @@ public class FilesMockTests : SyncAsyncTestBase
             "status_details": "This is definitely an error."
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFile fileInfo = IsAsync
             ? await client.GetFileAsync("file_id")
@@ -148,7 +148,7 @@ public class FilesMockTests : SyncAsyncTestBase
     [Test]
     public void GetFileRespectsTheCancellationToken()
     {
-        FileClient client = new FileClient(s_fakeCredential);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential);
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 
@@ -243,7 +243,7 @@ public class FilesMockTests : SyncAsyncTestBase
     [Test]
     public void UploadFileRespectsTheCancellationToken()
     {
-        FileClient client = new FileClient(s_fakeCredential);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential);
         using var stream = new MemoryStream(Array.Empty<byte>());
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
@@ -272,7 +272,7 @@ public class FilesMockTests : SyncAsyncTestBase
             ]
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFileCollection fileInfoCollection = IsAsync
             ? await client.GetFilesAsync(FilePurpose.Assistants)
@@ -294,7 +294,7 @@ public class FilesMockTests : SyncAsyncTestBase
             ]
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFileCollection fileInfoCollection = IsAsync
             ? await client.GetFilesAsync(FilePurpose.Assistants)
@@ -317,7 +317,7 @@ public class FilesMockTests : SyncAsyncTestBase
             ]
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFileCollection fileInfoCollection = IsAsync
             ? await client.GetFilesAsync(FilePurpose.Assistants)
@@ -341,7 +341,7 @@ public class FilesMockTests : SyncAsyncTestBase
             ]
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFileCollection fileInfoCollection = IsAsync
             ? await client.GetFilesAsync(FilePurpose.Assistants)
@@ -365,7 +365,7 @@ public class FilesMockTests : SyncAsyncTestBase
             ]
         }
         """);
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
 
         OpenAIFileCollection fileInfoCollection = IsAsync
             ? await client.GetFilesAsync(FilePurpose.Assistants)
@@ -379,7 +379,7 @@ public class FilesMockTests : SyncAsyncTestBase
     [Test]
     public void GetFilesRespectsTheCancellationToken()
     {
-        FileClient client = new FileClient(s_fakeCredential);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential);
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 
@@ -398,7 +398,7 @@ public class FilesMockTests : SyncAsyncTestBase
     [Test]
     public void DownloadFileRespectsTheCancellationToken()
     {
-        FileClient client = new FileClient(s_fakeCredential);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential);
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 
@@ -417,7 +417,7 @@ public class FilesMockTests : SyncAsyncTestBase
     [Test]
     public void DeleteFileRespectsTheCancellationToken()
     {
-        FileClient client = new FileClient(s_fakeCredential);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential);
         using CancellationTokenSource cancellationSource = new();
         cancellationSource.Cancel();
 
@@ -446,7 +446,7 @@ public class FilesMockTests : SyncAsyncTestBase
 
     private async ValueTask<OpenAIFile> InvokeUploadFileSyncOrAsync(OpenAIClientOptions clientOptions, FileSourceKind fileSourceKind)
     {
-        FileClient client = new FileClient(s_fakeCredential, clientOptions);
+        OpenAIFileClient client = new OpenAIFileClient(s_fakeCredential, clientOptions);
         string filename = "images_dog_and_cat.png";
         string path = Path.Combine("Assets", filename);
 

--- a/.dotnet/tests/Files/FilesTests.cs
+++ b/.dotnet/tests/Files/FilesTests.cs
@@ -16,7 +16,7 @@ namespace OpenAI.Tests.Files;
 [Category("Files")]
 public class FilesTests : SyncAsyncTestBase
 {
-    private static FileClient GetTestClient() => GetTestClient<FileClient>(TestScenario.Files);
+    private static OpenAIFileClient GetTestClient() => GetTestClient<OpenAIFileClient>(TestScenario.Files);
 
     public FilesTests(bool isAsync) : base(isAsync)
     {
@@ -25,7 +25,7 @@ public class FilesTests : SyncAsyncTestBase
     [Test]
     public async Task ListFiles()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         using Stream file1 = BinaryData.FromString("Hello! This is a test text file. Please delete me.").ToStream();
         using Stream file2 = BinaryData.FromString("Hello! This is another test text file. Please delete me.").ToStream();
         string filename = "test-file-delete-me.txt";
@@ -121,7 +121,7 @@ public class FilesTests : SyncAsyncTestBase
     [TestCaseSource(nameof(s_fileSourceKindSource))]
     public async Task UploadFile(FileSourceKind fileSourceKind)
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         string filename = "images_dog_and_cat.png";
         string path = Path.Combine("Assets", filename);
         OpenAIFile fileInfo = null;
@@ -182,7 +182,7 @@ public class FilesTests : SyncAsyncTestBase
     [Test]
     public void UploadFileCanParseServiceError()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         string filename = "images_dog_and_cat.png";
         string path = Path.Combine("Assets", filename);
         FileUploadPurpose fakePurpose = new FileUploadPurpose("world_domination");
@@ -205,7 +205,7 @@ public class FilesTests : SyncAsyncTestBase
     [TestCase(false)]
     public async Task DeleteFile(bool useFileInfoOverload)
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         string fileContent = "Hello! This is a test text file. Please delete me.";
         using Stream file = BinaryData.FromString(fileContent).ToStream();
         string filename = "test-file-delete-me.txt";
@@ -233,7 +233,7 @@ public class FilesTests : SyncAsyncTestBase
     [Test]
     public void DeleteFileCanParseServiceError()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         ClientResultException ex = null;
 
         if (IsAsync)
@@ -251,7 +251,7 @@ public class FilesTests : SyncAsyncTestBase
     [Test]
     public async Task GetFile()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         using Stream file = BinaryData.FromString("Hello! This is a test text file. Please delete me.").ToStream();
         string filename = "test-file-delete-me.txt";
         OpenAIFile uploadedFile = null;
@@ -288,7 +288,7 @@ public class FilesTests : SyncAsyncTestBase
     [Test]
     public void GetFileCanParseServiceError()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         ClientResultException ex = null;
 
         if (IsAsync)
@@ -306,7 +306,7 @@ public class FilesTests : SyncAsyncTestBase
     [Test]
     public async Task DownloadContent()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         string filename = "images_dog_and_cat.png";
         string path = Path.Combine("Assets", filename);
         using Stream file = File.OpenRead(path);
@@ -338,7 +338,7 @@ public class FilesTests : SyncAsyncTestBase
     [Test]
     public void DownloadFileCanParseServiceError()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         ClientResultException ex = null;
 
         if (IsAsync)
@@ -362,7 +362,7 @@ public class FilesTests : SyncAsyncTestBase
     [Test]
     public async Task NonAsciiFilename()
     {
-        FileClient client = GetTestClient();
+        OpenAIFileClient client = GetTestClient();
         string filename = "你好.txt";
         BinaryData fileContent = BinaryData.FromString("世界您好！这是个测试。");
         OpenAIFile uploadedFile = IsAsync

--- a/.dotnet/tests/Models/ModelsMockTests.cs
+++ b/.dotnet/tests/Models/ModelsMockTests.cs
@@ -29,7 +29,7 @@ public class ModelsMockTests : SyncAsyncTestBase
             "created": 1704096000
         }
         """);
-        ModelClient client = new ModelClient(s_fakeCredential, clientOptions);
+        OpenAIModelClient client = new OpenAIModelClient(s_fakeCredential, clientOptions);
 
         OpenAIModel modelInfo = IsAsync
             ? await client.GetModelAsync("model_name")
@@ -50,7 +50,7 @@ public class ModelsMockTests : SyncAsyncTestBase
             ]
         }
         """);
-        ModelClient client = new ModelClient(s_fakeCredential, clientOptions);
+        OpenAIModelClient client = new OpenAIModelClient(s_fakeCredential, clientOptions);
 
         OpenAIModelCollection modelInfoCollection = IsAsync
             ? await client.GetModelsAsync()

--- a/.dotnet/tests/Models/ModelsTests.cs
+++ b/.dotnet/tests/Models/ModelsTests.cs
@@ -22,7 +22,7 @@ public class ModelsTests : SyncAsyncTestBase
     [Test]
     public async Task ListModels()
     {
-        ModelClient client = GetTestClient<ModelClient>(TestScenario.Models);
+        OpenAIModelClient client = GetTestClient<OpenAIModelClient>(TestScenario.Models);
 
         OpenAIModelCollection allModels = IsAsync
             ? await client.GetModelsAsync()
@@ -44,7 +44,7 @@ public class ModelsTests : SyncAsyncTestBase
     [Test]
     public async Task GetModelInfo()
     {
-        ModelClient client = GetTestClient<ModelClient>(TestScenario.Models);
+        OpenAIModelClient client = GetTestClient<OpenAIModelClient>(TestScenario.Models);
         string modelId = "gpt-4o-mini";
 
         OpenAIModel model = IsAsync
@@ -62,7 +62,7 @@ public class ModelsTests : SyncAsyncTestBase
     [Test]
     public void GetModelCanParseServiceError()
     {
-        ModelClient client = GetTestClient<ModelClient>(TestScenario.Models);
+        OpenAIModelClient client = GetTestClient<OpenAIModelClient>(TestScenario.Models);
         ClientResultException ex = null;
 
         if (IsAsync)
@@ -80,7 +80,7 @@ public class ModelsTests : SyncAsyncTestBase
     [Test]
     public void DeleteModelCanParseServiceError()
     {
-        ModelClient client = GetTestClient<ModelClient>(TestScenario.Models);
+        OpenAIModelClient client = GetTestClient<OpenAIModelClient>(TestScenario.Models);
         ClientResultException ex = null;
 
         if (IsAsync)

--- a/.dotnet/tests/Utility/TestHelpers.cs
+++ b/.dotnet/tests/Utility/TestHelpers.cs
@@ -58,10 +58,10 @@ internal static class TestHelpers
             TestScenario.Batch => new BatchClient(credential, options),
             TestScenario.Chat => new ChatClient(overrideModel ?? "gpt-4o-mini", credential, options),
             TestScenario.Embeddings => new EmbeddingClient(overrideModel ?? "text-embedding-3-small", credential, options),
-            TestScenario.Files => new FileClient(credential, options),
+            TestScenario.Files => new OpenAIFileClient(credential, options),
             TestScenario.FineTuning => new FineTuningClient(credential, options),
             TestScenario.Images => new ImageClient(overrideModel ?? "dall-e-3", credential, options),
-            TestScenario.Models => new ModelClient(credential, options),
+            TestScenario.Models => new OpenAIModelClient(credential, options),
             TestScenario.Moderations => new ModerationClient(overrideModel ?? "text-moderation-stable", credential, options),
 #pragma warning disable OPENAI001
             TestScenario.VectorStores => new VectorStoreClient(credential, options),

--- a/.scripts/Run-Checks.ps1
+++ b/.scripts/Run-Checks.ps1
@@ -7,16 +7,16 @@ function Run-ModelsSubnamespaceCheck {
     $files = Get-ChildItem -Path $($directory + "\*") -Include "*.cs" -Recurse
 
     $exclusions = @(
-        "ModelDeletionResult.cs",
-        "ModelDeletionResult.Serialization.cs",
         "GeneratorStubs.cs",
         "InternalDeleteModelResponseObject.cs",
         "InternalListModelsResponseObject.cs",
         "InternalModelObject.cs",
-        "ModelClient.cs",
-        "ModelClient.Protocol.cs",
+        "ModelDeletionResult.cs",
+        "ModelDeletionResult.Serialization.cs",
         "OpenAIModel.cs",
         "OpenAIModel.Serialization.cs",
+        "OpenAIModelClient.cs",
+        "OpenAIModelClient.Protocol.cs",
         "OpenAIModelCollection.cs",
         "OpenAIModelCollection.Serialization.cs",
         "OpenAIModelsModelFactory.cs"


### PR DESCRIPTION
- Renamed `FileClient` to `OpenAIFileClient` and the corresponding `GetFileClient()` method in `OpenAIClient` to `GetOpenAIFileClient()`.
- Renamed `ModelClient` to `OpenAIModelClient` and the corresponding `GetModelClient()` method in `OpenAIClient` to `GetOpenAIModelClient()`.