### PR TITLE
AOAI: fix problem with `SetNewMaxCompletionTokensEnabled()` extension method

### DIFF
--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Release History
 
-## 2.2.0-beta.1 (2025-02-04)
+
+## 2.2.0-beta.2 (Unreleased)
+
+### Bugs fixed
+
+- Addressed a problem calling the `SetNewMaxCompletionTokensPropertyEnabled()` method, needed for o1/o3 model support, on `ChatCompletionOptions` instances prior to use in a method call. Related issue: [azure-sdk-for-net#46545](https://github.com/Azure/azure-sdk-for-net/issues/46545) with thanks to the PR  [azure-sdk-for-net#48218](https://github.com/Azure/azure-sdk-for-net/pull/48218).
+
+## 2.2.0-beta.1 (2025-02-07)
 
 This preview release aligns with the corresponding `2.2.0` beta of `OpenAI` and the `2025-01-01-Preview` Azure OpenAI Service API version.
 

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/README.md
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/README.md
@@ -66,7 +66,8 @@ AzureOpenAIClientOptions options = new()
 };
 AzureOpenAIClient azureClient = new(
     new Uri("https://your-azure-openai-resource.com"),
-    new DefaultAzureCredential());
+    new DefaultAzureCredential(),
+    options);
 ChatClient chatClient = azureClient.GetChatClient("my-gpt-4o-mini-deployment");
 ```
 
@@ -514,5 +515,3 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [code_of_conduct_faq]: https://opensource.microsoft.com/codeofconduct/faq/
 [email_opencode]: mailto:opencode@microsoft.com
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net/sdk/openai/Azure.AI.OpenAI/README.png)

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/assets.json
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "dotnet.azure/openai/Azure.AI.OpenAI",
-  "Tag": "dotnet.azure/openai/Azure.AI.OpenAI_b8adb4f8f7"
+  "Tag": "dotnet.azure/openai/Azure.AI.OpenAI_e68a9f6b56"
 }

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -34,7 +34,7 @@
     <Otherwise>
       <PropertyGroup>
         <VersionPrefix>2.2.0</VersionPrefix>
-        <VersionSuffix>beta.1</VersionSuffix>
+        <VersionSuffix>beta.2</VersionSuffix>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
@@ -42,6 +42,7 @@ public static partial class AzureChatExtensions
         if (newPropertyEnabled)
         {
             // Blocking serialization of max_tokens via dictionary acts as a signal to skip pre-serialization fixup
+            options.SerializedAdditionalRawData ??= new Dictionary<string, BinaryData>();
             AdditionalPropertyHelpers.SetEmptySentinelValue(options.SerializedAdditionalRawData, "max_tokens");
         }
         else

--- a/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Assets/playback_test_config.json
+++ b/.dotnet.azure/sdk/openai/Azure.AI.OpenAI/tests/Assets/playback_test_config.json
@@ -39,6 +39,11 @@
     "key": "Sanitized",
     "deployment": "o1"
   },
+  "chat_o3-mini": {
+    "endpoint": "https://Sanitized.openai.azure.com/",
+    "key": "Sanitized",
+    "deployment": "o3-mini"
+  },
   "chat_with_async_filter": {
     "endpoint": "https://Sanitized.openai.azure.com/",
     "key": "Sanitized",


### PR DESCRIPTION
- `Azure.AI.OpenAI` can't invariantly use `max_completion_tokens` as the serialization target for `MaxOutputTokenCount`, as (unlike OAI), AOAI remains sensitive to "which name to use for which models" -- o1/o3 reject the older `max_tokens`, gpt-35-turbo/etc. reject the newer `max_completion_tokens`
- To deal with this, AOAI (beginning with 2.1.0 stable) includes an `[Experimental]` `SetNewMaxCompletionTokensEnabled()` extension method for `ChatCompletionOptions` that functionally "opts into" the new property name (preserving the behavior for old models); it relies on manipulating the additional data dictionary to swap which property name is used on the wire
- This unfortunately shipped with and has continued to have a bug this whole time: `ChatCompletionOptions` doesn't immediately initialize its additional data dictionary, so calling `SetNewMaxCompletionTokensEnabled()` on a fresh instance will throw a `NullReferenceException`
- This PR fixes that by ensuring the dictionary is initialized in the extension method
- It includes test coverage that *does not* make method calls using `options` prior to calling the method, which is what previously caused this to be missed