### PR TITLE
/realtime: consistently mitigate codegen serialization issue with doubly-discriminated types

### DIFF
--- a/.dotnet/CHANGELOG.md
+++ b/.dotnet/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release History
 
+## 2.1.0-beta.3 (Unreleased)
+
+### Bugs fixed
+
+- `/realtime` (beta):
+  - Addressed serialization issues with `ConversationItem` creation of system and assistant messages
+  - Removed an extraneous `toolCallId` parameter from `ConversationItem.CreateSystemMessage()`
+
+### Other changes
+
+- `/realtime` (beta):
+  - Renamed `From*()` factory methods on `ConversationContentPart` to `Create*Part()`, aligning with other library types
+
 ## 2.1.0-beta.2 (2024-11-04)
 
 ### Features added

--- a/.dotnet/api/OpenAI.netstandard2.0.cs
+++ b/.dotnet/api/OpenAI.netstandard2.0.cs
@@ -2259,10 +2259,10 @@ namespace OpenAI.RealtimeConversation {
     public abstract class ConversationContentPart : IJsonModel<ConversationContentPart>, IPersistableModel<ConversationContentPart> {
         public string AudioTranscript { get; }
         public string Text { get; }
-        public static ConversationContentPart FromInputAudioTranscript(string transcript = null);
-        public static ConversationContentPart FromInputText(string text);
-        public static ConversationContentPart FromOutputAudioTranscript(string transcript = null);
-        public static ConversationContentPart FromOutputText(string text);
+        public static ConversationContentPart CreateInputAudioTranscriptPart(string transcript = null);
+        public static ConversationContentPart CreateInputTextPart(string text);
+        public static ConversationContentPart CreateOutputAudioTranscriptPart(string transcript = null);
+        public static ConversationContentPart CreateOutputTextPart(string text);
         public static implicit operator ConversationContentPart(string text);
         ConversationContentPart IJsonModel<ConversationContentPart>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<ConversationContentPart>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);
@@ -2395,7 +2395,7 @@ namespace OpenAI.RealtimeConversation {
         public static ConversationItem CreateAssistantMessage(IEnumerable<ConversationContentPart> contentItems);
         public static ConversationItem CreateFunctionCall(string name, string callId, string arguments);
         public static ConversationItem CreateFunctionCallOutput(string callId, string output);
-        public static ConversationItem CreateSystemMessage(string toolCallId, IEnumerable<ConversationContentPart> contentItems);
+        public static ConversationItem CreateSystemMessage(IEnumerable<ConversationContentPart> contentItems);
         public static ConversationItem CreateUserMessage(IEnumerable<ConversationContentPart> contentItems);
         ConversationItem IJsonModel<ConversationItem>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options);
         void IJsonModel<ConversationItem>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options);

--- a/.dotnet/src/Custom/RealtimeConversation/ConversationContentPart.cs
+++ b/.dotnet/src/Custom/RealtimeConversation/ConversationContentPart.cs
@@ -16,20 +16,20 @@ public partial class ConversationContentPart
         (this as InternalRealtimeRequestAudioContentPart)?.InternalTranscriptValue
         ?? (this as InternalRealtimeResponseAudioContentPart)?.InternalTranscriptValue;
 
-    public static ConversationContentPart FromInputText(string text)
+    public static ConversationContentPart CreateInputTextPart(string text)
         => new InternalRealtimeRequestTextContentPart(text);
 
-    public static ConversationContentPart FromInputAudioTranscript(string transcript = null)
+    public static ConversationContentPart CreateInputAudioTranscriptPart(string transcript = null)
         => new InternalRealtimeRequestAudioContentPart()
         {
             InternalTranscriptValue = transcript,
         };
 
-    public static ConversationContentPart FromOutputText(string text)
+    public static ConversationContentPart CreateOutputTextPart(string text)
         => new InternalRealtimeResponseTextContentPart(text);
 
