### PR TITLE
Realtime: fix response.audio.done serialization

### DIFF
--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 2.1.0-beta.1 (2024-10-01)
+
+Relative to the prior GA release, this update restores preview surfaces, retargeting to the latest `2024-08-01-preview` service `api-version` label. It also brings early support for the newly-announced `/realtime` capabilities with `gpt-4o-realtime-preview`. You can read more about Azure OpenAI support for `/realtime` in the annoucement post here: https://azure.microsoft.com/blog/announcing-new-products-and-features-for-azure-openai-service-including-gpt-4o-realtime-preview-with-audio-and-speech-capabilities/
+
+### Features Added
+
+- Added a new `RealtimeConversationClient` in a corresponding scenario namespace. ([ff75da4](https://github.com/openai/openai-dotnet/commit/ff75da4167bc83fa85eb69ac142cab88a963ed06))
+  - This maps to the new `/realtime` beta endpoint and is thus marked with a new `[Experimental("OPENAI002")]` diagnostic tag. 
+  - This is a very early version of the convenience surface and thus subject to significant change
+  - Documentation and samples will arrive soon; in the interim, see [the scenario test files](/tests/ConversationTests.cs) for basic usage
+  - You can also find an external sample employing this client, together with Azure OpenAI support, at https://github.com/Azure-Samples/aoai-realtime-audio-sdk/tree/main/dotnet/samples/console
+
 ## 2.0.0 (2024-09-30)
 
 This update marks the first stable library version for `Azure.AI.OpenAI`. It snaps its dependency to `OpenAI`'s matched `2.0.0` stable version and targets the latest Azure OpenAI Service stable `api-version` label of `2024-06-01`. As a GA label, the `2.0.0` stable version exposes a subset of preview features, with preview library labels continuing to support preview features.

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -9,7 +9,7 @@ Relative to the prior GA release, this update restores preview surfaces, retarge
 - Added a new `RealtimeConversationClient` in a corresponding scenario namespace. ([ff75da4](https://github.com/openai/openai-dotnet/commit/ff75da4167bc83fa85eb69ac142cab88a963ed06))
   - This maps to the new `/realtime` beta endpoint and is thus marked with a new `[Experimental("OPENAI002")]` diagnostic tag. 
   - This is a very early version of the convenience surface and thus subject to significant change
-  - Documentation and samples will arrive soon; in the interim, see [the scenario test files](/tests/ConversationTests.cs) for basic usage
+  - Documentation and samples will arrive soon; in the interim, see the scenario test files (in `/tests`) for basic usage
   - You can also find an external sample employing this client, together with Azure OpenAI support, at https://github.com/Azure-Samples/aoai-realtime-audio-sdk/tree/main/dotnet/samples/console
 
 ## 2.0.0 (2024-09-30)

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -10,7 +10,7 @@
     <DisableEnhancedAnalysis>true</DisableEnhancedAnalysis>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateAPIListing>true</GenerateAPIListing>
-    <NoWarn>$(NoWarn);CS1591;AZC0012;AZC0102;CS8002;CS0436;AZC0112;OPENAI001</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;AZC0012;AZC0102;CS8002;CS0436;AZC0112;OPENAI001;OPENAI002</NoWarn>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>disable</Nullable>

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Batch/AzureCreateBatchOperation.Protocol.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Batch/AzureCreateBatchOperation.Protocol.cs
@@ -11,8 +11,7 @@ using System.ClientModel.Primitives;
 namespace Azure.AI.OpenAI.Batch;
 
 /// <summary>
-/// A long-running operation for executing a batch from an uploaded file of 
-/// requests.
+/// A long-running operation for executing a batch from an uploaded file of requests.
 /// </summary>
 internal partial class AzureCreateBatchOperation : CreateBatchOperation
 {

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/OnYourData/MongoDBChatDataSource.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/OnYourData/MongoDBChatDataSource.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Azure.AI.OpenAI.Chat;
 
-
 [CodeGenModel("MongoDBChatDataSource")]
 [Experimental("AOAI001")]
 #if AZURE_OPENAI_GA

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/FineTuning/AzureFineTurningJobOperation.Protocol.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/FineTuning/AzureFineTurningJobOperation.Protocol.cs
@@ -106,7 +106,6 @@ internal class AzureFineTuningJobOperation : FineTuningJobOperation
     {
         using PipelineMessage message = CreateGetFineTuningEventsRequest(_jobId, after, limit, options);
         return ClientResult.FromResponse(_pipeline.ProcessMessage(message, options));
-
     }
 
     [Experimental("AOAI001")]

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/RealtimeConversation/AzureRealtimeConversationClient.Protocol.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/RealtimeConversation/AzureRealtimeConversationClient.Protocol.cs
@@ -14,10 +14,8 @@ internal partial class AzureRealtimeConversationClient : RealtimeConversationCli
 {
     /// <summary>
     /// <para>[Protocol Method]</para>
-    /// Creates a new realtime conversation operation instance, establishing the connection and optionally sending an
-    /// initial configuration message payload.
+    /// Creates a new realtime conversation operation instance, establishing a connection with the /realtime endpoint.
     /// </summary>
-    /// <param name="data"> An initial configuration payload to send once the connection is established. </param>
     /// <param name="options"></param>
     /// <returns></returns>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/RealtimeConversation/AzureRealtimeConversationSession.Protocol.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/RealtimeConversation/AzureRealtimeConversationSession.Protocol.cs
@@ -19,7 +19,7 @@ internal partial class AzureRealtimeConversationSession : RealtimeConversationSe
 
         if (_tokenCredential is not null)
         {
-            AccessToken token = await _tokenCredential.GetTokenAsync(_tokenRequestContext, options?.CancellationToken ?? default);
+            AccessToken token = await _tokenCredential.GetTokenAsync(_tokenRequestContext, options?.CancellationToken ?? default).ConfigureAwait(false);
             _clientWebSocket.Options.SetRequestHeader("Authorization", $"Bearer {token.Token}");
         }
         else

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/AssistantTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/AssistantTests.cs
@@ -716,4 +716,3 @@ public class AssistantTests(bool isAsync) : AoaiTestBase<AssistantClient>(isAsyn
     }
 #endif
 }
-

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/FineTuningTests.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/FineTuningTests.cs
@@ -211,7 +211,7 @@ public class FineTuningTests : AoaiTestBase<FineTuningClient>
         }
         catch (ClientResultException e)
         {
-            if(e.Message.Contains("ResourceNotFound"))
+            if (e.Message.Contains("ResourceNotFound"))
             {
                 // upload training data
                 uploadedFile = await UploadAndWaitForCompleteOrFail(fileClient, fineTuningFile.RelativePath);

--- a/.dotnet/.github/workflows/live-test.yml
+++ b/.dotnet/.github/workflows/live-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run live tests
         run: dotnet test ./tests/OpenAI.Tests.csproj
           --configuration Release
-          --filter="TestCategory!=Smoke&TestCategory!=Images&TestCategory!=Uploads&TestCategory!=Moderations&TestCategory!=FineTuning&TestCategory!=Manual"
+          --filter="TestCategory!=Smoke&TestCategory!=Images&TestCategory!=Uploads&TestCategory!=Moderations&TestCategory!=FineTuning&TestCategory!=Conversation&TestCategory!=Manual"
           --logger "trx;LogFilePrefix=live"
           --results-directory ${{github.workspace}}/artifacts/test-results
           ${{ env.version_suffix_args}}

--- a/.dotnet/.github/workflows/release.yml
+++ b/.dotnet/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run Live Tests
         run: dotnet test ./tests/OpenAI.Tests.csproj
           --configuration Release
-          --filter="TestCategory!=Smoke&TestCategory!=Images&TestCategory!=Uploads&TestCategory!=Moderations&TestCategory!=FineTuning&TestCategory!=Manual"
+          --filter="TestCategory!=Smoke&TestCategory!=Images&TestCategory!=Uploads&TestCategory!=Moderations&TestCategory!=FineTuning&TestCategory!=FineTuning&TestCategory!=Manual"
           --logger "trx;LogFilePrefix=live"
           --results-directory ${{ github.workspace }}/artifacts/test-results
           ${{ env.version_suffix_args }}

--- a/.dotnet/.github/workflows/release.yml
+++ b/.dotnet/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run Live Tests
         run: dotnet test ./tests/OpenAI.Tests.csproj
           --configuration Release
-          --filter="TestCategory!=Smoke&TestCategory!=Images&TestCategory!=Uploads&TestCategory!=Moderations&TestCategory!=FineTuning&TestCategory!=FineTuning&TestCategory!=Manual"
+          --filter="TestCategory!=Smoke&TestCategory!=Images&TestCategory!=Uploads&TestCategory!=Moderations&TestCategory!=FineTuning&TestCategory!=Conversation&TestCategory!=Manual"
           --logger "trx;LogFilePrefix=live"
           --results-directory ${{ github.workspace }}/artifacts/test-results
           ${{ env.version_suffix_args }}

--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -8,7 +8,7 @@ Given the scope and recency of the feature area, the new `RealtimeConversationCl
 
 ### Features Added
 
-- Added a new `RealtimeConversationClient` in a corresponding scenario namespace.
+- Added a new `RealtimeConversationClient` in a corresponding scenario namespace. ([ff75da4](https://github.com/openai/openai-dotnet/commit/ff75da4167bc83fa85eb69ac142cab88a963ed06))
   - This maps to the new `/realtime` beta endpoint and is thus marked with a new `[Experimental("OPENAI002")]` diagnostic tag. 
   - This is a very early version of the convenience surface and thus subject to significant change
   - Documentation and samples will arrive soon; in the interim, see [the scenario test files](/tests/RealtimeConversation) for basic usage
@@ -32,15 +32,18 @@ Given the scope and recency of the feature area, the new `RealtimeConversationCl
 
 ### Breaking Changes
 
-- Implemented `ChatMessageContent` to encapsulate the representation of content parts in `ChatMessage`, `ChatCompletion`, and `StreamingChatCompletionUpdate`. (commit_hash)
-- Changed the representation of function arguments to `BinaryData` in `ChatToolCall`, `StreamingChatToolCallUpdate`, `ChatFunctionCall`, and `StreamingChatFunctionCallUpdate`. (commit_hash)
-- Renamed `OpenAIClientOptions`'s `ApplicationId` to `UserAgentApplicationId` (commit_hash)
-- Renamed `StreamingChatToolCallUpdate`'s `Id` to `ToolCallId` (commit_hash)
-- Renamed `StreamingChatCompletionUpdate`'s `Id` to `CompletionId` (commit_hash)
-- Replaced `Auto` and `None` in the deprecated `ChatFunctionChoice` with `CreateAutoChoice()` and `CreateNoneChoice()` (commit_hash)
-- Replaced the deprecated `ChatFunctionChoice(ChatFunction)` constructor with `CreateNamedChoice(string functionName)` (commit_hash)
-- Renamed `FileClient` to `OpenAIFileClient` and the corresponding `GetFileClient()` method in `OpenAIClient` to `GetOpenAIFileClient()`. (commit_hash)
-- Renamed `ModelClient` to `OpenAIModelClient` and the corresponding `GetModelClient()` method in `OpenAIClient` to `GetOpenAIModelClient()`. (commit_hash)
+> [!NOTE]
+> The following breaking changes only apply when upgrading from the previous 2.0.0-beta.* versions.
+
+- Implemented `ChatMessageContent` to encapsulate the representation of content parts in `ChatMessage`, `ChatCompletion`, and `StreamingChatCompletionUpdate`. ([31c2ba6](https://github.com/openai/openai-dotnet/commit/31c2ba63c625b1b4fc2640ddf378a97e89b89167))
+- Changed the representation of function arguments to `BinaryData` in `ChatToolCall`, `StreamingChatToolCallUpdate`, `ChatFunctionCall`, and `StreamingChatFunctionCallUpdate`. ([31c2ba6](https://github.com/openai/openai-dotnet/commit/31c2ba63c625b1b4fc2640ddf378a97e89b89167))
+- Renamed `OpenAIClientOptions`'s `ApplicationId` to `UserAgentApplicationId`. ([31c2ba6](https://github.com/openai/openai-dotnet/commit/31c2ba63c625b1b4fc2640ddf378a97e89b89167))
+- Renamed `StreamingChatToolCallUpdate`'s `Id` to `ToolCallId`. ([31c2ba6](https://github.com/openai/openai-dotnet/commit/31c2ba63c625b1b4fc2640ddf378a97e89b89167))
+- Renamed `StreamingChatCompletionUpdate`'s `Id` to `CompletionId`. ([31c2ba6](https://github.com/openai/openai-dotnet/commit/31c2ba63c625b1b4fc2640ddf378a97e89b89167))
+- Replaced `Auto` and `None` in the deprecated `ChatFunctionChoice` with `CreateAutoChoice()` and `CreateNoneChoice()`. ([31c2ba6](https://github.com/openai/openai-dotnet/commit/31c2ba63c625b1b4fc2640ddf378a97e89b89167))
+- Replaced the deprecated `ChatFunctionChoice(ChatFunction)` constructor with `CreateNamedChoice(string functionName)`. ([31c2ba6](https://github.com/openai/openai-dotnet/commit/31c2ba63c625b1b4fc2640ddf378a97e89b89167))
+- Renamed `FileClient` to `OpenAIFileClient` and the corresponding `GetFileClient()` method in `OpenAIClient` to `GetOpenAIFileClient()`. ([31c2ba6](https://github.com/openai/openai-dotnet/commit/31c2ba63c625b1b4fc2640ddf378a97e89b89167))
+- Renamed `ModelClient` to `OpenAIModelClient` and the corresponding `GetModelClient()` method in `OpenAIClient` to `GetOpenAIModelClient()`. ([31c2ba6](https://github.com/openai/openai-dotnet/commit/31c2ba63c625b1b4fc2640ddf378a97e89b89167))
 
 ## 2.0.0-beta.13 (2024-09-27)
 

--- a/.dotnet/src/Generated/Models/ConversationAudioDoneUpdate.Serialization.cs
+++ b/.dotnet/src/Generated/Models/ConversationAudioDoneUpdate.Serialization.cs
@@ -21,11 +21,6 @@ namespace OpenAI.RealtimeConversation
             }
 
             writer.WriteStartObject();
-            if (SerializedAdditionalRawData?.ContainsKey("type") != true)
-            {
-                writer.WritePropertyName("type"u8);
-                writer.WriteStringValue(Type);
-            }
             if (SerializedAdditionalRawData?.ContainsKey("response_id") != true)
             {
                 writer.WritePropertyName("response_id"u8);
@@ -105,22 +100,16 @@ namespace OpenAI.RealtimeConversation
             {
                 return null;
             }
-            string type = default;
             string responseId = default;
             string itemId = default;
             int outputIndex = default;
             int contentIndex = default;
-            ConversationUpdateKind type0 = default;
+            ConversationUpdateKind type = default;
             string eventId = default;
             IDictionary<string, BinaryData> serializedAdditionalRawData = default;
             Dictionary<string, BinaryData> rawDataDictionary = new Dictionary<string, BinaryData>();
             foreach (var property in element.EnumerateObject())
             {
-                if (property.NameEquals("type"u8))
-                {
-                    type = property.Value.GetString();
-                    continue;
-                }
                 if (property.NameEquals("response_id"u8))
                 {
                     responseId = property.Value.GetString();
@@ -143,7 +132,7 @@ namespace OpenAI.RealtimeConversation
                 }
                 if (property.NameEquals("type"u8))
                 {
-                    type0 = property.Value.GetString().ToConversationUpdateKind();
+                    type = property.Value.GetString().ToConversationUpdateKind();
                     continue;
                 }
                 if (property.NameEquals("event_id"u8))
@@ -164,10 +153,9 @@ namespace OpenAI.RealtimeConversation
             }
             serializedAdditionalRawData = rawDataDictionary;
             return new ConversationAudioDoneUpdate(
-                type0,
+                type,
                 eventId,
                 serializedAdditionalRawData,
-                type,
                 responseId,
                 itemId,
                 outputIndex,

--- a/.dotnet/src/Generated/Models/ConversationAudioDoneUpdate.cs
+++ b/.dotnet/src/Generated/Models/ConversationAudioDoneUpdate.cs
@@ -21,9 +21,8 @@ namespace OpenAI.RealtimeConversation
             ContentIndex = contentIndex;
         }
 
-        internal ConversationAudioDoneUpdate(ConversationUpdateKind kind, string eventId, IDictionary<string, BinaryData> serializedAdditionalRawData, string type, string responseId, string itemId, int outputIndex, int contentIndex) : base(kind, eventId, serializedAdditionalRawData)
+        internal ConversationAudioDoneUpdate(ConversationUpdateKind kind, string eventId, IDictionary<string, BinaryData> serializedAdditionalRawData, string responseId, string itemId, int outputIndex, int contentIndex) : base(kind, eventId, serializedAdditionalRawData)
         {
-            Type = type;
             ResponseId = responseId;
             ItemId = itemId;
             OutputIndex = outputIndex;
@@ -33,8 +32,6 @@ namespace OpenAI.RealtimeConversation
         internal ConversationAudioDoneUpdate()
         {
         }
-
-        internal string Type { get; set; } = "response.audio.done";
 
         public string ResponseId { get; }
         public string ItemId { get; }

--- a/.dotnet/src/Generated/OpenAIModelFactory.cs
+++ b/.dotnet/src/Generated/OpenAIModelFactory.cs
@@ -131,6 +131,18 @@ namespace OpenAI
                 delta);
         }
 
+        public static ConversationAudioDoneUpdate ConversationAudioDoneUpdate(string eventId = null, string responseId = null, string itemId = null, int outputIndex = default, int contentIndex = default)
+        {
+            return new ConversationAudioDoneUpdate(
+                ConversationUpdateKind.ResponseAudioDone,
+                eventId,
+                serializedAdditionalRawData: null,
+                responseId,
+                itemId,
+                outputIndex,
+                contentIndex);
+        }
+
         public static ConversationOutputTranscriptionDeltaUpdate ConversationOutputTranscriptionDeltaUpdate(string eventId = null, string responseId = null, string itemId = null, int outputIndex = default, int contentIndex = default, string delta = null)
         {
             return new ConversationOutputTranscriptionDeltaUpdate(

--- a/.dotnet/tests/RealtimeConversation/ConversationSmokeTests.cs
+++ b/.dotnet/tests/RealtimeConversation/ConversationSmokeTests.cs
@@ -167,4 +167,23 @@ public class ConversationSmokeTests : ConversationTestFixtureBase
         Assert.That(serializedNode["turn_detection"]?["type"]?.GetValue<string>(), Is.EqualTo("server_vad"));
         Assert.That(serializedNode["turn_detection"]?["threshold"]?.GetValue<float>(), Is.EqualTo(0.42f));
     }
+
+    [Test]
+    public void ResponseMessageDeserializationWorks()
+    {
+        BinaryData messageData = BinaryData.FromString("""
+            {
+              "type": "response.audio.done",
+              "event_id": "event_ADfTaUV1cgTmnyktUnglV",
+              "response_id": "resp_ADfTYGCIHtEs0ORkI5xXc",
+              "item_id": "item_ADfTYSDe9pItxY8yiXmOx",
+              "output_index": 0,
+              "content_index": 0
+            }
+            """);
+        ConversationUpdate update = ModelReaderWriter.Read<ConversationUpdate>(messageData);
+        BinaryData reserializedUpdate = ModelReaderWriter.Write(update);
+        JsonNode reserializedNode = JsonNode.Parse(reserializedUpdate);
+        Assert.That(reserializedNode["type"]?.GetValue<string>(), Is.EqualTo("response.audio.done"));
+    }
 }

--- a/.typespec/realtime/client.tsp
+++ b/.typespec/realtime/client.tsp
@@ -27,6 +27,7 @@ using OpenAI;
 
 @@clientName(RealtimeResponseAudioDeltaCommand.type, "Kind", "csharp");
 @@clientName(RealtimeResponseAudioDeltaCommand.type, "Kind", "csharp");
+@@clientName(RealtimeResponseAudioDoneCommand.type, "Kind", "csharp");
 @@clientName(RealtimeResponseAudioTranscriptDeltaCommand.type,
   "Kind",
   "csharp"


### PR DESCRIPTION
I missed one of derived types in the client renames from "Type" to "Kind" for public discriminators. This left `Type` duplicatively serialized for `response.audio.done` -- causes limited issues with convenience models but messes up protocol.

This just adds the missing rename, which fixes the generation issue.