### PR TITLE
Realtime: complete port of fixes and tests for sendinputaudio behavior

### DIFF
--- a/.dotnet/src/Custom/RealtimeConversation/RealtimeConversationSession.cs
+++ b/.dotnet/src/Custom/RealtimeConversation/RealtimeConversationSession.cs
@@ -20,8 +20,8 @@ public partial class RealtimeConversationSession : IDisposable
     private readonly RealtimeConversationClient _parentClient;
     private readonly Uri _endpoint;
     private readonly ApiKeyCredential _credential;
-    private readonly object _sendingAudioLock = new();
-    private bool _isSendingAudio = false;
+    private readonly SemaphoreSlim _audioSendSemaphore = new(1, 1);
+    private bool _isSendingAudioStream = false;
 
     internal bool ShouldBufferTurnResponseData { get; set; }
 
@@ -47,13 +47,13 @@ public partial class RealtimeConversationSession : IDisposable
     public virtual async Task SendInputAudioAsync(Stream audio, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
-        lock (_sendingAudioLock)
+        using (await _audioSendSemaphore.AutoReleaseWaitAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (_isSendingAudio)
+            if (_isSendingAudioStream)
             {
                 throw new InvalidOperationException($"Only one stream of audio may be sent at once.");
             }
-            _isSendingAudio = true;
+            _isSendingAudioStream = true;
         }
         try
         {
@@ -75,9 +75,9 @@ public partial class RealtimeConversationSession : IDisposable
         }
         finally
         {
-            lock (_sendingAudioLock)
+            using (await _audioSendSemaphore.AutoReleaseWaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                _isSendingAudio = false;
+                _isSendingAudioStream = false;
             }
         }
     }
@@ -85,13 +85,13 @@ public partial class RealtimeConversationSession : IDisposable
     public virtual void SendInputAudio(Stream audio, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
-        lock (_sendingAudioLock)
+        using (_audioSendSemaphore.AutoReleaseWait(cancellationToken))
         {
-            if (_isSendingAudio)
+            if (_isSendingAudioStream)
             {
                 throw new InvalidOperationException($"Only one stream of audio may be sent at once.");
             }
-            _isSendingAudio = true;
+            _isSendingAudioStream = true;
         }
         try
         {
@@ -113,9 +113,9 @@ public partial class RealtimeConversationSession : IDisposable
         }
         finally
         {
-            lock (_sendingAudioLock)
+            using (_audioSendSemaphore.AutoReleaseWait(cancellationToken))
             {
-                _isSendingAudio = false;
+                _isSendingAudioStream = false;
             }
         }
     }