-    public static ConversationContentPart FromOutputAudioTranscript(string transcript = null)
+    public static ConversationContentPart CreateOutputAudioTranscriptPart(string transcript = null)
         => new InternalRealtimeResponseAudioContentPart(transcript);
 
-    public static implicit operator ConversationContentPart(string text) => FromInputText(text);
+    public static implicit operator ConversationContentPart(string text) => CreateInputTextPart(text);
 }

--- a/.dotnet/src/Custom/RealtimeConversation/ConversationItem.cs
+++ b/.dotnet/src/Custom/RealtimeConversation/ConversationItem.cs
@@ -24,7 +24,7 @@ public partial class ConversationItem
         return new InternalRealtimeRequestUserMessageItem(contentItems);
     }
 
-    public static ConversationItem CreateSystemMessage(string toolCallId, IEnumerable<ConversationContentPart> contentItems)
+    public static ConversationItem CreateSystemMessage(IEnumerable<ConversationContentPart> contentItems)
     {
         return new InternalRealtimeRequestSystemMessageItem(contentItems);
     }

--- a/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestAssistantMessageItem.cs
+++ b/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestAssistantMessageItem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace OpenAI.RealtimeConversation;
 
@@ -12,4 +13,18 @@ internal partial class InternalRealtimeRequestAssistantMessageItem
 {
     [CodeGenMember("Content")]
     public IList<ConversationContentPart> Content { get; }
+
+    public InternalRealtimeRequestAssistantMessageItem(IEnumerable<ConversationContentPart> content)
+    {
+        Argument.AssertNotNull(content, nameof(content));
+
+        // CUSTOM: Add missing Type via doubly-discriminated hierarchy
+        Type = InternalRealtimeItemType.Message;
+        Role = ConversationMessageRole.Assistant;
+
+        // CUSTOM: Convert input_text to text
+        Content = content
+            .Select(item => item.Kind == ConversationContentPartKind.InputText ? ConversationContentPart.CreateOutputTextPart(item.Text) : item)
+            .ToList();
+    }
 }

--- a/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestAssistantMessageItem.cs
+++ b/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestAssistantMessageItem.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.ClientModel.Primitives;
-using System.Text.Json;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 

--- a/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestSystemMessageItem.cs
+++ b/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestSystemMessageItem.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace OpenAI.RealtimeConversation;
 

--- a/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestSystemMessageItem.cs
+++ b/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestSystemMessageItem.cs
@@ -9,4 +9,14 @@ internal partial class InternalRealtimeRequestSystemMessageItem
 {
     [CodeGenMember("Content")]
     public IList<ConversationContentPart> Content { get; }
+
+    public InternalRealtimeRequestSystemMessageItem(IEnumerable<ConversationContentPart> content)
+    {
+        Argument.AssertNotNull(content, nameof(content));
+
+        // CUSTOM: Add missing Type via doubly-discriminated hierarchy
+        Type = InternalRealtimeItemType.Message;
+        Role = ConversationMessageRole.System;
+        Content = content.ToList();
+    }
 }

--- a/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestUserMessageItem.cs
+++ b/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestUserMessageItem.cs
@@ -11,15 +11,16 @@ namespace OpenAI.RealtimeConversation;
 [CodeGenModel("RealtimeRequestUserMessageItem")]
 internal partial class InternalRealtimeRequestUserMessageItem
 {
+    [CodeGenMember("Content")]
+    public IList<ConversationContentPart> Content { get; }
+
     public InternalRealtimeRequestUserMessageItem(IEnumerable<ConversationContentPart> content)
     {
         Argument.AssertNotNull(content, nameof(content));
 
+        // CUSTOM: Add missing Type via doubly-discriminated hierarchy
         Type = InternalRealtimeItemType.Message;
         Role = ConversationMessageRole.User;
         Content = content.ToList();
     }
-
-    [CodeGenMember("Content")]
-    public IList<ConversationContentPart> Content { get; }
 }

