### PR TITLE
Removing unused import and adding java emitter config

### DIFF
--- a/.typespec.azure/main.tsp
+++ b/.typespec.azure/main.tsp
@@ -1,5 +1,4 @@
 import "@typespec/http";
-import "@typespec/openapi3";
 import "@typespec/openapi";
 import "@typespec/versioning";
 

--- a/.typespec.azure/tspconfig.yaml
+++ b/.typespec.azure/tspconfig.yaml
@@ -24,5 +24,5 @@ options:
     generate-samples: false
     custom-types-subpackage: "implementation.models"
     # custom-types: "FunctionCallPreset,FileListResponse,OpenAIPageableListOfBatch"
-    customization-class: customization/src/main/java/OpenAICustomizations.java
+    # customization-class: customization/src/main/java/OpenAICustomizations.java
     flavor: azure

--- a/.typespec.azure/tspconfig.yaml
+++ b/.typespec.azure/tspconfig.yaml
@@ -15,3 +15,14 @@ options:
     new-project: false
     flavor: "unbranded"
     enable-internal-raw-data: true
+  "@azure-tools/typespec-java":
+    package-dir: "azure-ai-openai"
+    namespace: "com.azure.ai.openai"
+    # partial-update: true
+    enable-sync-stack: true
+    generate-tests: false
+    generate-samples: false
+    custom-types-subpackage: "implementation.models"
+    # custom-types: "FunctionCallPreset,FileListResponse,OpenAIPageableListOfBatch"
+    customization-class: customization/src/main/java/OpenAICustomizations.java
+    flavor: azure

--- a/.typespec/main.tsp
+++ b/.typespec/main.tsp
@@ -1,5 +1,4 @@
 import "@typespec/http";
-import "@typespec/openapi3";
 import "@typespec/openapi";
 
 import "./administration";


### PR DESCRIPTION
Changes introduced:

- Removing seemingly unused `@typespec/openapi3` import that causes code emission to fail while using the Java pipeline from the `azure-sdk-for-java`
- Adding a base configuration for the java emitter so we are able to iterate over once we have a clear migration path