@@ -130,18 +130,17 @@ public partial class RealtimeConversationSession : IDisposable
     public virtual async Task SendInputAudioAsync(BinaryData audio, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
-        lock (_sendingAudioLock)
+        using (await _audioSendSemaphore.AutoReleaseWaitAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (_isSendingAudio)
+            if (_isSendingAudioStream)
             {
                 throw new InvalidOperationException($"Cannot send a standalone audio chunk while a stream is already in progress.");
             }
-            _isSendingAudio = true;
+            // TODO: consider automatically limiting/breaking size of chunk (as with streaming)
+            InternalRealtimeClientEventInputAudioBufferAppend internalCommand = new(audio);
+            BinaryData requestData = ModelReaderWriter.Write(internalCommand);
+            await SendCommandAsync(requestData, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
         }
-        // TODO: consider automatically limiting/breaking size of chunk (as with streaming)
-        InternalRealtimeClientEventInputAudioBufferAppend internalCommand = new(audio);
-        BinaryData requestData = ModelReaderWriter.Write(internalCommand);
-        await SendCommandAsync(requestData, cancellationToken.ToRequestOptions()).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -154,18 +153,17 @@ public partial class RealtimeConversationSession : IDisposable
     public virtual void SendInputAudio(BinaryData audio, CancellationToken cancellationToken = default)
     {
         Argument.AssertNotNull(audio, nameof(audio));
-        lock (_sendingAudioLock)
+        using (_audioSendSemaphore.AutoReleaseWait(cancellationToken))
         {
-            if (_isSendingAudio)
+            if (_isSendingAudioStream)
             {
                 throw new InvalidOperationException($"Cannot send a standalone audio chunk while a stream is already in progress.");
             }
-            _isSendingAudio = true;
+            // TODO: consider automatically limiting/breaking size of chunk (as with streaming)
+            InternalRealtimeClientEventInputAudioBufferAppend internalCommand = new(audio);
+            BinaryData requestData = ModelReaderWriter.Write(internalCommand);
+            SendCommand(requestData, cancellationToken.ToRequestOptions());
         }
-        // TODO: consider automatically limiting/breaking size of chunk (as with streaming)
-        InternalRealtimeClientEventInputAudioBufferAppend internalCommand = new(audio);
-        BinaryData requestData = ModelReaderWriter.Write(internalCommand);
-        SendCommand(requestData, cancellationToken.ToRequestOptions());
     }
 
     public virtual async Task ClearInputAudioAsync(CancellationToken cancellationToken = default)

--- a/.dotnet/src/Utility/SemaphoreSlimExtensions.cs
+++ b/.dotnet/src/Utility/SemaphoreSlimExtensions.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Diagnostics.Contracts;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenAI;
+
+internal static class SemaphoreSlimExtensions
+{
+    public static async Task<IDisposable> AutoReleaseWaitAsync(
+        this SemaphoreSlim semaphore,
+        CancellationToken cancellationToken = default)
+    {
+        Contract.Requires(semaphore != null);
+        var wrapper = new ReleaseableSemaphoreSlimWrapper(semaphore);
+        await semaphore.WaitAsync(cancellationToken);
+        return wrapper;
+    }
+
+    public static IDisposable AutoReleaseWait(
+        this SemaphoreSlim semaphore,
+        CancellationToken cancellationToken = default)
+    {
+        Contract.Requires(semaphore != null);
+        var wrapper = new ReleaseableSemaphoreSlimWrapper(semaphore);
+        semaphore.Wait(cancellationToken);
+        return wrapper;
+    }
+
+    private class ReleaseableSemaphoreSlimWrapper
+        : IDisposable
+    {
+        private readonly SemaphoreSlim semaphore;
+        private bool alreadyDisposed = false;
+
+        public ReleaseableSemaphoreSlimWrapper(SemaphoreSlim semaphore)
+            => this.semaphore = semaphore;
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool disposeActuallyCalled)
+        {
+            if (!this.alreadyDisposed)
+            {
+                if (disposeActuallyCalled)
+                {
+                    this.semaphore?.Release();
+                }
+
+                this.alreadyDisposed = true;
+            }
+        }
+    }
+}

--- a/.scripts/Run-Checks.ps1
+++ b/.scripts/Run-Checks.ps1
@@ -102,7 +102,8 @@ function Run-TopLevelNamespaceCheck {
         "MultipartFormDataBinaryContent.cs",
         "PageCollectionHelpers.cs",
         "PageEnumerator.cs",
-        "PageResultEnumerator.cs"
+        "PageResultEnumerator.cs",
+        "SemaphoreSlimExtensions.cs"
     )
 
     $failures = @()


### PR DESCRIPTION
The changes in #303 were incompletely migrated into #301. This PR completes the functional migration and remedies the remaining bug with `SendInputAudioAsync(BinaryData)`.

Most importantly: the boolean sentinel for audio sending is only set and reset when sending a stream, while single-payload sends are fully locked.

This is more efficiently and elegantly accomplished via a `SemaphoreSlim` (with a wrapping pair of extension methods to simplify the try/finally patterns).

Test coverage that validates intended behavior was also ported.