--- a/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestUserMessageItem.cs
+++ b/.dotnet/src/Custom/RealtimeConversation/Internal/InternalRealtimeRequestUserMessageItem.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.ClientModel.Primitives;
-using System.Text.Json;
-using System.Linq;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace OpenAI.RealtimeConversation;
 

--- a/.dotnet/src/Generated/Models/InternalRealtimeRequestAssistantMessageItem.cs
+++ b/.dotnet/src/Generated/Models/InternalRealtimeRequestAssistantMessageItem.cs
@@ -10,14 +10,6 @@ namespace OpenAI.RealtimeConversation
 {
     internal partial class InternalRealtimeRequestAssistantMessageItem : InternalRealtimeRequestMessageItem
     {
-        public InternalRealtimeRequestAssistantMessageItem(IEnumerable<ConversationContentPart> content)
-        {
-            Argument.AssertNotNull(content, nameof(content));
-
-            Role = ConversationMessageRole.Assistant;
-            Content = content.ToList();
-        }
-
         internal InternalRealtimeRequestAssistantMessageItem(InternalRealtimeItemType type, string id, IDictionary<string, BinaryData> serializedAdditionalRawData, ConversationMessageRole role, ConversationItemStatus? status, IList<ConversationContentPart> content) : base(type, id, serializedAdditionalRawData, role, status)
         {
             Content = content;

--- a/.dotnet/src/Generated/Models/InternalRealtimeRequestSystemMessageItem.cs
+++ b/.dotnet/src/Generated/Models/InternalRealtimeRequestSystemMessageItem.cs
@@ -10,14 +10,6 @@ namespace OpenAI.RealtimeConversation
 {
     internal partial class InternalRealtimeRequestSystemMessageItem : InternalRealtimeRequestMessageItem
     {
-        public InternalRealtimeRequestSystemMessageItem(IEnumerable<ConversationContentPart> content)
-        {
-            Argument.AssertNotNull(content, nameof(content));
-
-            Role = ConversationMessageRole.System;
-            Content = content.ToList();
-        }
-
         internal InternalRealtimeRequestSystemMessageItem(InternalRealtimeItemType type, string id, IDictionary<string, BinaryData> serializedAdditionalRawData, ConversationMessageRole role, ConversationItemStatus? status, IList<ConversationContentPart> content) : base(type, id, serializedAdditionalRawData, role, status)
         {
             Content = content;


### PR DESCRIPTION
## Problem

`ConversationItem.CreateSystemMessage()` and `ConversationItem.CreateAssistantMessage()` don't work -- they serialize `null` to the `type` field and result in a validation error.

This occurs because the generated constructors for doubly-discriminated types don't propagate things properly.

For example:

```javascript
@discriminator("taxonomic_family")
model Animal {
  taxonomic_family: string;
}
@discriminator ("breed")
model Dog extends Animal {
  taxonomic_family: "canidae",
  breed: string;
}
model Labrador extends Dog {
  breed: "labrador"
}
```

In the above, the generated constructors for `Dog` will properly set `TaxonomicFamily` of the `Animal` base with the `"canidae"` value, but the generated constructors for `Labrador` will not set any automatic value to `TaxonomicFamily`.

Concretely here, `RealtimeRequestSystemMessageItem` extends `RealtimeRequestMessageItem`, which in turn extends `RealtimeRequestItem` -- in generated code, the inner discriminator of `role` is set, but the outer discriminator of `type` is left null.

This was missed until now because the more common user message had already been hand-customized to fix the problem. System and Assistant messages are used to contrive artificial conversation history and didn't have test coverage.

## Changes

- Incorrect constructors moved to `Custom` to address
- Added test to perform basic exercise of all items
- Incidental: removed unused, vestigial parameter from `CreateSystemMessage()`
- Incidental: added automatic conversion of `input_text` content parts into Assistant messages to `text`
- Incidental: renamed `ConversationContentPart` factory methods for consistency