### PR TITLE
`realtime` specific entry point + Java emitter config

### DIFF
--- a/.typespec/realtime/client.tsp
+++ b/.typespec/realtime/client.tsp
@@ -1,85 +1,24 @@
-import "@azure-tools/typespec-client-generator-core";
-import "./models.tsp";
+// import "./models.tsp";
+import "@typespec/http";
 
-using Azure.ClientGenerator.Core;
-using OpenAI;
+import "./main.tsp";
 
-@@clientName(RealtimeClientEvent.type, "Kind", "csharp");
-@@clientName(RealtimeClientEventSessionUpdate.type, "Kind", "csharp");
-@@clientName(RealtimeClientEventInputAudioBufferAppend.type, "Kind", "csharp");
-@@clientName(RealtimeClientEventInputAudioBufferCommit.type, "Kind", "csharp");
-@@clientName(RealtimeClientEventInputAudioBufferClear.type, "Kind", "csharp");
-@@clientName(RealtimeClientEventConversationItemCreate.type, "Kind", "csharp");
-@@clientName(RealtimeClientEventConversationItemTruncate.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeClientEventConversationItemDelete.type, "Kind", "csharp");
-@@clientName(RealtimeClientEventResponseCreate.type, "Kind", "csharp");
-@@clientName(RealtimeClientEventResponseCancel.type, "Kind", "csharp");
-@@clientName(RealtimeServerEvent.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventError.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventSessionCreated.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventSessionUpdated.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventConversationCreated.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventInputAudioBufferCommitted.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventInputAudioBufferCleared.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventInputAudioBufferSpeechStarted.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventInputAudioBufferSpeechStopped.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventConversationItemCreated.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventConversationItemInputAudioTranscriptionCompleted.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventConversationItemInputAudioTranscriptionFailed.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventConversationItemTruncated.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventConversationItemDeleted.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseCreated.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseDone.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseOutputItemAdded.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseOutputItemDone.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseContentPartAdded.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventResponseContentPartDone.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseTextDelta.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseTextDone.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseAudioTranscriptDelta.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventResponseAudioTranscriptDone.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventResponseAudioDelta.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseAudioDone.type, "Kind", "csharp");
-@@clientName(RealtimeServerEventResponseFunctionCallArgumentsDelta.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventResponseFunctionCallArgumentsDone.type,
-  "Kind",
-  "csharp"
-);
-@@clientName(RealtimeServerEventRateLimitsUpdated.type, "Kind", "csharp");
-@@clientName(RealtimeTurnDetection.type, "Kind", "csharp");
-@@clientName(RealtimeServerVadTurnDetection.type, "Kind", "csharp");
-@@clientName(RealtimeContentPart.type, "Kind", "csharp");
-@@clientName(RealtimeResponseStatusDetails.type, "Kind", "csharp");
+using TypeSpec.Http;
+
+/** The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details. */
+@service({
+  title: "OpenAI API",
+  termsOfService: "https://openai.com/policies/terms-of-use",
+  contact: {
+    name: "OpenAI Support",
+    url: "https://help.openai.com",
+  },
+  license: {
+    name: "MIT",
+    url: "https://github.com/openai/openai-openapi/blob/master/LICENSE",
+  },
+})
+@server("wss://api.openai.com/v1", "OpenAI Endpoint")
+@useAuth(BearerAuth)
+namespace OpenAI;
+

--- a/.typespec/realtime/custom.tsp
+++ b/.typespec/realtime/custom.tsp
@@ -2,7 +2,7 @@ import "./custom/events.tsp";
 import "./custom/items.tsp";
 import "./custom/tools.tsp";
 
-using TypeSpec.OpenAPI;
+// using TypeSpec.OpenAPI;
 
 namespace OpenAI;
 

--- a/.typespec/realtime/custom/content_parts.tsp
+++ b/.typespec/realtime/custom/content_parts.tsp
@@ -1,4 +1,4 @@
-using TypeSpec.OpenAPI;
+// using TypeSpec.OpenAPI;
 
 namespace OpenAI;
 

--- a/.typespec/realtime/custom/events.tsp
+++ b/.typespec/realtime/custom/events.tsp
@@ -1,4 +1,4 @@
-using TypeSpec.OpenAPI;
+// using TypeSpec.OpenAPI;
 
 namespace OpenAI;
 

--- a/.typespec/realtime/custom/items.tsp
+++ b/.typespec/realtime/custom/items.tsp
@@ -1,6 +1,6 @@
 import "./content_parts.tsp";
 
-using TypeSpec.OpenAPI;
+// using TypeSpec.OpenAPI;
 
 namespace OpenAI;
 

--- a/.typespec/realtime/custom/tools.tsp
+++ b/.typespec/realtime/custom/tools.tsp
@@ -1,4 +1,4 @@
-using TypeSpec.OpenAPI;
+// using TypeSpec.OpenAPI;
 
 namespace OpenAI;
 

