### PR TITLE
Address lingering deviation in null content serialization for deprecated FunctionChatMessage

### DIFF
--- a/.dotnet/src/Custom/Chat/Messages/FunctionChatMessage.cs
+++ b/.dotnet/src/Custom/Chat/Messages/FunctionChatMessage.cs
@@ -30,6 +30,13 @@ public partial class FunctionChatMessage : ChatMessage
         Argument.AssertNotNull(functionName, nameof(functionName));
 
         FunctionName = functionName;
+
+        // FunctionChatMessage treats content as *required* but explicitly *nullable*. If null content was provided,
+        // enforce manifestation of the (nullable) content collection via .Clear().
+        if (!Content.IsInnerCollectionDefined())
+        {
+            Content.Clear();
+        }
     }
 
     // CUSTOM: Renamed.


### PR DESCRIPTION
The recent spec update pull request:
#334 

Inadvertently fixed a bug whereby `ChatMessage` content collections (`ChatMessageContent`) were always initialized with concrete inner collections and thus could never be treated as optional. Specifically quirked behavior in `AssistantChatMessage` was all that allowed the intended behavior of "content is optional" to work as intended.

The inadvertent fixing of the bug (that is, making it possible for `Content` to be treated as optional) exposed the other side of the problem, which is that `FunctionChatMessage` specifically and uniquely treats `content` as *required but nullable*, i.e. `"content": null` is valid but omitting `content is not. Since `Content` could now be optional, `new FunctionChatMessage("name", content: null)` now produces an invalid schema element (with no required `content`) instead of the valid one with `"content": null`. Utility and importance notwithstanding, this is a clear cut regression that we should fix.

And the fix: `FunctionChatMessage` now just checks in its one and only addressable constructor to see if the inner Content collection is defined, then invokes `.Clear()` if it isn't -- which is enough to force the instantiation of the underlying list that will write as `null`. Test coverage added, as well, which failed before the fix.