### PR TITLE
Infra: Powershell updates for retries

### DIFF
--- a/.scripts/Edit-Deserialization.ps1
+++ b/.scripts/Edit-Deserialization.ps1
@@ -11,7 +11,7 @@ foreach ($file in $files) {
     $statusText = "{0:D3}/{1:D3} : Processing codegen fixup for response deserialization..." -f $editedFilesCount, $files.Count
     $percentComplete = [math]::Round(($editedFilesCount / $files.Count) * 100)
     Write-Progress -Activity "Editing" -Status $statusText -PercentComplete $percentComplete
-    Update-In-File-With-Lock-And-Retry `
+    Update-In-File-With-Retry `
         -FilePath $file.FullName `
         -SearchPattern "options.Format != `"W`"" `
         -ReplacePattern "true"

--- a/.scripts/Edit-Deserialization.ps1
+++ b/.scripts/Edit-Deserialization.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\Helpers.ps1
+
 $repoRoot = Join-Path $PSScriptRoot .. -Resolve
 $generatedModelFolder = Join-Path $repoRoot .dotnet\src\Generated\Models
 
@@ -9,11 +11,10 @@ foreach ($file in $files) {
     $statusText = "{0:D3}/{1:D3} : Processing codegen fixup for response deserialization..." -f $editedFilesCount, $files.Count
     $percentComplete = [math]::Round(($editedFilesCount / $files.Count) * 100)
     Write-Progress -Activity "Editing" -Status $statusText -PercentComplete $percentComplete
-    $content = Get-Content -Path $file.FullName
-    $updatedContent = $content -replace "options.Format != `"W`"", "true"
-    if ($content -ne $updatedContent) {
-        Set-Content -Path $file.FullName -Value $updatedContent
-    }
+    Update-In-File-With-Lock-And-Retry `
+        -FilePath $file.FullName `
+        -SearchPattern "options.Format != `"W`"" `
+        -ReplacePattern "true"
     $editedFilesCount++
 }
 

--- a/.scripts/Edit-Serialization.ps1
+++ b/.scripts/Edit-Serialization.ps1
@@ -3,7 +3,7 @@
 $root = Split-Path $PSScriptRoot -Parent
 $directory = Join-Path -Path $root -ChildPath ".dotnet\src\Generated\Models"
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\InternalChatCompletionResponseMessage.Serialization.cs" `
     -SearchPatternLines @(
         "return new InternalChatCompletionResponseMessage\("
@@ -27,7 +27,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\InternalChatCompletionStreamResponseDelta.Serialization.cs" `
     -SearchPatternLines @(
         "if \(Optional\.IsDefined\(Content\) && _additionalBinaryDataProperties\?\.ContainsKey\(`"content`"\) != true\)"
@@ -39,7 +39,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\InternalChatCompletionStreamResponseDelta.Serialization.cs" `
     -SearchPatternLines @(
         "return new InternalChatCompletionStreamResponseDelta\("
@@ -63,7 +63,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\ChatMessage.Serialization.cs" `
     -SearchPatternLines @(
         "if \(true && Optional\.IsDefined\(Content\) && _additionalBinaryDataProperties\?\.ContainsKey\(`"content`"\) != true\)"
@@ -75,7 +75,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\AssistantChatMessage.Serialization.cs" `
     -SearchPatternLines @(
         "return new AssistantChatMessage\("
@@ -101,7 +101,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\FunctionChatMessage.Serialization.cs" `
     -SearchPatternLines @(
         "return new FunctionChatMessage\(role, content, additionalBinaryDataProperties, functionName\);"
@@ -113,7 +113,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\SystemChatMessage.Serialization.cs" `
     -SearchPatternLines @(
         "return new SystemChatMessage\(role, content, additionalBinaryDataProperties, participantName\);"
@@ -125,7 +125,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\ToolChatMessage.Serialization.cs" `
     -SearchPatternLines @(
         "return new ToolChatMessage\(role, content, additionalBinaryDataProperties, toolCallId\);"
@@ -137,7 +137,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\UserChatMessage.Serialization.cs" `
     -SearchPatternLines @(
         "return new UserChatMessage\(role, content, additionalBinaryDataProperties, participantName\);"
@@ -149,7 +149,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\InternalUnknownChatMessage.Serialization.cs" `
     -SearchPatternLines @(
         "return new InternalUnknownChatMessage\(role, content, additionalBinaryDataProperties\);"
@@ -161,7 +161,7 @@ Update-In-File-With-Lock-And-Retry `
     -OutputIndentation 12 `
     -RequirePresence
 
-Update-In-File-With-Lock-And-Retry `
+Update-In-File-With-Retry `
     -FilePath "$directory\InternalFineTuneChatCompletionRequestAssistantMessage.Serialization.cs" `
     -SearchPatternLines @(
         "return new InternalFineTuneChatCompletionRequestAssistantMessage\("

--- a/.scripts/Edit-Serialization.ps1
+++ b/.scripts/Edit-Serialization.ps1
@@ -1,42 +1,11 @@
-function Edit-Serialization {
-    param(
-        [string] $Filename,
-        [string[]] $InputRegex,
-        [string[]] $OutputString,
-        [int] $OutputIndentation
-    )
-    $root = Split-Path $PSScriptRoot -Parent
-    $directory = Join-Path -Path $root -ChildPath ".dotnet\src\Generated\Models"
-    $file = Get-ChildItem -Path $directory -Filter $Filename
-    $content = Get-Content -Path $file -Raw
+. $PSScriptRoot\Helpers.ps1
 
-    Write-Output "Editing $($file.FullName)"
+$root = Split-Path $PSScriptRoot -Parent
+$directory = Join-Path -Path $root -ChildPath ".dotnet\src\Generated\Models"
 
-    $regex = "(?s)"
-    foreach ($line in $InputRegex) { $regex += "\s+" + $line }
-
-    if ($content -cnotmatch $regex)
-    {
-        throw "The code does not match the expected pattern. If this is by design, please update or disable this edit."
-    }
-    else
-    {
-        $output = ""
-        foreach ($line in $OutputString) { $output += "`r`n" + $line.PadLeft($line.Length + $OutputIndentation) }
-
-        $content = $content -creplace $regex, $output
-        $content | Set-Content -Path $file.FullName -NoNewline
-    }
-}
-
-function Edit-InternalChatCompletionResponseMessageSerialization {
-    $filename = "InternalChatCompletionResponseMessage.Serialization.cs"
-
-    # content serialization
-    # no-op
-
-    # content deserialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\InternalChatCompletionResponseMessage.Serialization.cs" `
+    -SearchPatternLines @(
         "return new InternalChatCompletionResponseMessage\("
         "    refusal,"
         "    toolCalls \?\? new ChangeTrackingList<ChatToolCall>\(\),"
@@ -44,8 +13,8 @@ function Edit-InternalChatCompletionResponseMessageSerialization {
         "    content,"
         "    functionCall,"
         "    additionalBinaryDataProperties\);"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Initialize Content collection property."
         "return new InternalChatCompletionResponseMessage("
         "    refusal,"
@@ -54,25 +23,25 @@ function Edit-InternalChatCompletionResponseMessageSerialization {
         "    content ?? new ChatMessageContent(),"
         "    functionCall,"
         "    additionalBinaryDataProperties);"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
-}
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-function Edit-InternalChatCompletionStreamResponseDeltaSerialization {
-    $filename = "InternalChatCompletionStreamResponseDelta.Serialization.cs"
-
-    # content serialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\InternalChatCompletionStreamResponseDelta.Serialization.cs" `
+    -SearchPatternLines @(
         "if \(Optional\.IsDefined\(Content\) && _additionalBinaryDataProperties\?\.ContainsKey\(`"content`"\) != true\)"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Check inner collection is defined."
         "if (Optional.IsDefined(Content) && _additionalBinaryDataProperties?.ContainsKey(`"content`") != true && Content.IsInnerCollectionDefined())"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-    # content deserialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\InternalChatCompletionStreamResponseDelta.Serialization.cs" `
+    -SearchPatternLines @(
         "return new InternalChatCompletionStreamResponseDelta\("
         "    functionCall,"
         "    toolCalls \?\? new ChangeTrackingList<StreamingChatToolCallUpdate>\(\),"
@@ -80,8 +49,8 @@ function Edit-InternalChatCompletionStreamResponseDeltaSerialization {
         "    role,"
         "    content,"
         "    additionalBinaryDataProperties\);"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Initialize Content collection property."
         "return new InternalChatCompletionStreamResponseDelta("
         "    functionCall,"
@@ -90,36 +59,25 @@ function Edit-InternalChatCompletionStreamResponseDeltaSerialization {
         "    role,"
         "    content ?? new ChatMessageContent(),"
         "    additionalBinaryDataProperties);"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
-}
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-function Edit-ChatMessageSerialization {
-    $filename = "ChatMessage.Serialization.cs"
-
-    # content serialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\ChatMessage.Serialization.cs" `
+    -SearchPatternLines @(
         "if \(true && Optional\.IsDefined\(Content\) && _additionalBinaryDataProperties\?\.ContainsKey\(`"content`"\) != true\)"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Check inner collection is defined."
         "if (true && Optional.IsDefined(Content) && Content.IsInnerCollectionDefined() && _additionalBinaryDataProperties?.ContainsKey(`"content`") != true)"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-    # content deserialization
-    # no-op
-}
-
-
-function Edit-AssistantChatMessageSerialization {
-    $filename = "AssistantChatMessage.Serialization.cs"
-
-    # content serialization
-    # no-op
-
-    # content deserialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\AssistantChatMessage.Serialization.cs" `
+    -SearchPatternLines @(
         "return new AssistantChatMessage\("
         "    role,"
         "    content,"
@@ -128,8 +86,8 @@ function Edit-AssistantChatMessageSerialization {
         "    participantName,"
         "    toolCalls \?\? new ChangeTrackingList<ChatToolCall>\(\),"
         "    functionCall\);"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Initialize Content collection property."
         "return new AssistantChatMessage("
         "    role,"
@@ -139,103 +97,73 @@ function Edit-AssistantChatMessageSerialization {
         "    participantName,"
         "    toolCalls ?? new ChangeTrackingList<ChatToolCall>(),"
         "    functionCall);"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
-}
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-function Edit-FunctionChatMessageSerialization {
-    $filename = "FunctionChatMessage.Serialization.cs"
-
-    # content serialization
-    # no-op
-
-    # content deserialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\FunctionChatMessage.Serialization.cs" `
+    -SearchPatternLines @(
         "return new FunctionChatMessage\(role, content, additionalBinaryDataProperties, functionName\);"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Initialize Content collection property."
         "return new FunctionChatMessage(role, content ?? new ChatMessageContent(), additionalBinaryDataProperties, functionName);"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
-}
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-function Edit-SystemChatMessageSerialization {
-    $filename = "SystemChatMessage.Serialization.cs"
-
-    # content serialization
-    # no-op
-
-    # content deserialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\SystemChatMessage.Serialization.cs" `
+    -SearchPatternLines @(
         "return new SystemChatMessage\(role, content, additionalBinaryDataProperties, participantName\);"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Initialize Content collection property."
         "return new SystemChatMessage(role, content ?? new ChatMessageContent(), additionalBinaryDataProperties, participantName);"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
-}
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-function Edit-ToolChatMessageSerialization {
-    $filename = "ToolChatMessage.Serialization.cs"
-
-    # content serialization
-    # no-op
-
-    # content deserialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\ToolChatMessage.Serialization.cs" `
+    -SearchPatternLines @(
         "return new ToolChatMessage\(role, content, additionalBinaryDataProperties, toolCallId\);"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Initialize Content collection property."
         "return new ToolChatMessage(role, content ?? new ChatMessageContent(), additionalBinaryDataProperties, toolCallId);"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
-}
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-function Edit-UserChatMessageSerialization {
-    $filename = "UserChatMessage.Serialization.cs"
-
-    # content serialization
-    # no-op
-
-    # content deserialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\UserChatMessage.Serialization.cs" `
+    -SearchPatternLines @(
         "return new UserChatMessage\(role, content, additionalBinaryDataProperties, participantName\);"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Initialize Content collection property."
         "return new UserChatMessage(role, content ?? new ChatMessageContent(), additionalBinaryDataProperties, participantName);"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
-}
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-function Edit-InternalUnknownChatMessageSerialization {
-    $filename = "InternalUnknownChatMessage.Serialization.cs"
-
-    # content serialization
-    # no-op
-
-    # content deserialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\InternalUnknownChatMessage.Serialization.cs" `
+    -SearchPatternLines @(
         "return new InternalUnknownChatMessage\(role, content, additionalBinaryDataProperties\);"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Initialize Content collection property."
         "return new InternalUnknownChatMessage(role, content ?? new ChatMessageContent(), additionalBinaryDataProperties);"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
-}
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence
 
-function Edit-InternalFineTuneChatCompletionRequestAssistantMessageSerialization {
-    $filename = "InternalFineTuneChatCompletionRequestAssistantMessage.Serialization.cs"
-
-    # content serialization
-    # no-op
-
-    # content deserialization
-    $inputRegex = @(
+Update-In-File-With-Lock-And-Retry `
+    -FilePath "$directory\InternalFineTuneChatCompletionRequestAssistantMessage.Serialization.cs" `
+    -SearchPatternLines @(
         "return new InternalFineTuneChatCompletionRequestAssistantMessage\("
         "    role,"
         "    content,"
@@ -244,8 +172,8 @@ function Edit-InternalFineTuneChatCompletionRequestAssistantMessageSerialization
         "    participantName,"
         "    toolCalls \?\? new ChangeTrackingList<ChatToolCall>\(\),"
         "    functionCall\);"
-    )
-    $outputString = @(
+    ) `
+    -ReplacePatternLines @(
         "// CUSTOM: Initialize Content collection property."
         "return new InternalFineTuneChatCompletionRequestAssistantMessage("
         "    role,"
@@ -255,17 +183,6 @@ function Edit-InternalFineTuneChatCompletionRequestAssistantMessageSerialization
         "    participantName,"
         "    toolCalls ?? new ChangeTrackingList<ChatToolCall>(),"
         "    functionCall);"
-    )
-    Edit-Serialization -Filename $filename -InputRegex $inputRegex -OutputString $outputString -OutputIndentation 12
-}
-
-Edit-InternalChatCompletionResponseMessageSerialization
-Edit-InternalChatCompletionStreamResponseDeltaSerialization
-Edit-ChatMessageSerialization
-Edit-AssistantChatMessageSerialization
-Edit-FunctionChatMessageSerialization
-Edit-SystemChatMessageSerialization
-Edit-ToolChatMessageSerialization
-Edit-UserChatMessageSerialization
-Edit-InternalUnknownChatMessageSerialization
-Edit-InternalFineTuneChatCompletionRequestAssistantMessageSerialization
+    ) `
+    -OutputIndentation 12 `
+    -RequirePresence

--- a/.scripts/Helpers.ps1
+++ b/.scripts/Helpers.ps1
@@ -1,0 +1,67 @@
+function Update-In-File-With-Lock-And-Retry {
+    param(
+        [string]$filePath,
+        [string]$searchPattern,
+        [string[]]$searchPatternLines,
+        [string]$replacePattern,
+        [string[]]$replacePatternLines,
+        [switch]$RequirePresence,
+        [int]$outputIndentation = 0,
+        [int]$maxRetries = 5,
+        [int]$delayMilliseconds = 200
+    )
+
+    $indent = (" " * $outputIndentation)
+
+    if ($searchPatternLines) {
+        $searchPattern = "(?s)"
+        foreach ($line in $searchPatternLines) { $searchPattern += "\s+" + $line }
+    }
+
+    if ($replacePatternLines) {
+        $replacePattern = ""
+        foreach ($line in $replacePatternLines) { $replacePattern += "`n" + $indent + $line }
+    }
+
+    $retryCount = 0
+    $success = $false
+
+    while (-not $success -and $retryCount -lt $maxRetries) {
+        try {
+            $fileStream = [System.IO.File]::Open($filePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)
+            try {
+                $reader = New-Object System.IO.StreamReader($fileStream)
+                $content = $reader.ReadToEnd()
+                $reader.Close()
+                $updatedContent = $content -replace $searchPattern, $replacePattern
+                if ($content -ne $updatedContent) {
+                    $fileStream.Close()  # Close the read stream before writing
+                    $writerStream = [System.IO.File]::Open($filePath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+                    $writer = New-Object System.IO.StreamWriter($writerStream)
+                    $writer.Write($updatedContent)
+                    $writer.Flush()  # Ensure all data is written to the file
+                    $writer.Close()
+                    $success = $true
+                }
+                elseif ($requirePresence) {
+                    $retryCount = $maxRetries
+                    throw "Failed to find pattern '$searchPattern' in file '$filePath'."
+                }
+                else {
+                    $success = $true
+                }
+            } finally {
+                $fileStream.Close()
+            }
+        } catch {
+            $exceptionMessage = $_.Exception.Message
+            Write-Host "Retrying for error: $exceptionMessage"
+            Start-Sleep -Milliseconds $delayMilliseconds
+            $retryCount++
+        }
+    }
+
+    if (-not $success) {
+        throw "Failed to replace content in file '$filePath' after $maxRetries attempts."
+    }
+}

--- a/.scripts/Remove-Abstract.ps1
+++ b/.scripts/Remove-Abstract.ps1
@@ -1,3 +1,5 @@
+. $PSScriptRoot\Helpers.ps1
+
 $repoRoot = Join-Path $PSScriptRoot .. -Resolve
 $generatedModelFolder = Join-Path $repoRoot .dotnet\src\Generated\Models
 
@@ -10,10 +12,9 @@ $targetFilenames = (
 
 foreach ($targetFilename in $targetFilenames) {
     $filePath = Join-Path $generatedModelFolder $targetFilename -Resolve
-    $content = Get-Content -Path $filePath
-    $updatedContent = $content -replace "public abstract", "public"
-    if ($content -ne $updatedContent) {
-        Write-Output "Removing abstract class modifier from file: $targetFilename"
-        Set-Content -Path $filePath -Value $updatedContent
-    }
+    Update-In-File-With-Lock-And-Retry `
+        -FilePath $filePath `
+        -SearchPattern "public abstract" `
+        -ReplacePattern "public" `
+        -RequirePresence
 }

--- a/.scripts/Remove-Abstract.ps1
+++ b/.scripts/Remove-Abstract.ps1
@@ -12,7 +12,7 @@ $targetFilenames = (
 
 foreach ($targetFilename in $targetFilenames) {
     $filePath = Join-Path $generatedModelFolder $targetFilename -Resolve
-    Update-In-File-With-Lock-And-Retry `
+    Update-In-File-With-Retry `
         -FilePath $filePath `
         -SearchPattern "public abstract" `
         -ReplacePattern "public" `

--- a/.scripts/Run-Checks.ps1
+++ b/.scripts/Run-Checks.ps1
@@ -103,7 +103,7 @@ function Run-TopLevelNamespaceCheck {
         "CodeGenTypeAttribute.cs",
         "CustomSerializationHelpers.cs",
         "GenericActionPipelinePolicy.cs",
-        "MultipartFormDataBinaryContent.cs",
+        "MultiPartFormDataBinaryContent.cs",
         "PageCollectionHelpers.cs",
         "PageEnumerator.cs",
         "PageResultEnumerator.cs",

--- a/.scripts/Update-ClientModel.ps1
+++ b/.scripts/Update-ClientModel.ps1
@@ -1,31 +1,13 @@
+. $PSScriptRoot\Helpers.ps1
+
 function Remove-MultipartFormDataBinaryContent {
     $root = Split-Path $PSScriptRoot -Parent
-    $filePath = Join-Path -Path $root -ChildPath ".dotnet\src\Generated\Internal\MultipartFormDataBinaryContent.cs"
+    $filePath = Join-Path -Path $root -ChildPath ".dotnet\src\Generated\Internal\MultiPartFormDataBinaryContent.cs"
     $file = Get-ChildItem -Path $filePath
 
     Write-Output "Removing $($file.FullName)"
 
     Remove-Item $file
-}
-
-function Remove-ObsoleteAttribute {
-    $root = Split-Path $PSScriptRoot -Parent
-    $directory = Join-Path -Path $root -ChildPath ".dotnet\src\Generated\Models"
-
-    $targets = @(
-        "ChatFunction.cs",
-        "FunctionChatMessage.cs")
-        
-    foreach ($target in $targets) {
-        $file = Get-ChildItem -Path $directory -Filter $target
-        $content = Get-Content -Path $file -Raw
-
-        Write-Output "Editing $($file.FullName)"
-
-        $content = $content -creplace "\s+\[Obsolete\((`")+(.*)(`")+\)\]", ""
-
-        $content | Set-Content -Path $file.FullName -NoNewline
-    }
 }
 
 function Remove-ChatMessageContentSerialization {
@@ -39,5 +21,4 @@ function Remove-ChatMessageContentSerialization {
 }
 
 Remove-MultipartFormDataBinaryContent
-Remove-ObsoleteAttribute
 Remove-ChatMessageContentSerialization


### PR DESCRIPTION
Currently, PS calls to read from and write to files are brittle and will frequently fail if they're under rapid access while running -- which is, unfortunately, very common if you have an editor/IDE open right as CodeGen just spit out hundreds of things to index.

This adds a (largely Copilot-authored) helper function that attempts to retry in the event of a failure. It's parameterized to handle all the string replacements we currently do.

The end result shows up as the retries avoiding a failure (that would in turn typically require you to "start over" and often disruptively lose a full minute on your inner dev loop):

```
>  .$PSScriptRoot\Edit-Deserialization.ps1

Retrying for error: Exception calling "Open" with "4" argument(s): "The process cannot access the file 'C:\s\joseharriaga-openai-in-typespec\.dotnet\src\Generated\Models\AssistantChatMessage.Serialization.cs' because it is being used by another process."
Retrying for error: Exception calling "Open" with "4" argument(s): "The process cannot access the file 'C:\s\joseharriaga-openai-in-typespec\.dotnet\src\Generated\Models\ChatTokenTopLogProbabilityDetails.Serialization.cs' because it is being used by another process."
Complete: deserialization edited.
```

I'd frequently been closing VS/VSCode every time I ran invoke-codegen to avoid this problem; addressing it this way is smarter.