--- a/.typespec/realtime/main.tsp
+++ b/.typespec/realtime/main.tsp
@@ -1,2 +1,88 @@
-import "./client.tsp";
+// import "./client.tsp";
 import "./operations.tsp";
+import "./models.tsp";
+
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+using OpenAI;
+
+@@clientName(RealtimeClientEvent.type, "Kind", "csharp");
+@@clientName(RealtimeClientEventSessionUpdate.type, "Kind", "csharp");
+@@clientName(RealtimeClientEventInputAudioBufferAppend.type, "Kind", "csharp");
+@@clientName(RealtimeClientEventInputAudioBufferCommit.type, "Kind", "csharp");
+@@clientName(RealtimeClientEventInputAudioBufferClear.type, "Kind", "csharp");
+@@clientName(RealtimeClientEventConversationItemCreate.type, "Kind", "csharp");
+@@clientName(RealtimeClientEventConversationItemTruncate.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeClientEventConversationItemDelete.type, "Kind", "csharp");
+@@clientName(RealtimeClientEventResponseCreate.type, "Kind", "csharp");
+@@clientName(RealtimeClientEventResponseCancel.type, "Kind", "csharp");
+@@clientName(RealtimeServerEvent.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventError.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventSessionCreated.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventSessionUpdated.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventConversationCreated.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventInputAudioBufferCommitted.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventInputAudioBufferCleared.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventInputAudioBufferSpeechStarted.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventInputAudioBufferSpeechStopped.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventConversationItemCreated.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventConversationItemInputAudioTranscriptionCompleted.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventConversationItemInputAudioTranscriptionFailed.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventConversationItemTruncated.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventConversationItemDeleted.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseCreated.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseDone.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseOutputItemAdded.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseOutputItemDone.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseContentPartAdded.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventResponseContentPartDone.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseTextDelta.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseTextDone.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseAudioTranscriptDelta.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventResponseAudioTranscriptDone.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventResponseAudioDelta.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseAudioDone.type, "Kind", "csharp");
+@@clientName(RealtimeServerEventResponseFunctionCallArgumentsDelta.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventResponseFunctionCallArgumentsDone.type,
+  "Kind",
+  "csharp"
+);
+@@clientName(RealtimeServerEventRateLimitsUpdated.type, "Kind", "csharp");
+@@clientName(RealtimeTurnDetection.type, "Kind", "csharp");
+@@clientName(RealtimeServerVadTurnDetection.type, "Kind", "csharp");
+@@clientName(RealtimeContentPart.type, "Kind", "csharp");
+@@clientName(RealtimeResponseStatusDetails.type, "Kind", "csharp");

--- a/.typespec/realtime/models.tsp
+++ b/.typespec/realtime/models.tsp
@@ -5,7 +5,7 @@
 
 import "./custom.tsp";
 
-using TypeSpec.OpenAPI;
+// using TypeSpec.OpenAPI;
 
 namespace OpenAI;
 

--- a/.typespec/realtime/operations.tsp
+++ b/.typespec/realtime/operations.tsp
@@ -1,7 +1,7 @@
 import "./models.tsp";
 
 using TypeSpec.Http;
-using TypeSpec.OpenAPI;
+// using TypeSpec.OpenAPI;
 
 namespace OpenAI;
 

--- a/.typespec/realtime/tspconfig.yaml
+++ b/.typespec/realtime/tspconfig.yaml
@@ -1,0 +1,11 @@
+options:  
+  "@azure-tools/typespec-java":
+    package-dir: "azure-ai-openai-realtime"
+    namespace: "com.azure.ai.openai.realtime"
+    partial-update: true
+    enable-sync-stack: true
+    generate-tests: false
+    generate-samples: false
+    custom-types-subpackage: "implementation.models"
+    # custom-types: "FileListResponse,OpenAIPageableListOfAssistant,OpenAIPageableListOfRunStep,OpenAIPageableListOfThreadMessage,OpenAIPageableListOfThreadRun,OpenAIPageableListOfVectorStore,OpenAIPageableListOfVectorStoreFile"
+    flavor: azure


### PR DESCRIPTION
## What's this?

A custom entry point to allow code gen for `realtime` specifically by having a `tsp-location.yaml` that looks like this:

```yaml
directory: .typespec/realtime
commit: <commit-id>
repo: joseharriaga/openai-in-typespec
```

The steps taken:

- copy `@service` to realtime/client.tsp
- in `realtime/main.tsp` remove import to `./client.tsp`
- try generating java from location `directory: .typespec/realtime/` (this should pick up the right service)

By doing this, we exclude the `@service` in `realtime/client.tsp` for a normal codegen. If we target the `realtime` folder directly, code gen is bootstrapped from the `client.tsp` and generates from the said service.

## Remaining TODOs

- Confirm that the other emitters using this spec behave the same
- Better extraction of what was originally in `.typespec/realtime/client.tsp`. Now it's all dumped in main.